### PR TITLE
Replace hardcoded bounds to the imported region

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 !import/sql
 !import/docker-startup.sh
 !import/openrailwaymap.lua
+!data/import
 !martin
 !proxy
 !symbols

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Setup Fly
         uses: superfly/flyctl-actions/setup-flyctl@master
 
+      # Manually write import bounds, to decouple proxy from tile generation/import
+      - name: Output import bounds
+        run: |
+          echo '[[-10.0, 35.7], [39.0, 70.0]]' > data/import/bounds.json
+
       - name: Deploy
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/import/docker-startup.sh
+++ b/import/docker-startup.sh
@@ -128,6 +128,9 @@ esac
 echo "Vacuuming database"
 $PSQL -c "VACUUM FULL;"
 
+$PSQL --tuples-only -c "with bounds as (SELECT st_transform(st_setsrid(ST_Extent(way), 3857), 4326) as table_extent FROM railway_line) select '[[' || ST_XMin(table_extent) || ', ' || ST_YMin(table_extent) || '], [' || ST_XMax(table_extent) || ', ' || ST_YMax(table_extent) || ']]' from bounds;" > /data/import/bounds.json
+echo "Import bounds: $(cat /data/import/bounds.json)"
+
 echo "Database summary"
 $PSQL -c "select table_name as table, pg_size_pretty(pg_total_relation_size(quote_ident(table_name))) as size from information_schema.tables where table_schema = 'public' order by table_name;"
 $PSQL -c "select pg_size_pretty(sum(pg_total_relation_size(quote_ident(table_name)))) as total_size from information_schema.tables where table_schema = 'public';"

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -22,6 +22,7 @@ COPY proxy/api /etc/nginx/public/api
 COPY proxy/js /etc/nginx/public/js
 COPY proxy/css /etc/nginx/public/css
 COPY proxy/image /etc/nginx/public/image
+COPY data/import /etc/nginx/public/import
 
 COPY --from=build-styles \
   /build /etc/nginx/public/style

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -698,3 +698,14 @@ map.on('click', event => {
       .addTo(map);
   }
 });
+
+fetch(`${location.origin}/bounds.json`)
+  .then(result => {
+    if (result.status === 200) {
+      return result.json()
+    } else {
+      throw `Invalid status code ${result.status}`
+    }
+  })
+  .then(result => map.setMaxBounds(result))
+  .catch(error => console.error('Error during fetching of import map bounds', error))

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -254,7 +254,6 @@ function removeDomElement(node) {
 
 const globalMinZoom = 1;
 const globalMaxZoom = 18;
-const globalMaxBounds = [[-10.0, 35.7], [39.0, 70.0]];
 
 const knownStyles = {
   standard: 'Infrastructure',
@@ -375,7 +374,6 @@ const map = new maplibregl.Map({
   maxZoom: globalMaxZoom,
   minPitch: 0,
   maxPitch: 0,
-  maxBounds: globalMaxBounds,
 });
 
 const onStyleChange = changedStyle => {

--- a/proxy/proxy.conf.template
+++ b/proxy/proxy.conf.template
@@ -28,6 +28,10 @@ server {
     root /etc/nginx/public;
   }
 
+  location = /bounds.json {
+    root /etc/nginx/public/import;
+  }
+
   location = /favicon.ico {
     root /etc/nginx/public/image;
     expires $cache_assets;


### PR DESCRIPTION
Part of https://github.com/hiddewie/OpenRailwayMap-vector/issues/99

### Scenarios

Local import: data is imported using Docker compose, and the import script will output the imported data bounds as JSON. The proxy can pick up this file, and serve it for the UI.

Deployed: the file is manually written with the deployed import bounds.

Failure: if no file can be found, or the file fails to be served with a 200 OK response, the UI shows the entire map without bounds. 

### Alternatives

I tried getting the bounds from https://maplibre.org/martin/sources-pg-tables.html, but these were not served by Martin, neither from a database nor from mbtlies tile files.

### Testing 

Import bounds not available: entire map is visible

Import bounds available and coordinates outside bound: UI moves the view inside the imported bounds.

Import bounds available and coordinates inside bound: UI takes the existing center/zoom from the hash in the URL, and shows the UI with that center/zoom.