### PR TITLE
Fix tag for resetting switches

### DIFF
--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -630,7 +630,7 @@ function osm2pgsql.process_node(object)
       type = tags['railway:switch'],
       turnout_side = tags['railway:turnout_side'],
       local_operated = tags['railway:local_operated'] == 'yes',
-      resetting = tags['railway:resetting'] == 'yes',
+      resetting = tags['railway:switch:resetting'] == 'yes',
     })
   end
 end


### PR DESCRIPTION
From comment https://github.com/hiddewie/OpenRailwayMap-vector/pull/300#issuecomment-2750964599. 

Change `railway:resetting` to `railway:switch:resetting` in the import code.

See https://github.com/hiddewie/OpenRailwayMap-vector/pull/309