### PR TITLE
Don't rotate signal direction indicators

### DIFF
--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -1836,6 +1836,8 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
           'top',
         ],
         'icon-rotate': ['get', 'azimuth'],
+        'icon-keep-upright': true,
+        'icon-rotation-alignment': 'map',
       },
     },
     ...[0, 1].flatMap(featureIndex =>
@@ -2043,6 +2045,8 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
           'top',
         ],
         'icon-rotate': ['get', 'azimuth'],
+        'icon-keep-upright': true,
+        'icon-rotation-alignment': 'map',
       },
     },
     // Show at most 2 combined features
@@ -2317,6 +2321,8 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
           'top',
         ],
         'icon-rotate': ['get', 'azimuth'],
+        'icon-keep-upright': true,
+        'icon-rotation-alignment': 'map',
       },
     },
     ...imageLayerWithOutline(


### PR DESCRIPTION
Situation right now, when rotating the map
![image](https://github.com/user-attachments/assets/38b77c83-e4a9-4b95-bce9-23809e4f2c62)

Afterward
![image](https://github.com/user-attachments/assets/85322f0b-b1aa-47e0-835d-8ed7b0604b7a)
