### PR TITLE
Render signal boxes as points with text below

### DIFF
--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -233,6 +233,7 @@ local boxes = osm2pgsql.define_table({
   columns = {
     { column = 'id', sql_type = 'serial', create_only = true },
     { column = 'way', type = 'geometry' },
+    { column = 'center', type = 'geometry' },
     { column = 'way_area', type = 'real' },
     { column = 'feature', type = 'text' },
     { column = 'ref', type = 'text' },
@@ -333,8 +334,10 @@ function osm2pgsql.process_node(object)
   local tags = object.tags
 
   if railway_box_values(tags.railway) then
+    local point = object:as_point()
     boxes:insert({
-      way = object:as_point(),
+      way = point,
+      center = point,
       way_area = 0,
       feature = tags.railway,
       ref = tags['railway:ref'],
@@ -623,6 +626,7 @@ function osm2pgsql.process_way(object)
     local polygon = object:as_polygon():transform(3857)
     boxes:insert({
       way = polygon,
+      center = polygon:centroid(),
       way_area = polygon:area(),
       feature = tags.railway,
       ref = tags['railway:ref'],

--- a/import/sql/tile_views.sql
+++ b/import/sql/tile_views.sql
@@ -291,15 +291,34 @@ CREATE OR REPLACE VIEW speed_railway_signals AS
 
 --- Signals ---
 
-CREATE OR REPLACE VIEW signals_signal_boxes AS
-  SELECT
-    id,
-    way,
-    feature,
-    ref,
-    name
-  FROM boxes
-  ORDER BY way_area DESC NULLS LAST;
+CREATE OR REPLACE FUNCTION signals_signal_boxes(z integer, x integer, y integer)
+  RETURNS bytea
+  LANGUAGE SQL
+  IMMUTABLE
+  STRICT
+  PARALLEL SAFE
+  RETURN (
+    SELECT
+      ST_AsMVT(tile, 'signals_signal_boxes', 4096, 'way')
+    FROM (
+      SELECT
+        ST_AsMVTGeom(
+          CASE
+            WHEN z >= 14 THEN way
+            ELSE center
+          END,
+          ST_TileEnvelope(z, x, y),
+          4096, 64, true
+        ) AS way,
+        id,
+        feature,
+        ref,
+        name
+      FROM boxes
+      WHERE way && ST_TileEnvelope(z, x, y)
+    ) as tile
+    WHERE way IS NOT NULL
+  );
 
 CREATE OR REPLACE VIEW signals_railway_signals AS
   SELECT

--- a/martin/configuration.yml
+++ b/martin/configuration.yml
@@ -260,17 +260,7 @@ postgres:
         azimuth: number
         direction_both: boolean
 
-    signals_signal_boxes:
-      schema: public
-      table: signals_signal_boxes
-      srid: 3857
-      geometry_column: way
-      geometry_type: GEOMETRY
-      properties:
-        id: integer
-        feature: string
-        ref: string
-        name: string
+    # signals_signal_boxes, see function below
 
     # --- Electrification --- #
 
@@ -285,6 +275,17 @@ postgres:
         feature: string
         azimuth: number
         direction_both: boolean
+
+
+  functions:
+
+    # --- Signals --- #
+
+    signals_signal_boxes:
+      schema: public
+      function: signals_signal_boxes
+      minzoom: 8
+      maxzoom: 14
 
 fonts:
   - /config/fonts

--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -2381,7 +2381,7 @@ const layers = {
           ['boolean', ['feature-state', 'hover'], false], colors.hover.main,
           '#008206',
         ],
-        'circle-radius': 6,
+        'circle-radius': 4,
         'circle-stroke-color': 'white',
         'circle-stroke-width': 1,
       },
@@ -2389,7 +2389,7 @@ const layers = {
     {
       id: 'signal_boxes_polygon',
       type: 'fill',
-      minzoom: 12,
+      minzoom: 14,
       source: 'openrailwaymap_signals',
       'source-layer': 'signals_signal_boxes',
       filter: ['any',
@@ -2407,7 +2407,7 @@ const layers = {
     {
       id: 'signal_boxes_polygon_outline',
       type: 'line',
-      minzoom: 12,
+      minzoom: 14,
       source: 'openrailwaymap_signals',
       'source-layer': 'signals_signal_boxes',
       filter: ['any',
@@ -2515,6 +2515,7 @@ const layers = {
         'text-field': '{ref}',
         'text-font': ['Noto Sans Bold'],
         'text-size': 11,
+        'text-offset': ['literal', [0, 1]],
       }
     },
     railwayKmText,


### PR DESCRIPTION
This requires a different rendering for polygons as for points, because the polygons need to have their center rendered for the lower zoom levels.

The center can only be calculated in the backend, not during rendering in MapLibre GL JS.

The center is stored along with the full geometry, such that polygon signal boxes can be rendered as such for high zoom levels.

The `signals_signal_boxes` tile source is converted to a function to ensure it can take the zoom level into account to determine which geometry to return to the client.

Fixes https://github.com/hiddewie/OpenRailwayMap-vector/issues/133