### PR TITLE
Draw distant H/V signals with lower priority than main signals 

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -816,17 +816,6 @@ features:
       - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:so14' }
       - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
 
-  - description: distant signal replacement by sign Ne 2
-    country: DE
-    icon:
-      match: 'railway:signal:distant:shortened'
-      cases:
-        - { regex: '^yes$', value: 'de/ne2-reduced-distance' }
-      default: 'de/ne2'
-    tags:
-      - { tag: 'railway:signal:distant', value: 'DE-ESO:db:ne2' }
-      - { tag: 'railway:signal:distant:form', value: 'sign' }
-
   - description: main semaphore signals type Hp
     country: DE
     icon:
@@ -902,6 +891,17 @@ features:
     tags:
       - { tag: 'railway:signal:distant', value: 'DE-ESO:vr' }
       - { tag: 'railway:signal:distant:form', value: 'semaphore' }
+
+  - description: distant signal replacement by sign Ne 2
+    country: DE
+    icon:
+      match: 'railway:signal:distant:shortened'
+      cases:
+        - { regex: '^yes$', value: 'de/ne2-reduced-distance' }
+      default: 'de/ne2'
+    tags:
+      - { tag: 'railway:signal:distant', value: 'DE-ESO:db:ne2' }
+      - { tag: 'railway:signal:distant:form', value: 'sign' }
 
   - description: distant light signals type Hl
     country: DE

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -778,58 +778,6 @@ features:
       - { tag: 'railway:signal:main', value: 'DE-ESO:ne1' }
       - { tag: 'railway:signal:main:form', value: 'sign' }
 
-  - description: distant light signals type Vr (repeated)
-    country: DE
-    icon:
-      match: 'railway:signal:distant:states'
-      cases:
-        - { regex: '^(.*;)?DE-ESO:vr2(;.*)?$', value: 'de/vr2-light-repeated', description: 'shortened' }
-        - { regex: '^(.*;)?DE-ESO:vr1(;.*)?$', value: 'de/vr1-light-repeated' }
-      default: 'de/vr0-light-repeated'
-    tags:
-      - { tag: 'railway:signal:distant', value: 'DE-ESO:vr' }
-      - { tag: 'railway:signal:distant:form', value: 'light' }
-      - { tag: 'railway:signal:distant:repeated', value: 'yes' }
-
-  - description: distant light signals type Vr (shortened)
-    country: DE
-    # TODO make distinct icon
-    # Shown with the same icon as shortened
-    icon:
-      match: 'railway:signal:distant:states'
-      cases:
-        - { regex: '^(.*;)?DE-ESO:vr2(;.*)?$', value: 'de/vr2-light-repeated' }
-        - { regex: '^(.*;)?DE-ESO:vr1(;.*)?$', value: 'de/vr1-light-repeated' }
-      default: 'de/vr0-light-repeated'
-    tags:
-      - { tag: 'railway:signal:distant', value: 'DE-ESO:vr' }
-      - { tag: 'railway:signal:distant:form', value: 'light' }
-      - { tag: 'railway:signal:distant:shortened', value: 'yes' }
-
-  - description: distant light signals type Vr
-    country: DE
-    icon:
-      match: 'railway:signal:distant:states'
-      cases:
-        - { regex: '^(.*;)?DE-ESO:vr2(;.*)?$', value: 'de/vr2-light' }
-        - { regex: '^(.*;)?DE-ESO:vr1(;.*)?$', value: 'de/vr1-light' }
-      default: 'de/vr0-light'
-    tags:
-      - { tag: 'railway:signal:distant', value: 'DE-ESO:vr' }
-      - { tag: 'railway:signal:distant:form', value: 'light' }
-
-  - description: distant semaphore signals type Vr
-    country: DE
-    icon:
-      match: 'railway:signal:distant:states'
-      cases:
-        - { regex: '^(.*;)?DE-ESO:vr2(;.*)?$', value: 'de/vr2-semaphore' }
-        - { regex: '^(.*;)?DE-ESO:vr1(;.*)?$', value: 'de/vr1-semaphore' }
-      default: 'de/vr0-semaphore'
-    tags:
-      - { tag: 'railway:signal:distant', value: 'DE-ESO:vr' }
-      - { tag: 'railway:signal:distant:form', value: 'semaphore' }
-
   - description: Hamburger Hochbahn distant signal
     country: DE
     icon: { default: 'de/hha/v1' }
@@ -902,6 +850,58 @@ features:
     tags:
       - { tag: 'railway:signal:main', value: 'DE-ESO:hp' }
       - { tag: 'railway:signal:main:form', value: 'light' }
+
+  - description: distant light signals type Vr (repeated)
+    country: DE
+    icon:
+      match: 'railway:signal:distant:states'
+      cases:
+        - { regex: '^(.*;)?DE-ESO:vr2(;.*)?$', value: 'de/vr2-light-repeated', description: 'shortened' }
+        - { regex: '^(.*;)?DE-ESO:vr1(;.*)?$', value: 'de/vr1-light-repeated' }
+      default: 'de/vr0-light-repeated'
+    tags:
+      - { tag: 'railway:signal:distant', value: 'DE-ESO:vr' }
+      - { tag: 'railway:signal:distant:form', value: 'light' }
+      - { tag: 'railway:signal:distant:repeated', value: 'yes' }
+
+  - description: distant light signals type Vr (shortened)
+    country: DE
+    # TODO make distinct icon
+    # Shown with the same icon as shortened
+    icon:
+      match: 'railway:signal:distant:states'
+      cases:
+        - { regex: '^(.*;)?DE-ESO:vr2(;.*)?$', value: 'de/vr2-light-repeated' }
+        - { regex: '^(.*;)?DE-ESO:vr1(;.*)?$', value: 'de/vr1-light-repeated' }
+      default: 'de/vr0-light-repeated'
+    tags:
+      - { tag: 'railway:signal:distant', value: 'DE-ESO:vr' }
+      - { tag: 'railway:signal:distant:form', value: 'light' }
+      - { tag: 'railway:signal:distant:shortened', value: 'yes' }
+
+  - description: distant light signals type Vr
+    country: DE
+    icon:
+      match: 'railway:signal:distant:states'
+      cases:
+        - { regex: '^(.*;)?DE-ESO:vr2(;.*)?$', value: 'de/vr2-light' }
+        - { regex: '^(.*;)?DE-ESO:vr1(;.*)?$', value: 'de/vr1-light' }
+      default: 'de/vr0-light'
+    tags:
+      - { tag: 'railway:signal:distant', value: 'DE-ESO:vr' }
+      - { tag: 'railway:signal:distant:form', value: 'light' }
+
+  - description: distant semaphore signals type Vr
+    country: DE
+    icon:
+      match: 'railway:signal:distant:states'
+      cases:
+        - { regex: '^(.*;)?DE-ESO:vr2(;.*)?$', value: 'de/vr2-semaphore' }
+        - { regex: '^(.*;)?DE-ESO:vr1(;.*)?$', value: 'de/vr1-semaphore' }
+      default: 'de/vr0-semaphore'
+    tags:
+      - { tag: 'railway:signal:distant', value: 'DE-ESO:vr' }
+      - { tag: 'railway:signal:distant:form', value: 'semaphore' }
 
   - description: distant light signals type Hl
     country: DE


### PR DESCRIPTION
Right now distant H/V signals take higher priority over their main counterparts, causing main signals with a distant signal attached to be drawn as distant signal, which is wrong, as the main signal is more important.

Example now https://openrailwaymap.fly.dev/#view=16.48/49.470724/10.991369&style=signals

With this fix all signals with a main signal ref, e.g. (N|P|S|R)[1-9]+ are drawn correctly. This matches the old ORM style:
![image](https://github.com/user-attachments/assets/8a45b8cc-6df4-40c3-909e-a418a655c993)

 