### PR TITLE
fix: remove full screen map button

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -766,7 +766,6 @@ map.addControl(
     showUserLocation: true,
   })
 );
-map.addControl(new maplibregl.FullscreenControl());
 map.addControl(new EditControl());
 map.addControl(new ConfigurationControl());
 


### PR DESCRIPTION
Fixes https://github.com/hiddewie/OpenRailwayMap-vector/issues/244

The full screen control, https://github.com/maplibre/maplibre-gl-js/blob/b52cb12b19b1064741bf821683c93e823d50294b/src/ui/control/fullscreen_control.ts#L52 uses the `requestFullscreen()` browser function (see https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullscreen).

This puts a single element (the map) full screen, instead of the entire page. Especially the popup dialogs, and the background maps, are separate components on the screen, so not included in the full screen component of just the map.

Solution: remove the full-screen button alltogether.

It remains possible to put the browser in full screen mode by using the `F11` button (or the browser menu controls).

![image](https://github.com/user-attachments/assets/0fa15ea1-f117-4d63-8abc-daf04e7c1ddb)
