### PR TITLE
Extract tile generation script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
           BBOX: '-10.0,35.7,39.0,70.0'
         run: |
           docker compose run martin-cp
-          ls -las tiles/
+          ls -lah tiles/*.mbtiles
 
       - uses: actions/upload-artifact@v4
         with:
@@ -110,7 +110,7 @@ jobs:
 
       - name: List generated tiles
         run: |
-          ls -lah tiles/
+          ls -lah tiles/*.mbtiles
 
       - name: Deploy
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,7 +253,7 @@ jobs:
 
       - name: List generated tiles
         run: |
-          ls -la tiles/*.mbtiles
+          ls -lah tiles/*.mbtiles
 
       - name: Start martin with tiles
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,25 +48,10 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    entrypoint: ['sh', '-c']
-    command: |
-      '
-      export MARTIN="martin-cp --config /config/configuration.yml --mbtiles-type flat --on-duplicate override --skip-agg-tiles-hash --bbox=$$BBOX"
-      [ "$$TILES" = "low-med" ] && $$MARTIN --min-zoom 0 --max-zoom 6 --source railway_line_low --output-file /tiles/railway_line_low.mbtiles && mbtiles summary /tiles/railway_line_low.mbtiles
-      [ "$$TILES" = "low-med" ] && $$MARTIN --min-zoom 0 --max-zoom 6 --source standard_railway_text_stations_low --output-file /tiles/standard_railway_text_stations_low.mbtiles && mbtiles summary /tiles/standard_railway_text_stations_low.mbtiles
-      [ "$$TILES" = "low-med" ] && $$MARTIN --min-zoom 7 --max-zoom 7 --source railway_line_med --output-file /tiles/railway_line_med.mbtiles && mbtiles summary /tiles/railway_line_med.mbtiles
-      [ "$$TILES" = "low-med" ] && $$MARTIN --min-zoom 7 --max-zoom 7 --source standard_railway_text_stations_med --output-file /tiles/standard_railway_text_stations_med.mbtiles && mbtiles summary /tiles/standard_railway_text_stations_med.mbtiles
-      [ "$$TILES" = "high" ] && $$MARTIN --min-zoom 8 --max-zoom "$$MAX_ZOOM" --source railway_line_high,railway_text_km --output-file /tiles/high.mbtiles && mbtiles summary /tiles/high.mbtiles
-      [ "$$TILES" = "standard" ] && $$MARTIN --min-zoom 8 --max-zoom "$$MAX_ZOOM" --source standard_railway_turntables,standard_railway_text_stations,standard_railway_grouped_stations,standard_railway_symbols,standard_railway_switch_ref --output-file /tiles/standard.mbtiles && mbtiles summary /tiles/standard.mbtiles
-      [ "$$TILES" = "speed" ] && $$MARTIN --min-zoom 8 --max-zoom "$$MAX_ZOOM" --source speed_railway_signals --output-file /tiles/speed.mbtiles && mbtiles summary /tiles/speed.mbtiles
-      [ "$$TILES" = "signals" ] && $$MARTIN --min-zoom 8 --max-zoom "$$MAX_ZOOM" --source signals_railway_signals,signals_signal_boxes --output-file /tiles/signals.mbtiles && mbtiles summary /tiles/signals.mbtiles
-      [ "$$TILES" = "electrification" ] && $$MARTIN --min-zoom 8 --max-zoom "$$MAX_ZOOM" --source electrification_signals --output-file /tiles/electrification.mbtiles && mbtiles summary /tiles/electrification.mbtiles
-      true
-      '
-
     volumes:
       - ./martin:/config
       - ./tiles:/tiles
+    entrypoint: '/tiles/tiles.sh'
     environment:
       # Europe center: -10.0,35.7,39.0,70.0
       # AT: 9.52678,46.36851,17.16273,48.90201

--- a/tiles/tiles.sh
+++ b/tiles/tiles.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+
+# This script renders tiles from Martin sources to MBTiles files
+# The zoom levels of the sources are taken into account to avoid outputting unused data into tiles
+# Documentation:
+#  - https://maplibre.org/martin/martin-cp.html
+#  - httpshttps://maplibre.org/martin/mbtiles-copy.html
+
+set -e
+
+export MARTIN="martin-cp --config /config/configuration.yml --mbtiles-type flat --on-duplicate abort --skip-agg-tiles-hash --bbox=$BBOX"
+
+if [ "$TILES" = "low-med" ]; then
+  rm -f /tiles/railway_line_high.mbtiles
+  $MARTIN --min-zoom 0 --max-zoom 6 --source railway_line_high --output-file /tiles/railway_line_high.mbtiles
+  mbtiles summary /tiles/railway_line_high.mbtiles
+
+  rm -f /tiles/standard_railway_text_stations_low.mbtiles
+  $MARTIN --min-zoom 0 --max-zoom 6 --source standard_railway_text_stations_low --output-file /tiles/standard_railway_text_stations_low.mbtiles
+  mbtiles summary /tiles/standard_railway_text_stations_low.mbtiles
+
+  rm -f /tiles/railway_line_high.mbtiles
+  $MARTIN --min-zoom 7 --max-zoom 7 --source railway_line_high --output-file /tiles/railway_line_high.mbtiles
+  mbtiles summary /tiles/railway_line_high.mbtiles
+
+  rm -f /tiles/standard_railway_text_stations_med.mbtiles
+  $MARTIN --min-zoom 7 --max-zoom 7 --source standard_railway_text_stations_med --output-file /tiles/standard_railway_text_stations_med.mbtiles
+  mbtiles summary /tiles/standard_railway_text_stations_med.mbtiles
+fi
+
+if [ "$TILES" = "high" ]; then
+  rm -f /tiles/high8.mbtiles
+  $MARTIN --min-zoom 8 --max-zoom 9 --source railway_line_high --output-file /tiles/high8.mbtiles
+  mbtiles summary /tiles/high8.mbtiles
+
+  rm -f /tiles/high10.mbtiles
+  $MARTIN --min-zoom 10 --max-zoom "$MAX_ZOOM" --source railway_line_high,railway_text_km --output-file /tiles/high10.mbtiles
+  mbtiles summary /tiles/high10.mbtiles
+
+  rm -f /tiles/high.mbtiles
+  mbtiles copy --on-duplicate abort /tiles/high8.mbtiles /tiles/high.mbtiles
+  mbtiles copy --on-duplicate override /tiles/high10.mbtiles /tiles/high.mbtiles
+  mbtiles summary /tiles/high.mbtiles
+fi
+
+if [ "$TILES" = "standard" ]; then
+  rm -f /tiles/standard.mbtiles
+  $MARTIN --min-zoom 8 --max-zoom "$MAX_ZOOM" --source standard_railway_turntables,standard_railway_text_stations,standard_railway_grouped_stations,standard_railway_symbols,standard_railway_switch_ref --output-file /tiles/standard.mbtiles
+  mbtiles summary /tiles/standard.mbtiles
+fi
+
+if [ "$TILES" = "speed" ]; then
+  rm -f /tiles/speed.mbtiles
+  $MARTIN --min-zoom 8 --max-zoom "$MAX_ZOOM" --source speed_railway_signals --output-file /tiles/speed.mbtiles
+  mbtiles summary /tiles/speed.mbtiles
+fi
+
+if [ "$TILES" = "signals" ]; then
+  rm -f /tiles/signals.mbtiles
+  $MARTIN --min-zoom 8 --max-zoom "$MAX_ZOOM" --source signals_railway_signals,signals_signal_boxes --output-file /tiles/signals.mbtiles
+  mbtiles summary /tiles/signals.mbtiles
+fi
+
+if [ "$TILES" = "electrification" ]; then
+  rm -f /tiles/electrification.mbtiles
+  $MARTIN --min-zoom 8 --max-zoom "$MAX_ZOOM" --source electrification_signals --output-file /tiles/electrification.mbtiles
+  mbtiles summary /tiles/electrification.mbtiles
+fi


### PR DESCRIPTION
Also split high tiles generation into zoom 8-9 generation and zoom 10+ generation.

Delete tile files before regenerating them.

Extracted from https://github.com/hiddewie/OpenRailwayMap-vector/pull/191.