### PR TITLE
Add signal features to materialized view

### DIFF
--- a/import/Dockerfile
+++ b/import/Dockerfile
@@ -11,17 +11,17 @@ RUN --mount=type=bind,source=import/openrailwaymap.lua,target=openrailwaymap.lua
     | template --configuration - --format yaml --template openrailwaymap.lua.tmpl \
     > /build/openrailwaymap.lua
 
-FROM ghcr.io/hiddewie/template:v0.4.1 as build-tile-views
+FROM ghcr.io/hiddewie/template:v0.4.1 as build-signals
 
 WORKDIR /build
 
-RUN --mount=type=bind,source=import/sql/tile_views.sql,target=tile_views.sql.tmpl \
+RUN --mount=type=bind,source=import/sql/signals_with_azimuth.sql,target=signals_with_azimuth.sql.tmpl \
   --mount=type=bind,source=features/electrification_signals.yaml,target=electrification_signals.yaml \
   --mount=type=bind,source=features/signals_railway_signals.yaml,target=signals_railway_signals.yaml \
   --mount=type=bind,source=features/speed_railway_signals.yaml,target=speed_railway_signals.yaml \
   cat electrification_signals.yaml signals_railway_signals.yaml speed_railway_signals.yaml \
-    | template --configuration - --format yaml --template tile_views.sql.tmpl \
-    > /build/tile_views.sql
+    | template --configuration - --format yaml --template signals_with_azimuth.sql.tmpl \
+    > /build/signals_with_azimuth.sql
 
 FROM debian:unstable-20240211-slim
 
@@ -53,8 +53,8 @@ COPY import/docker-startup.sh docker-startup.sh
 COPY --from=build-lua \
   /build/openrailwaymap.lua openrailwaymap.lua
 
-COPY --from=build-tile-views \
-  /build/tile_views.sql sql/tile_views.sql
+COPY --from=build-signals \
+  /build/signals_with_azimuth.sql sql/signals_with_azimuth.sql
 
 ENTRYPOINT ["/openrailwaymap/docker-startup.sh"]
 

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -341,6 +341,8 @@ function osm2pgsql.process_node(object)
       (tags['railway:signal:distant'] and 9000) or
       (tags['railway:signal:train_protection'] and 8500) or
       (tags['railway:signal:main_repeated'] and 8000) or
+      (tags['railway:signal:speed_limit'] and 5500) or
+      (tags['railway:signal:speed_limit_distant'] and 5000) or
       (tags['railway:signal:minor'] and 4000) or
       (tags['railway:signal:passing'] and 3500) or
       (tags['railway:signal:shunting'] and 3000) or
@@ -351,6 +353,7 @@ function osm2pgsql.process_node(object)
       (tags['railway:signal:crossing_distant'] and 500) or
       (tags['railway:signal:ring'] and 500) or
       (tags['railway:signal:whistle'] and 500) or
+      (tags['railway:signal:electricity'] and 500) or
       (tags['railway:signal:departure'] and 400) or
       (tags['railway:signal:resetting_switch'] and 300) or
       (tags['railway:signal:resetting_switch_distant'] and 200) or

--- a/import/sql/signals_with_azimuth.sql
+++ b/import/sql/signals_with_azimuth.sql
@@ -1,17 +1,111 @@
 -- Table with signals including their azimuth based on the direction of the signal and the railway line
 CREATE MATERIALIZED VIEW IF NOT EXISTS signals_with_azimuth AS
+  -- TODO investigate signals with null features
   SELECT
-    s.*,
+    fs.*,
     degrees(ST_Azimuth(
-      st_lineinterpolatepoint(sl.way, greatest(0, st_linelocatepoint(sl.way, ST_ClosestPoint(sl.way, s.way)) - 0.01)),
-      st_lineinterpolatepoint(sl.way, least(1, st_linelocatepoint(sl.way, ST_ClosestPoint(sl.way, s.way)) + 0.01))
-    )) + (CASE WHEN s.signal_direction = 'backward' THEN 180.0 ELSE 0.0 END) as azimuth
-  FROM signals s
+      st_lineinterpolatepoint(sl.way, greatest(0, st_linelocatepoint(sl.way, ST_ClosestPoint(sl.way, fs.way)) - 0.01)),
+      st_lineinterpolatepoint(sl.way, least(1, st_linelocatepoint(sl.way, ST_ClosestPoint(sl.way, fs.way)) + 0.01))
+    )) + (CASE WHEN signal_direction = 'backward' THEN 180.0 ELSE 0.0 END) as azimuth,
+    CASE
+
+        {% for feature in signals_railway_signals.features %}
+        -- ({% feature.country %}) {% feature.description %}
+        WHEN{% for tag in feature.tags %} "{% tag.tag %}"{% if tag.value %}='{% tag.value %}'{% elif tag.values %} IN ({% for value in tag.values %}{% unless loop.first %}, {% end %}'{% value %}'{% end %}){% end %}{% unless loop.last %} AND{% end %}{% end %}
+
+          THEN {% if feature.icon.match %} CASE
+            {% for case in feature.icon.cases %}
+            WHEN "{% feature.icon.match %}" ~ '{% case.regex %}' THEN '{% case.value %}'
+
+{% end %}
+            {% if feature.icon.default %}
+            ELSE '{% feature.icon.default %}'
+{% end %}
+          END{% else %} '{% feature.icon.default %}'{% end %}
+
+
+{% end %}
+
+    END as signal_feature,
+    CASE
+        {% for feature in speed_railway_signals.features %}
+        -- ({% feature.country %}) {% feature.description %}
+        WHEN{% for tag in feature.tags %} "{% tag.tag %}"{% if tag.value %}='{% tag.value %}'{% elif tag.values %} IN ({% for value in tag.values %}{% unless loop.first %}, {% end %}'{% value %}'{% end %}){% end %}{% unless loop.last %} AND{% end %}{% end %}
+
+          THEN {% if feature.icon.match %} CASE
+            {% for case in feature.icon.cases %}
+            WHEN "{% feature.icon.match %}" ~ '{% case.regex %}' THEN{% if case.value | contains("{}") %} CONCAT('{% case.value | regexReplace("\{\}.*$", "") %}', "{% feature.icon.match %}", '{% case.value | regexReplace("^.*\{\}", "") %}'){% else %} '{% case.value %}'{% end %}
+
+{% end %}
+            {% if feature.icon.default %}
+            ELSE '{% feature.icon.default %}'
+{% end %}
+          END{% else %} '{% feature.icon.default %}'{% end %}
+
+
+{% end %}
+
+    END as speed_feature,
+    CASE
+      {% for feature in speed_railway_signals.features %}
+        {% if feature.type %}
+        -- ({% feature.country %}) {% feature.description %}
+        WHEN{% for tag in feature.tags %} "{% tag.tag %}"{% if tag.value %}='{% tag.value %}'{% elif tag.values %} IN ({% for value in tag.values %}{% unless loop.first %}, {% end %}'{% value %}'{% end %}){% end %}{% unless loop.last %} AND{% end %}{% end %} THEN '{% feature.type %}'
+
+{% end %}
+{% end %}
+
+    END as speed_feature_type,
+    CASE
+      {% for feature in electrification_signals.features %}
+        -- ({% feature.country %}) {% feature.description %}
+        WHEN{% for tag in feature.tags %} "{% tag.tag %}"{% if tag.value %}='{% tag.value %}'{% elif tag.values %} IN ({% for value in tag.values %}{% unless loop.first %}, {% end %}'{% value %}'{% end %}){% end %}{% unless loop.last %} AND{% end %}{% end %}
+
+          THEN {% if feature.icon.match %} CASE
+            {% for case in feature.icon.cases %}
+            WHEN "{% feature.icon.match %}" ~ '{% case.regex %}' THEN '{% case.value %}'
+{% end %}
+            ELSE '{% feature.icon.default %}'
+          END{% else %} '{% feature.icon.default %}'{% end %}
+
+
+{% end %}
+    END as electrification_feature
+  FROM (
+    SELECT
+      id,
+      way,
+      railway,
+      rank,
+      ref,
+      ref_multiline,
+      signal_direction,
+      deactivated,
+      {% for tag in signals_railway_signals.tags %}
+      "{% tag %}",
+{% end %}
+      {% for tag in speed_railway_signals.tags %}
+      {% unless tag | matches("railway:signal:speed_limit:speed") %}
+      {% unless tag | matches("railway:signal:speed_limit_distant:speed") %}
+      "{% tag %}",
+{% end %}
+{% end %}
+{% end %}
+      {% for tag in electrification_signals.tags %}
+      "{% tag %}",
+{% end %}
+      -- We cast the highest speed to text to make it possible to only select those speeds
+      -- we have an icon for. Otherwise we might render an icon for 40 kph if
+      -- 42 is tagged (but invalid tagging).
+      CASE WHEN "railway:signal:speed_limit" IS NOT NULL THEN railway_largest_speed_noconvert("railway:signal:speed_limit:speed")::text ELSE "railway:signal:speed_limit:speed" END AS "railway:signal:speed_limit:speed",
+      CASE WHEN "railway:signal:speed_limit_distant" IS NOT NULL THEN railway_largest_speed_noconvert("railway:signal:speed_limit_distant:speed")::text ELSE "railway:signal:speed_limit_distant:speed" END AS "railway:signal:speed_limit_distant:speed"
+    FROM signals s
+  ) AS fs
   LEFT JOIN LATERAL (
     SELECT line.way as way
     FROM railway_line line
-    WHERE st_dwithin(s.way, line.way, 10) AND line.railway IN ('rail', 'tram', 'light_rail', 'subway', 'narrow_gauge', 'construction', 'preserved', 'monorail', 'miniature') -- TODO use feature
-    ORDER BY s.way <-> line.way
+    WHERE st_dwithin(fs.way, line.way, 10) AND line.railway IN ('rail', 'tram', 'light_rail', 'subway', 'narrow_gauge', 'construction', 'preserved', 'monorail', 'miniature') -- TODO use feature
+    ORDER BY fs.way <-> line.way
     LIMIT 1
   ) as sl ON true
   WHERE


### PR DESCRIPTION
This will speed up the tile generation for the `signals` layer.

Later optimizations: add a single `feature` column in the materialized view, and a type to indicate signal, speed or electricity.