### PR TITLE
Fix `way_length` using meter unit for showing bridges

### DIFF
--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -842,7 +842,7 @@ const railwayLine = (theme, text, layers) => [
           ['>=',
             ['get', 'way_length'],
             ['interpolate', ["exponential", .5], ['zoom'],
-              8, 0.015,
+              8, 1500,
               16, 0
             ],
           ],
@@ -869,9 +869,10 @@ const railwayLine = (theme, text, layers) => [
         filter: ['all',
           ['==', ['get', 'state'], 'present'],
           ['get', 'bridge'],
-          ['>=', ['get', 'way_length'],
+          ['>=',
+            ['get', 'way_length'],
             ['interpolate', ["exponential", .5], ['zoom'],
-              8, 0.015,
+              8, 1500,
               16, 0
             ],
           ],


### PR DESCRIPTION
Since https://github.com/hiddewie/OpenRailwayMap-vector/pull/197

`way_length` is now in meters instead of degrees.

With this change, bridges of short length in the current zoom level are not shown with casing:
![image](https://github.com/user-attachments/assets/0ed7774e-b7f5-49f1-a542-fa3db99eb5f7)
