### PR TITLE
Make popup not overlap with icons

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -1011,7 +1011,19 @@ map.on('click', event => {
         ? closestPointOnLine(event.lngLat, feature.geometry.coordinates)
         : event.lngLat;
 
-    new maplibregl.Popup()
+    const iconHeight = 20;
+    const iconWidth = 10;
+    const popupOffsets = {
+      'top': [0, iconHeight],
+      'top-left': [iconWidth, iconHeight],
+      'top-right': [-iconWidth, iconHeight],
+      'bottom': [0, -iconHeight],
+      'bottom-left': [iconWidth, -iconHeight],
+      'bottom-right': [-iconWidth, -iconHeight],
+      'left': [iconWidth, 0],
+      'right': [-iconWidth, 0]
+    }
+    new maplibregl.Popup({offset: popupOffsets})
       .setLngLat(coordinates)
       .setHTML(popupContent(feature))
       .addTo(map);


### PR DESCRIPTION
The popup currently opens very close to the center point of the feature on the map.

The offsets can tweak this. See https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/PopupOptions/

Not perfect yet for stacked icons (e.g. multiple signals on single pole), but works well for most icons.

http://localhost:8000/#view=15.6/50.942202/6.964626/22.6&style=speed

![image](https://github.com/user-attachments/assets/f5d79752-29d3-4605-a8e2-3980833fc4fe)
![image](https://github.com/user-attachments/assets/1ad5de49-bb42-4fb5-b9a6-52c9855cc05c)
![image](https://github.com/user-attachments/assets/c279311a-6420-4031-a767-259ae68f2ceb)
![image](https://github.com/user-attachments/assets/6bacd4c7-03d0-4184-b0ff-6fe5f3f8f396)
![image](https://github.com/user-attachments/assets/2d1fbfea-e123-4be0-8e6a-b610ced4c77f)
![image](https://github.com/user-attachments/assets/b9378173-d4d9-4b6f-9d77-6fac3d608ed3)
![image](https://github.com/user-attachments/assets/f4d10df5-0c2a-4348-a927-a0e3746ba51f)
