### PR TITLE
Run tests on pull requests from forked repositories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,8 @@
 name: Test
 
 on:
-  push: ~
+  workflow_dispatch: ~
+  pull_request: ~
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   workflow_dispatch: ~
+  push: ~
   pull_request: ~
 
 concurrency:


### PR DESCRIPTION
See https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull-request-events-for-forked-repositories


Ref https://github.com/hiddewie/OpenRailwayMap-vector/pull/232#issuecomment-2666803060

This PR should solve the problem that there is no button to approve CI to run the tests on pull requests from forked repositories.