### PR TITLE
Render railway positions for low zooms without decimal

### DIFF
--- a/import/sql/tile_views.sql
+++ b/import/sql/tile_views.sql
@@ -247,7 +247,8 @@ CREATE OR REPLACE VIEW railway_text_km AS
     way,
     railway,
     pos,
-    (railway_pos_decimal(pos) = '0') as zero
+    (railway_pos_decimal(pos) = '0') as zero,
+    left(pos, -2) as pos_int
   FROM
     (SELECT
        id,

--- a/martin/configuration.yml
+++ b/martin/configuration.yml
@@ -212,6 +212,7 @@ postgres:
         id: integer
         railway: string
         pos: string
+        pos_int: string
         zero: boolean
 
     standard_railway_switch_ref:

--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -1087,7 +1087,11 @@ const railwayKmText = {
   },
   layout: {
     'symbol-z-order': 'source',
-    'text-field': '{pos}',
+    'text-field': ['step', ['zoom'],
+      ['get', 'pos_int'],
+      13,
+      ['get', 'pos'],
+    ],
     'text-font': ['Noto Sans Bold'],
     'text-size': 11,
   },


### PR DESCRIPTION
This solves some of the clutter on the map, now that railway positions are shown in every layer.

![image](https://github.com/user-attachments/assets/aff963d2-d993-4a28-9d01-42d3821362b1)
