### PR TITLE
Do not render maxspeed for razed/abandoned railways

### DIFF
--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -87,8 +87,10 @@ function largest_speed_noconvert(value)
 end
 
 -- Speed label and dominant speed, taking the preferred direction and forward, backward an non-directional speed into account
-function dominant_speed_label(preferred_direction, speed, forward_speed, backward_speed)
-  if (not speed) and (not forward_speed) and (not backward_speed) then
+function dominant_speed_label(state, preferred_direction, speed, forward_speed, backward_speed)
+  if state == 'abandoned' or state == 'razed' then
+    return nil, nil
+  elseif (not speed) and (not forward_speed) and (not backward_speed) then
     return nil, nil
   elseif speed and (not forward_speed) and (not backward_speed) then
     return speed_int(speed), speed
@@ -642,7 +644,7 @@ function osm2pgsql.process_way(object)
     local name = railway_line_name(state_name, tunnel, tags['tunnel:name'], bridge, tags['bridge:name'])
 
     local preferred_direction = tags['railway:preferred_direction']
-    local dominant_speed, speed_label = dominant_speed_label(preferred_direction, tags['maxspeed'], tags['maxspeed:forward'], tags['maxspeed:backward'])
+    local dominant_speed, speed_label = dominant_speed_label(state, preferred_direction, tags['maxspeed'], tags['maxspeed:forward'], tags['maxspeed:backward'])
 
     -- Segmentize linestring to optimize tile queries
     for way in object:as_linestring():transform(3857):segmentize(max_segment_length):geometries() do


### PR DESCRIPTION
Fixes #192

Ignore maxspeed tags for razed/abandoned railways

Way https://www.openstreetmap.org/way/35361564

On http://localhost:8000/#view=13.71/45.61507/-72.98418&style=standard
![image](https://github.com/user-attachments/assets/65969b00-4edd-4bf2-ab0e-c1e1c33cca85)

Speed layer does not show razed/abandoned railways:
![image](https://github.com/user-attachments/assets/cbf391a2-79e9-49bc-9aba-a0685d7ce87d)

