### PR TITLE
fix high railway tiles only available from zoom 10

### DIFF
--- a/tiles/tiles.sh
+++ b/tiles/tiles.sh
@@ -25,17 +25,8 @@ if [ "$TILES" = "low-med" ]; then
 fi
 
 if [ "$TILES" = "high" ]; then
-  rm -f /tiles/high8.mbtiles
-  $MARTIN --min-zoom 8 --max-zoom 9 --source railway_line_high --output-file /tiles/high8.mbtiles
-  mbtiles summary /tiles/high8.mbtiles
-
-  rm -f /tiles/high10.mbtiles
-  $MARTIN --min-zoom 10 --max-zoom "$MAX_ZOOM" --source railway_line_high,railway_text_km --output-file /tiles/high10.mbtiles
-  mbtiles summary /tiles/high10.mbtiles
-
   rm -f /tiles/high.mbtiles
-  mbtiles copy --on-duplicate abort /tiles/high8.mbtiles /tiles/high.mbtiles
-  mbtiles copy --on-duplicate override /tiles/high10.mbtiles /tiles/high.mbtiles
+  $MARTIN --min-zoom 8 --max-zoom "$MAX_ZOOM" --source railway_line_high,railway_text_km --output-file /tiles/high.mbtiles
   mbtiles summary /tiles/high.mbtiles
 fi
 


### PR DESCRIPTION
merging the 8-9 and 10+ zoom tiles outputs a minzoom of 10, hiding all railway lines on zoom 8 up to 10:

![image](https://github.com/user-attachments/assets/cb6cb0be-c062-49aa-9091-a29351e01859)

![image](https://github.com/user-attachments/assets/d14f46c0-b052-4e82-b645-4657bb7ad9b1)
