### PR TITLE
fix: signal type for DE-BOStrab:so5

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -676,7 +676,7 @@ signals_railway_signals:
       tags:
         - { tag: 'railway:signal:passing', value: 'DE-BOStrab:so5' }
         - { tag: 'railway:signal:passing:form', value: 'sign' }
-        - { tag: 'railway:signal:passing:type', value: 'no_type' }
+        - { tag: 'railway:signal:passing:type', value: 'no_passing' }
 
     - description: tram passing prohibited end sign So 6
       country: DE


### PR DESCRIPTION
Fixes #155 

The signal type was wrongly configured.

Now it works

![image](https://github.com/user-attachments/assets/93e7087c-ca8b-4c24-86cf-0554b6d87c69)
