### PR TITLE
Improve tagging/description for ne5 and schaltzeiger

### DIFF
--- a/features/electrification_signals.yaml
+++ b/features/electrification_signals.yaml
@@ -88,7 +88,7 @@ features:
       - { tag: 'railway:signal:electricity:type', value: 'pantograph_up' }
       - { tag: 'railway:signal:electricity:form', value: 'sign' }
 
-  - description: AT-V2:schaltzeiger
+  - description: Schaltzeiger
     country: AT
     icon: { default: 'at/schaltzeiger' }
     tags:

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -622,7 +622,7 @@ features:
     country: DE
     icon: { default: 'de/ne5-sign' }
     tags:
-      - { tag: 'railway:signal:stop_demand', value: 'DE-ESO:ne5' }
+      - { tag: 'railway:signal:stop', value: 'DE-ESO:ne5' }
       - { tag: 'railway:signal:stop:form', value: 'sign' }
 
   - description: Ne13 resetting switch signal


### PR DESCRIPTION
The tagging for ne5 was wrong, and the description for the Schaltzeiger was too close to the tag.