### PR TITLE
Set minzoom for electrification signals to 13

### DIFF
--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -2290,7 +2290,7 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
     {
       id: 'electrification_signals_direction',
       type: 'symbol',
-      minzoom: 15,
+      minzoom: 13,
       source: 'openrailwaymap_electrification',
       'source-layer': 'electrification_signals',
       filter: ['all',
@@ -2325,7 +2325,7 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
       ['get', 'feature'],
       {
         type: 'symbol',
-        minzoom: 15,
+        minzoom: 13,
         source: 'openrailwaymap_electrification',
         'source-layer': 'electrification_signals',
         paint: {


### PR DESCRIPTION
This sets minzoom for signals on this layer to the same value as on the speed and train protection layers.