### PR TITLE
fix: crossing distant sign Bü 2 not rendered

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -491,6 +491,7 @@ signals_railway_signals:
         default: 'de/bue4-ds'
       tags:
         - { tag: 'railway:signal:whistle', value: 'DE-ESO:db:bü4' }
+        - { tag: 'railway:signal:whistle:form', value: 'sign' }
 
     - description: crossing distant sign Bü 2
       country: DE
@@ -500,7 +501,8 @@ signals_railway_signals:
           - { regex: '^yes$', value: 'de/bue2-ds-reduced-distance', description: 'reduced distance' }
         default: 'de/bue2-ds'
       tags:
-        - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:db:bü4' }
+        - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:bü2' }
+        - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
 
     - description: whistle sign Bü 3
       country: DE
@@ -517,6 +519,7 @@ signals_railway_signals:
         default: 'de/pf1-dv'
       tags:
         - { tag: 'railway:signal:whistle', value: 'DE-ESO:dr:pf1' }
+        - { tag: 'railway:signal:whistle:form', value: 'sign' }
 
     - description: ring sign Bü 5
       country: DE


### PR DESCRIPTION
Fixes https://github.com/hiddewie/OpenRailwayMap-vector/issues/160

It was mistagged as Bü4

![image](https://github.com/user-attachments/assets/8e201750-9a6d-472d-b1ca-8c3b1b84e2d6)
