### PR TITLE
Stop showing station size in the popup

### DIFF
--- a/proxy/js/features.mjs
+++ b/proxy/js/features.mjs
@@ -187,9 +187,6 @@ const stationFeatures = {
     station: {
       name: 'Type',
     },
-    station_size: {
-      name: 'Size',
-    },
     label: {
       name: 'Reference',
     },


### PR DESCRIPTION
From discussion with #278

The station size is good for showing stations at certain zoom levels, but there the value small / normal / large is rather arbitrary.

![image](https://github.com/user-attachments/assets/ad1f5c1b-45f8-41d7-b871-ace25e90ecf0)
