### PR TITLE
Create background map visualization for rendering vector background map

### DIFF
--- a/proxy/css/ui.css
+++ b/proxy/css/ui.css
@@ -94,3 +94,7 @@ body {
 .maplibregl-ctrl.maplibregl-ctrl-attrib.maplibregl-compact {
   margin-left: 100px;
 }
+
+input[type=url] {
+  font-family: monospace;
+}

--- a/proxy/css/ui.css
+++ b/proxy/css/ui.css
@@ -10,8 +10,8 @@ body {
   width: 100%;
   height: 100%;
 }
-#map {
-  position: relative;
+#background-map, #map {
+  position: absolute;
   width: 100%;
   height: 100%;
 }

--- a/proxy/index.html
+++ b/proxy/index.html
@@ -116,14 +116,14 @@
         <form>
           <div class="form-group">
             <label for="backgroundSaturation">Background map saturation</label>
-            <input type="range" min="0.0" max="1.0" step="0.05" class="form-control-range" id="backgroundSaturation" onchange="updateConfiguration('backgroundSaturation', parseFloat(this.value)); updateBackgroundMapStyle();">
+            <input type="range" min="0.0" max="1.0" step="0.05" class="form-control-range" id="backgroundSaturation" onchange="updateConfiguration('backgroundSaturation', parseFloat(this.value)); updateBackgroundMapContainer();">
             <small class="form-text text-muted">
               Control the saturation of the background map. The smallest value makes the map grayscale, while the largest value makes the map full color.
             </small>
           </div>
           <div class="form-group">
             <label for="backgroundOpacity">Background map opacity</label>
-            <input type="range" min="0.0" max="1.0" step="0.05" class="form-control-range" id="backgroundOpacity" onchange="updateConfiguration('backgroundOpacity', parseFloat(this.value)); updateBackgroundMapStyle();">
+            <input type="range" min="0.0" max="1.0" step="0.05" class="form-control-range" id="backgroundOpacity" onchange="updateConfiguration('backgroundOpacity', parseFloat(this.value)); updateBackgroundMapContainer();">
             <small class="form-text text-muted">
               Control the opacity of the background map. The smallest value makes the map transparent, while the largest value makes the map opaque.
             </small>

--- a/proxy/index.html
+++ b/proxy/index.html
@@ -144,7 +144,7 @@
             <small class="form-text text-muted">
               The tile URL for the background map.<br>
               Raster tiles: A URL serving raster tiles. See <a href="https://wiki.openstreetmap.org/wiki/Raster_tile_providers" target="_blank">the wiki</a> for a list of raster tile providers, for example <code>https://tile.openstreetmap.org/{z}/{x}/{y}.png</code>.<br>
-              Vector tiles: A URL specifying a vector style. See <a href="https://wiki.openstreetmap.org/wiki/Vector_tiles#https://wiki.openstreetmap.org/wiki/Vector_tiles" target="_blank">the wiki</a> for a list of vector tile providers, for example <code>https://americanamap.org/style.json</code>.
+              Vector tiles: A URL specifying a vector style. See <a href="https://wiki.openstreetmap.org/wiki/Vector_tiles#Providers" target="_blank">the wiki</a> for a list of vector tile providers, for example <code>https://americanamap.org/style.json</code>.
             </small>
           </div>
         </form>

--- a/proxy/index.html
+++ b/proxy/index.html
@@ -110,21 +110,31 @@
         <form>
           <div class="form-group">
             <label for="backgroundSaturation">Background map saturation</label>
-            <input type="range" min="-1.0" max="0.0" step="0.05" class="form-control-range" id="backgroundSaturation" onchange="updateConfiguration('backgroundSaturation', parseFloat(this.value))">
+            <input type="range" min="-1.0" max="0.0" step="0.05" class="form-control-range" id="backgroundSaturation" onchange="updateConfiguration('backgroundSaturation', parseFloat(this.value)); updateBackgroundMapStyle();">
             <small class="form-text text-muted">
               Control the saturation of the background map. The smallest value makes the map grayscale, while the largest value makes the map full color.
             </small>
           </div>
           <div class="form-group">
             <label for="backgroundOpacity">Background map opacity</label>
-            <input type="range" min="0.0" max="1.0" step="0.05" class="form-control-range" id="backgroundOpacity" onchange="updateConfiguration('backgroundOpacity', parseFloat(this.value))">
+            <input type="range" min="0.0" max="1.0" step="0.05" class="form-control-range" id="backgroundOpacity" onchange="updateConfiguration('backgroundOpacity', parseFloat(this.value)); updateBackgroundMapStyle();">
             <small class="form-text text-muted">
               Control the opacity of the background map. The smallest value makes the map transparent, while the largest value makes the map opaque.
             </small>
           </div>
           <div class="form-group">
-            <label for="backgroundRasterUrl">Background map tile URL</label>
-            <input type="url" required class="form-control" id="backgroundRasterUrl" onchange="updateConfiguration('backgroundRasterUrl', this.value)">
+            <label for="backgroundUrl">Background map tile URL</label>
+            <div>
+              <label>
+                <input type="radio" name="backgroundType" required class="form-control" id="backgroundTypeRaster" onchange="updateConfiguration('backgroundType', 'raster'); updateBackgroundMapStyle();">
+                Raster
+              </label>
+              <label>
+                <input type="radio" name="backgroundType" required class="form-control" id="backgroundTypeVector" onchange="updateConfiguration('backgroundType', 'vector'); updateBackgroundMapStyle();">
+                Vector
+              </label>
+            </div>
+            <input type="url" required class="form-control" id="backgroundUrl" onchange="updateConfiguration('backgroundUrl', this.value); updateBackgroundMapStyle();">
             <small class="form-text text-muted">
               The tile URL of the background map. Only supports raster tiles. See <a href="https://wiki.openstreetmap.org/wiki/Raster_tile_providers" target="_blank">the wiki</a> for a list of raster tile providers.
             </small>

--- a/proxy/index.html
+++ b/proxy/index.html
@@ -138,6 +138,7 @@
   <div id="legend-map"></div>
 </div>
 <div id="map-container">
+  <div id="background-map"></div>
   <div id="map"></div>
 </div>
 

--- a/proxy/index.html
+++ b/proxy/index.html
@@ -12,6 +12,12 @@
   <link rel="stylesheet" href="css/bootstrap-4.6/bootstrap.min.css">
   <link rel="stylesheet" href="css/maplibre-gl-4.3/maplibre-gl.css">
   <link rel="stylesheet" href="css/ui.css">
+
+  <script>
+    // See https://stackoverflow.com/a/64158043/711129
+    let FF_FOUC_FIX;
+  </script>
+
   <title>OpenRailwayMap</title>
 </head>
 
@@ -98,7 +104,7 @@
   </div>
 </div>
 <div id="configuration-backdrop" class="modal backdrop" tabindex="-1" role="dialog">
-  <div class="modal-dialog modal-dialog-scrollable" role="document">
+  <div class="modal-dialog modal-dialog-scrollable modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header bg-light">
         <h5 class="modal-title">Map configuration</h5>
@@ -110,7 +116,7 @@
         <form>
           <div class="form-group">
             <label for="backgroundSaturation">Background map saturation</label>
-            <input type="range" min="-1.0" max="0.0" step="0.05" class="form-control-range" id="backgroundSaturation" onchange="updateConfiguration('backgroundSaturation', parseFloat(this.value)); updateBackgroundMapStyle();">
+            <input type="range" min="0.0" max="1.0" step="0.05" class="form-control-range" id="backgroundSaturation" onchange="updateConfiguration('backgroundSaturation', parseFloat(this.value)); updateBackgroundMapStyle();">
             <small class="form-text text-muted">
               Control the saturation of the background map. The smallest value makes the map grayscale, while the largest value makes the map full color.
             </small>
@@ -125,18 +131,20 @@
           <div class="form-group">
             <label for="backgroundUrl">Background map tile URL</label>
             <div>
-              <label>
-                <input type="radio" name="backgroundType" required class="form-control" id="backgroundTypeRaster" onchange="updateConfiguration('backgroundType', 'raster'); updateBackgroundMapStyle();">
-                Raster
-              </label>
-              <label>
-                <input type="radio" name="backgroundType" required class="form-control" id="backgroundTypeVector" onchange="updateConfiguration('backgroundType', 'vector'); updateBackgroundMapStyle();">
-                Vector
-              </label>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="backgroundType" id="backgroundTypeRaster" value="raster" checked onchange="updateConfiguration('backgroundType', 'raster'); updateBackgroundMapStyle();">
+                <label class="form-check-label" for="backgroundTypeRaster">Raster</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="backgroundType" id="backgroundTypeVector" value="raster" checked onchange="updateConfiguration('backgroundType', 'vector'); updateBackgroundMapStyle();">
+                <label class="form-check-label" for="backgroundTypeVector">Vector</label>
+              </div>
             </div>
             <input type="url" required class="form-control" id="backgroundUrl" onchange="updateConfiguration('backgroundUrl', this.value); updateBackgroundMapStyle();">
             <small class="form-text text-muted">
-              The tile URL of the background map. Only supports raster tiles. See <a href="https://wiki.openstreetmap.org/wiki/Raster_tile_providers" target="_blank">the wiki</a> for a list of raster tile providers.
+              The tile URL for the background map.<br>
+              Raster tiles: A URL serving raster tiles. See <a href="https://wiki.openstreetmap.org/wiki/Raster_tile_providers" target="_blank">the wiki</a> for a list of raster tile providers, for example <code>https://tile.openstreetmap.org/{z}/{x}/{y}.png</code>.<br>
+              Vector tiles: A URL specifying a vector style. See <a href="https://wiki.openstreetmap.org/wiki/Vector_tiles#https://wiki.openstreetmap.org/wiki/Vector_tiles" target="_blank">the wiki</a> for a list of vector tile providers, for example <code>https://americanamap.org/style.json</code>.
             </small>
           </div>
         </form>

--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -961,12 +961,16 @@ const attribution = '<a href="https://github.com/hiddewie/OpenRailwayMap-vector"
 
 const sources = {
   background_map: {
-    type: 'raster',
-    tiles: [
-      'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-    ],
-    tileSize: 256,
-    attribution: '<a href="https://www.openstreetmap.org/about" target="_blank">&copy; OpenStreetMap contributors</a>'
+    type: 'vector',
+    url: 'https://api.maptiler.com/tiles/contours/tiles.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
+    // url: 'https://tile.ourmap.us/data/v3.json',
+    // url: 'https://www.openhistoricalmap.org/map-styles/main/main.json',
+    // tiles: [
+    //   'https://vtiles.openhistoricalmap.org/maps/osm/{z}/{x}/{y}.pbf',
+    //   'https://tile.openstreetmap.org/.png',
+    // ],
+    // tileSize: 256,
+    // attribution: '<a href="https://www.openstreetmap.org/about" target="_blank">&copy; OpenStreetMap contributors</a>'
   },
   search: {
     type: 'geojson',
@@ -1041,12 +1045,21 @@ const backgroundColor = {
 
 const backgroundMap = {
   id: "background-map",
-  type: "raster",
+  'type': 'line',
+  'source-layer': 'contour',
+  'layout': {
+    'line-join': 'round',
+    'line-cap': 'round'
+  },
+  'paint': {
+    'line-color': '#ff69b4',
+    'line-width': 1
+  },
   source: "background_map",
-  paint: {
-    'raster-saturation': -1.0, // or 0.0 for colorful
-    'raster-opacity': 1.0, // or 0.0 for transparent
-  }
+  // paint: {
+  //   'raster-saturation': -1.0, // or 0.0 for colorful
+  //   'raster-opacity': 1.0, // or 0.0 for transparent
+  // }
 };
 
 const searchResults = {
@@ -1064,8 +1077,8 @@ const searchResults = {
 // TODO remove all [switch, [zoom]] to ensure legend displays only visible features
 const layers = {
   standard: [
-    backgroundColor,
-    backgroundMap,
+    // backgroundColor,
+    // backgroundMap,
     {
       id: 'railway_line_low_casing',
       type: 'line',
@@ -3013,7 +3026,12 @@ const makeStyle = selectedStyle => ({
   metadata: {},
   name: `OpenRailwayMap ${selectedStyle}`,
   sources,
-  sprite: `${origin}/sprite/symbols`,
+  sprite: [
+    {
+      id: 'default',
+      url: `${origin}/sprite/symbols`,
+    }
+  ],
   version: 8,
   layers: layers[selectedStyle],
 });

--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -17,7 +17,7 @@ const knownStyles = [
 ];
 
 const globalMinZoom = 1;
-const glodalMaxZoom= 18;
+const glodalMaxZoom = 18;
 
 const colors = {
   hover: {
@@ -59,27 +59,27 @@ const colors = {
 const turntable_casing_width = 2;
 
 const electrificationLegends = [
-  { legend: '> 25 kV ~', voltage: 25000, frequency: 60, electrification_label: '26kV 60Hz' },
-  { legend: '25 kV 60 Hz ~', voltage: 25000, frequency: 60, electrification_label: '25kV 60Hz' },
-  { legend: '25 kV 50 Hz ~', voltage: 25000, frequency: 50, electrification_label: '25kV 50Hz' },
-  { legend: '20 kV 60 Hz ~', voltage: 20000, frequency: 60, electrification_label: '20kV 60Hz' },
-  { legend: '20 kV 50 Hz ~', voltage: 20000, frequency: 50, electrification_label: '20kV 50Hz' },
-  { legend: '15 kV - 25 kV ~', voltage: 15001, frequency: 60, electrification_label: '16kV 60Hz' },
-  { legend: '15 kV 16.7 Hz ~', voltage: 15000, frequency: 16.7, electrification_label: '15kV 16.7Hz' },
-  { legend: '15 kV 16.67 Hz ~', voltage: 15000, frequency: 16.67, electrification_label: '15kV 16.67Hz' },
-  { legend: '12.5 kV - 15 kV ~', voltage: 12501, frequency: 60, electrification_label: '13kV 60Hz' },
-  { legend: '12.5 kV 60 Hz ~', voltage: 12500, frequency: 60, electrification_label: '12.5kV 60Hz' },
-  { legend: '12.5 kV 25 Hz ~', voltage: 12500, frequency: 25, electrification_label: '12.5kV 25Hz' },
-  { legend: '< 12.5 kV ~', voltage: 12499, frequency: 60, electrification_label: '11kV 60Hz' },
-  { legend: '> 3 kV =', voltage: 3001, frequency: 0, electrification_label: '4kV =' },
-  { legend: '3 kV =', voltage: 3000, frequency: 0, electrification_label: '3kV =' },
-  { legend: '1.5 kV - 3 kV =', voltage: 1501, frequency: 0, electrification_label: '2kV =' },
-  { legend: '1.5 kV =', voltage: 1500, frequency: 0, electrification_label: '1.5kV =' },
-  { legend: '1 kV - 1.5 kV =', voltage: 1001, frequency: 0, electrification_label: '1.2kV =' },
-  { legend: '1 kV =', voltage: 1000, frequency: 0, electrification_label: '1kV =' },
-  { legend: '750 V - 1 kV =', voltage: 751, frequency: 0, electrification_label: '800V =' },
-  { legend: '750 V =', voltage: 750, frequency: 0, electrification_label: '750V =' },
-  { legend: '< 750 V =', voltage: 749, frequency: 0, electrification_label: '700V =' },
+  {legend: '> 25 kV ~', voltage: 25000, frequency: 60, electrification_label: '26kV 60Hz'},
+  {legend: '25 kV 60 Hz ~', voltage: 25000, frequency: 60, electrification_label: '25kV 60Hz'},
+  {legend: '25 kV 50 Hz ~', voltage: 25000, frequency: 50, electrification_label: '25kV 50Hz'},
+  {legend: '20 kV 60 Hz ~', voltage: 20000, frequency: 60, electrification_label: '20kV 60Hz'},
+  {legend: '20 kV 50 Hz ~', voltage: 20000, frequency: 50, electrification_label: '20kV 50Hz'},
+  {legend: '15 kV - 25 kV ~', voltage: 15001, frequency: 60, electrification_label: '16kV 60Hz'},
+  {legend: '15 kV 16.7 Hz ~', voltage: 15000, frequency: 16.7, electrification_label: '15kV 16.7Hz'},
+  {legend: '15 kV 16.67 Hz ~', voltage: 15000, frequency: 16.67, electrification_label: '15kV 16.67Hz'},
+  {legend: '12.5 kV - 15 kV ~', voltage: 12501, frequency: 60, electrification_label: '13kV 60Hz'},
+  {legend: '12.5 kV 60 Hz ~', voltage: 12500, frequency: 60, electrification_label: '12.5kV 60Hz'},
+  {legend: '12.5 kV 25 Hz ~', voltage: 12500, frequency: 25, electrification_label: '12.5kV 25Hz'},
+  {legend: '< 12.5 kV ~', voltage: 12499, frequency: 60, electrification_label: '11kV 60Hz'},
+  {legend: '> 3 kV =', voltage: 3001, frequency: 0, electrification_label: '4kV ='},
+  {legend: '3 kV =', voltage: 3000, frequency: 0, electrification_label: '3kV ='},
+  {legend: '1.5 kV - 3 kV =', voltage: 1501, frequency: 0, electrification_label: '2kV ='},
+  {legend: '1.5 kV =', voltage: 1500, frequency: 0, electrification_label: '1.5kV ='},
+  {legend: '1 kV - 1.5 kV =', voltage: 1001, frequency: 0, electrification_label: '1.2kV ='},
+  {legend: '1 kV =', voltage: 1000, frequency: 0, electrification_label: '1kV ='},
+  {legend: '750 V - 1 kV =', voltage: 751, frequency: 0, electrification_label: '800V ='},
+  {legend: '750 V =', voltage: 750, frequency: 0, electrification_label: '750V ='},
+  {legend: '< 750 V =', voltage: 749, frequency: 0, electrification_label: '700V ='},
 ];
 
 const speedLegends = [
@@ -957,21 +957,9 @@ const gaugeLayout = {
   'line-cap': 'round',
 };
 
-const attribution = '<a href="https://github.com/hiddewie/OpenRailwayMap-vector" target="_blank">&copy; OpenRailwayMap contributors</a>';
+const attribution = '<a href="https://github.com/hiddewie/OpenRailwayMap-vector" target="_blank">&copy; OpenRailwayMap contributors</a> | <a href="https://www.openstreetmap.org/about" target="_blank">&copy; OpenStreetMap contributors</a>';
 
 const sources = {
-  background_map: {
-    type: 'vector',
-    url: 'https://api.maptiler.com/tiles/contours/tiles.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL',
-    // url: 'https://tile.ourmap.us/data/v3.json',
-    // url: 'https://www.openhistoricalmap.org/map-styles/main/main.json',
-    // tiles: [
-    //   'https://vtiles.openhistoricalmap.org/maps/osm/{z}/{x}/{y}.pbf',
-    //   'https://tile.openstreetmap.org/.png',
-    // ],
-    // tileSize: 256,
-    // attribution: '<a href="https://www.openstreetmap.org/about" target="_blank">&copy; OpenStreetMap contributors</a>'
-  },
   search: {
     type: 'geojson',
     data: {
@@ -1035,33 +1023,6 @@ const sources = {
   }
 };
 
-const backgroundColor = {
-  id: 'background',
-  type: 'background',
-  paint: {
-    'background-color': 'rgb(242, 243, 240)'
-  }
-};
-
-const backgroundMap = {
-  id: "background-map",
-  'type': 'line',
-  'source-layer': 'contour',
-  'layout': {
-    'line-join': 'round',
-    'line-cap': 'round'
-  },
-  'paint': {
-    'line-color': '#ff69b4',
-    'line-width': 1
-  },
-  source: "background_map",
-  // paint: {
-  //   'raster-saturation': -1.0, // or 0.0 for colorful
-  //   'raster-opacity': 1.0, // or 0.0 for transparent
-  // }
-};
-
 const searchResults = {
   id: 'search',
   type: 'circle',
@@ -1077,8 +1038,6 @@ const searchResults = {
 // TODO remove all [switch, [zoom]] to ensure legend displays only visible features
 const layers = {
   standard: [
-    // backgroundColor,
-    // backgroundMap,
     {
       id: 'railway_line_low_casing',
       type: 'line',
@@ -1990,8 +1949,6 @@ const layers = {
   ],
 
   speed: [
-    backgroundColor,
-    backgroundMap,
     {
       id: 'speed_railway_line_low_casing',
       type: 'line',
@@ -2167,8 +2124,6 @@ const layers = {
   ],
 
   signals: [
-    backgroundColor,
-    backgroundMap,
     {
       id: 'railway_line_low_casing',
       type: 'line',
@@ -2475,8 +2430,6 @@ const layers = {
   ],
 
   electrification: [
-    backgroundColor,
-    backgroundMap,
     {
       id: 'electrification_railway_line_low_casing',
       type: 'line',
@@ -2738,8 +2691,6 @@ const layers = {
   ],
 
   gauge: [
-    backgroundColor,
-    backgroundMap,
     {
       id: 'gauge_railway_line_low_casing',
       type: 'line',
@@ -3978,7 +3929,7 @@ const legendData = {
           electrification_label: '',
         },
       },
-      ...electrificationLegends.map(({legend, voltage, frequency, electrification_label }) => ({
+      ...electrificationLegends.map(({legend, voltage, frequency, electrification_label}) => ({
         legend,
         type: 'line',
         properties: {
@@ -4490,16 +4441,16 @@ function makeLegendStyle(style) {
                 : 'Point',
               coordinates:
                 subItem.type === 'line' ? [
-                  legendPointToMapPoint(legendZoom, [index / subItems.length * 1.5 - 1.5, -entry * 0.6]),
-                  legendPointToMapPoint(legendZoom, [(index + 1) / subItems.length * 1.5 - 1.5, -entry * 0.6]),
-                ] :
-                subItem.type === 'polygon' ? Array.from({length: 20 + 1}, (_, i) => i * Math.PI * 2 / 20).map(phi =>
-                    legendPointToMapPoint(legendZoom, [Math.cos(phi) * 0.1 + (index + 0.5) / subItems.length * 1.5 - 1.5, Math.sin(phi) * 0.1 - entry * 0.6]))
-                  : legendPointToMapPoint(legendZoom, [(index + 0.5) / subItems.length * 1.5 - 1.5, -entry * 0.6]),
+                    legendPointToMapPoint(legendZoom, [index / subItems.length * 1.5 - 1.5, -entry * 0.6]),
+                    legendPointToMapPoint(legendZoom, [(index + 1) / subItems.length * 1.5 - 1.5, -entry * 0.6]),
+                  ] :
+                  subItem.type === 'polygon' ? Array.from({length: 20 + 1}, (_, i) => i * Math.PI * 2 / 20).map(phi =>
+                      legendPointToMapPoint(legendZoom, [Math.cos(phi) * 0.1 + (index + 0.5) / subItems.length * 1.5 - 1.5, Math.sin(phi) * 0.1 - entry * 0.6]))
+                    : legendPointToMapPoint(legendZoom, [(index + 0.5) / subItems.length * 1.5 - 1.5, -entry * 0.6]),
             },
             properties: subItem.properties,
           }));
-          entry ++;
+          entry++;
           return itemFeatures;
         });
         done.add(sourceName);
@@ -4541,7 +4492,7 @@ function makeLegendStyle(style) {
               legend,
             },
           };
-          entry ++;
+          entry++;
           return feature;
         });
         done.add(sourceName);
@@ -4580,6 +4531,6 @@ function makeLegendStyle(style) {
 }
 
 knownStyles.forEach(style => {
-    fs.writeFileSync(`${style}.json`, JSON.stringify(makeStyle(style)));
-    fs.writeFileSync(`legend-${style}.json`, JSON.stringify(makeLegendStyle(style)));
+  fs.writeFileSync(`${style}.json`, JSON.stringify(makeStyle(style)));
+  fs.writeFileSync(`legend-${style}.json`, JSON.stringify(makeLegendStyle(style)));
 });

--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -2977,12 +2977,7 @@ const makeStyle = selectedStyle => ({
   metadata: {},
   name: `OpenRailwayMap ${selectedStyle}`,
   sources,
-  sprite: [
-    {
-      id: 'default',
-      url: `${origin}/sprite/symbols`,
-    }
-  ],
+  sprite: `${origin}/sprite/symbols`,
   version: 8,
   layers: layers[selectedStyle],
 });

--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -59,27 +59,27 @@ const colors = {
 const turntable_casing_width = 2;
 
 const electrificationLegends = [
-  {legend: '> 25 kV ~', voltage: 25000, frequency: 60, electrification_label: '26kV 60Hz'},
-  {legend: '25 kV 60 Hz ~', voltage: 25000, frequency: 60, electrification_label: '25kV 60Hz'},
-  {legend: '25 kV 50 Hz ~', voltage: 25000, frequency: 50, electrification_label: '25kV 50Hz'},
-  {legend: '20 kV 60 Hz ~', voltage: 20000, frequency: 60, electrification_label: '20kV 60Hz'},
-  {legend: '20 kV 50 Hz ~', voltage: 20000, frequency: 50, electrification_label: '20kV 50Hz'},
-  {legend: '15 kV - 25 kV ~', voltage: 15001, frequency: 60, electrification_label: '16kV 60Hz'},
-  {legend: '15 kV 16.7 Hz ~', voltage: 15000, frequency: 16.7, electrification_label: '15kV 16.7Hz'},
-  {legend: '15 kV 16.67 Hz ~', voltage: 15000, frequency: 16.67, electrification_label: '15kV 16.67Hz'},
-  {legend: '12.5 kV - 15 kV ~', voltage: 12501, frequency: 60, electrification_label: '13kV 60Hz'},
-  {legend: '12.5 kV 60 Hz ~', voltage: 12500, frequency: 60, electrification_label: '12.5kV 60Hz'},
-  {legend: '12.5 kV 25 Hz ~', voltage: 12500, frequency: 25, electrification_label: '12.5kV 25Hz'},
-  {legend: '< 12.5 kV ~', voltage: 12499, frequency: 60, electrification_label: '11kV 60Hz'},
-  {legend: '> 3 kV =', voltage: 3001, frequency: 0, electrification_label: '4kV ='},
-  {legend: '3 kV =', voltage: 3000, frequency: 0, electrification_label: '3kV ='},
-  {legend: '1.5 kV - 3 kV =', voltage: 1501, frequency: 0, electrification_label: '2kV ='},
-  {legend: '1.5 kV =', voltage: 1500, frequency: 0, electrification_label: '1.5kV ='},
-  {legend: '1 kV - 1.5 kV =', voltage: 1001, frequency: 0, electrification_label: '1.2kV ='},
-  {legend: '1 kV =', voltage: 1000, frequency: 0, electrification_label: '1kV ='},
-  {legend: '750 V - 1 kV =', voltage: 751, frequency: 0, electrification_label: '800V ='},
-  {legend: '750 V =', voltage: 750, frequency: 0, electrification_label: '750V ='},
-  {legend: '< 750 V =', voltage: 749, frequency: 0, electrification_label: '700V ='},
+  { legend: '> 25 kV ~', voltage: 25000, frequency: 60, electrification_label: '26kV 60Hz' },
+  { legend: '25 kV 60 Hz ~', voltage: 25000, frequency: 60, electrification_label: '25kV 60Hz' },
+  { legend: '25 kV 50 Hz ~', voltage: 25000, frequency: 50, electrification_label: '25kV 50Hz' },
+  { legend: '20 kV 60 Hz ~', voltage: 20000, frequency: 60, electrification_label: '20kV 60Hz' },
+  { legend: '20 kV 50 Hz ~', voltage: 20000, frequency: 50, electrification_label: '20kV 50Hz' },
+  { legend: '15 kV - 25 kV ~', voltage: 15001, frequency: 60, electrification_label: '16kV 60Hz' },
+  { legend: '15 kV 16.7 Hz ~', voltage: 15000, frequency: 16.7, electrification_label: '15kV 16.7Hz' },
+  { legend: '15 kV 16.67 Hz ~', voltage: 15000, frequency: 16.67, electrification_label: '15kV 16.67Hz' },
+  { legend: '12.5 kV - 15 kV ~', voltage: 12501, frequency: 60, electrification_label: '13kV 60Hz' },
+  { legend: '12.5 kV 60 Hz ~', voltage: 12500, frequency: 60, electrification_label: '12.5kV 60Hz' },
+  { legend: '12.5 kV 25 Hz ~', voltage: 12500, frequency: 25, electrification_label: '12.5kV 25Hz' },
+  { legend: '< 12.5 kV ~', voltage: 12499, frequency: 60, electrification_label: '11kV 60Hz' },
+  { legend: '> 3 kV =', voltage: 3001, frequency: 0, electrification_label: '4kV =' },
+  { legend: '3 kV =', voltage: 3000, frequency: 0, electrification_label: '3kV =' },
+  { legend: '1.5 kV - 3 kV =', voltage: 1501, frequency: 0, electrification_label: '2kV =' },
+  { legend: '1.5 kV =', voltage: 1500, frequency: 0, electrification_label: '1.5kV =' },
+  { legend: '1 kV - 1.5 kV =', voltage: 1001, frequency: 0, electrification_label: '1.2kV =' },
+  { legend: '1 kV =', voltage: 1000, frequency: 0, electrification_label: '1kV =' },
+  { legend: '750 V - 1 kV =', voltage: 751, frequency: 0, electrification_label: '800V =' },
+  { legend: '750 V =', voltage: 750, frequency: 0, electrification_label: '750V =' },
+  { legend: '< 750 V =', voltage: 749, frequency: 0, electrification_label: '700V =' },
 ];
 
 const speedLegends = [
@@ -4436,16 +4436,16 @@ function makeLegendStyle(style) {
                 : 'Point',
               coordinates:
                 subItem.type === 'line' ? [
-                    legendPointToMapPoint(legendZoom, [index / subItems.length * 1.5 - 1.5, -entry * 0.6]),
-                    legendPointToMapPoint(legendZoom, [(index + 1) / subItems.length * 1.5 - 1.5, -entry * 0.6]),
-                  ] :
-                  subItem.type === 'polygon' ? Array.from({length: 20 + 1}, (_, i) => i * Math.PI * 2 / 20).map(phi =>
-                      legendPointToMapPoint(legendZoom, [Math.cos(phi) * 0.1 + (index + 0.5) / subItems.length * 1.5 - 1.5, Math.sin(phi) * 0.1 - entry * 0.6]))
-                    : legendPointToMapPoint(legendZoom, [(index + 0.5) / subItems.length * 1.5 - 1.5, -entry * 0.6]),
+                  legendPointToMapPoint(legendZoom, [index / subItems.length * 1.5 - 1.5, -entry * 0.6]),
+                  legendPointToMapPoint(legendZoom, [(index + 1) / subItems.length * 1.5 - 1.5, -entry * 0.6]),
+                ] :
+                subItem.type === 'polygon' ? Array.from({length: 20 + 1}, (_, i) => i * Math.PI * 2 / 20).map(phi =>
+                    legendPointToMapPoint(legendZoom, [Math.cos(phi) * 0.1 + (index + 0.5) / subItems.length * 1.5 - 1.5, Math.sin(phi) * 0.1 - entry * 0.6]))
+                  : legendPointToMapPoint(legendZoom, [(index + 0.5) / subItems.length * 1.5 - 1.5, -entry * 0.6]),
             },
             properties: subItem.properties,
           }));
-          entry++;
+          entry ++;
           return itemFeatures;
         });
         done.add(sourceName);

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -346,13 +346,37 @@ const legendStyles = Object.fromEntries(
     .map(style => [style, `${location.origin}/style/legend-${style}.json`])
 );
 
-const transformMapStyle = (style, configuration) => {
-  const backgroundMapLayer = style.layers.find(it => it.id === 'background-map');
-  backgroundMapLayer.paint['raster-saturation'] = configuration.backgroundSaturation ?? defaultConfiguration.backgroundSaturation;
-  backgroundMapLayer.paint['raster-opacity'] = configuration.backgroundOpacity ?? defaultConfiguration.backgroundOpacity;
+// let backgroundStyle = null;
 
-  const backgroundMapSource = style.sources.background_map;
-  backgroundMapSource.tiles = [configuration.backgroundRasterUrl ?? defaultConfiguration.backgroundRasterUrl];
+// fetch('')
+//   .then(result => result.json())
+//   .then(result => backgroundStyle = result)
+//   .catch(error => {
+//     console.error('Error while fetching background style', error);
+//   });
+
+const transformMapStyle = (style, configuration) => {
+  // console.info('transform', backst)
+
+
+  // const backgroundMapLayer = style.layers.find(it => it.id === 'background-map');
+  // backgroundMapLayer.paint['raster-saturation'] = configuration.backgroundSaturation ?? defaultConfiguration.backgroundSaturation;
+  // backgroundMapLayer.paint['raster-opacity'] = configuration.backgroundOpacity ?? defaultConfiguration.backgroundOpacity;
+  //
+  // const backgroundMapSource = style.sources.background_map;
+  // backgroundMapSource.tiles = [configuration.backgroundRasterUrl ?? defaultConfiguration.backgroundRasterUrl];
+
+  // if (backgroundStyle) {
+  //   const layers = backgroundStyle.layers.map(layer => ({...layer, id: `background-${layer.id}`, source: `background-${layer.source}`}))
+  //   const sources = Object.fromEntries(Object.entries(backgroundStyle.sources).map(([name, source]) => [`background-${name}`, source]))
+  //
+  //   // TODO support array form
+  //   const sprite = backgroundStyle.sprite
+  //
+  //   style.layers = [...layers, ...style.layers]
+  //   style.sources = {...sources, ...style.sources}
+  //   style.sprite = [...style.sprite, {id: 'background', url: sprite}]
+  // }
 
   return style;
 }
@@ -365,6 +389,11 @@ const legendMap = new maplibregl.Map({
   interactive: false,
   // See https://github.com/maplibre/maplibre-gl-js/issues/3503
   maxCanvasSize: [Infinity, Infinity],
+});
+
+const backgroundMap = new maplibregl.Map({
+  container: 'background-map',
+  style: 'https://americanamap.org/style.json',
 });
 
 const map = new maplibregl.Map({
@@ -382,9 +411,8 @@ const onStyleChange = changedStyle => {
   // Change styles
   map.setStyle(mapStyles[changedStyle], {
     validate: false,
-    transformStyle: (previous, next) => {
-      return transformMapStyle(next, configuration);
-    },
+    transformStyle: (previous, next) =>
+      transformMapStyle(next, configuration),
   });
   legendMap.setStyle(legendStyles[changedStyle], {
     validate: false,
@@ -622,6 +650,9 @@ function popupContent(properties) {
 
 map.on('load', () => onMapZoom(map.getZoom()));
 map.on('zoomend', () => onMapZoom(map.getZoom()));
+map.on('move', () => backgroundMap.setCenter(map.getCenter()));
+map.on('zoom', () => backgroundMap.setZoom(map.getZoom()));
+document.getElementById('background-map').style.filter = 'filter: saturate(0) opacity(0.1)';
 
 let hoveredFeature = null
 map.on('mousemove', event => {

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -751,5 +751,8 @@ fetch(`${location.origin}/bounds.json`)
       throw `Invalid status code ${result.status}`
     }
   })
-  .then(result => map.setMaxBounds(result))
+  .then(result => {
+    map.setMaxBounds(result);
+    backgroundMap.jumpTo({ center: map.getCenter(), zoom: map.getZoom(), bearing: map.getBearing()});
+  })
   .catch(error => console.error('Error during fetching of import map bounds', error))

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -394,6 +394,7 @@ const legendMap = new maplibregl.Map({
 const backgroundMap = new maplibregl.Map({
   container: 'background-map',
   style: 'https://americanamap.org/style.json',
+  interactive: false,
 });
 
 const map = new maplibregl.Map({
@@ -652,7 +653,7 @@ map.on('load', () => onMapZoom(map.getZoom()));
 map.on('zoomend', () => onMapZoom(map.getZoom()));
 map.on('move', () => backgroundMap.setCenter(map.getCenter()));
 map.on('zoom', () => backgroundMap.setZoom(map.getZoom()));
-document.getElementById('background-map').style.filter = 'filter: saturate(0) opacity(0.1)';
+document.getElementById('background-map').style.filter = 'saturate(0.1) opacity(0.3)';
 
 let hoveredFeature = null
 map.on('mousemove', event => {

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -332,11 +332,17 @@ function updateConfiguration(name, value) {
   storeConfiguration(localStorage, configuration);
 }
 
+function clamp(value, min, max) {
+  return Math.max(Math.min(value, max), min);
+}
+
 function updateBackgroundMapStyle() {
-  backgroundMapContainer.style.filter = `saturate(${configuration.backgroundSaturation ?? defaultConfiguration.backgroundSaturation}) opacity(${configuration.backgroundOpacity ?? defaultConfiguration.backgroundOpacity})`;
+  backgroundMapContainer.style.filter = `saturate(${clamp(configuration.backgroundSaturation ?? defaultConfiguration.backgroundSaturation, 0.0, 1.0)}) opacity(${clamp(configuration.backgroundOpacity ?? defaultConfiguration.backgroundOpacity, 0.0, 1.0)})`;
 
   if ((configuration.backgroundType ?? defaultConfiguration.backgroundType) === 'raster') {
     backgroundMap.setStyle({
+      name: 'Background map',
+      version: 8,
       layers: [
         {
           id: "background-map",
@@ -360,7 +366,7 @@ function updateBackgroundMapStyle() {
 }
 
 const defaultConfiguration = {
-  backgroundSaturation: -1.0,
+  backgroundSaturation: 0.0,
   backgroundOpacity: 1.0,
   backgroundType: 'raster',
   backgroundUrl: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -388,8 +388,6 @@ const legendStyles = Object.fromEntries(
     .map(style => [style, `${location.origin}/style/legend-${style}.json`])
 );
 
-// TODO https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/Reuse#Vector_tiles_and_stylesheets
-
 const legendMap = new maplibregl.Map({
   container: 'legend-map',
   zoom: 5,


### PR DESCRIPTION
Fixes https://github.com/hiddewie/OpenRailwayMap-vector/issues/66

### Implementation details

For raster tiles, adding a single extra layer is trivial. However, for vector background maps, an entire new MapLibre GL JS map instance must be made, to support a style, fonts, layers and sources.

The background map instance is created and rendered behind the railway map. Whenever the map changes location or zoom, the background map must also change.

This introduces a small lag. Possibly the raster implementation stays the same, while the vector implementation uses this implementation (?). 

The current opacity and saturation configuration options can be supported by plain CSS `filter` values for the entire background map.

Inspiration from https://github.com/maplibre/maplibre-gl-compare


