### PR TITLE
Fix secondary/tertiary feature lookup for signals with variables

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -838,12 +838,16 @@ function popupContent(feature) {
   }
 
   const featureProperty = featureCatalog.featureProperty || 'feature';
-  // Remove the variable part of the property to get the key
-  const catalogKey = properties[featureProperty] && properties[featureProperty].replace(/\{[^}]+}/, '{}');
-  // Capture the variable part as well for display
-  const keyVariable = properties[featureProperty]
-    ? properties[featureProperty].match(/\{([^}]+)}/)?.[1]
-    : null;
+
+  const constructCatalogKey = propertyValue => ({
+    // Remove the variable part of the property to get the key
+    catalogKey: propertyValue && propertyValue.replace(/\{[^}]+}/, '{}'),
+    // Capture the variable part as well for display
+    keyVariable: propertyValue
+      ? propertyValue.match(/\{([^}]+)}/)?.[1]
+      : null
+  });
+  const {catalogKey, keyVariable} = constructCatalogKey(properties[featureProperty]);
 
   const featureContent = featureCatalog.features && featureCatalog.features[catalogKey];
   if (!featureContent) {
@@ -876,12 +880,13 @@ function popupContent(feature) {
             console.warn('Lookup catalog', format.lookup, 'not found for feature', feature);
             return stringValue;
           } else {
-            const lookedUpValue = lookupCatalog.features[value];
+            const {lookUpCatalogKey, lookUpKeyVariable} = constructCatalogKey(value);
+            const lookedUpValue = lookupCatalog.features[lookUpCatalogKey];
             if (!lookedUpValue) {
               console.warn('Lookup catalog', format.lookup, 'did not contain value', value, 'for feature', feature);
               return stringValue;
             } else {
-              return lookedUpValue.name;
+              return `${lookedUpValue.name}${lookUpKeyVariable ? ` (${lookUpKeyVariable})` : ''}`;
             }
           }
         } else {

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -880,7 +880,7 @@ function popupContent(feature) {
             console.warn('Lookup catalog', format.lookup, 'not found for feature', feature);
             return stringValue;
           } else {
-            const {lookUpCatalogKey, lookUpKeyVariable} = constructCatalogKey(value);
+            const {catalogKey: lookUpCatalogKey, keyVariable: lookUpKeyVariable} = constructCatalogKey(value);
             const lookedUpValue = lookupCatalog.features[lookUpCatalogKey];
             if (!lookedUpValue) {
               console.warn('Lookup catalog', format.lookup, 'did not contain value', value, 'for feature', feature);


### PR DESCRIPTION
http://localhost:8000/#view=18.2/52.263192/10.598613/22.6&style=speed

![image](https://github.com/user-attachments/assets/03f755e4-5cda-47ce-aeb2-d8cc8dd4e682)

> Lookup catalog openrailwaymap_speed-speed_railway_signals did not contain value de/lf6-sign-down-{120} for feature  ...

This is caused because the variable part `{120}` is not extracted correctly.

After:
![image](https://github.com/user-attachments/assets/910eda46-45fd-49fa-b2fb-f366aede6f58)

