### PR TITLE
Rate limit requests

### DIFF
--- a/proxy/proxy.conf.template
+++ b/proxy/proxy.conf.template
@@ -11,6 +11,11 @@ proxy_cache_path /var/cache/nginx/
                  use_temp_path=off
                  keys_zone=cache:50m;
 
+map $http_referer $cache_index {
+  ~^http://localhost 0s;
+  default 1h;
+}
+
 map $http_referer $cache_style {
   ~^http://localhost 0s;
   default 1h;
@@ -151,14 +156,17 @@ server {
 
   location = / {
     root /etc/nginx/public;
+    expires $cache_index;
   }
 
   location = /index.html {
     root /etc/nginx/public;
+    expires $cache_index;
   }
 
   location = /manifest.json {
     root /etc/nginx/public;
+    expires $cache_index;
   }
 
   location = /favicon.ico {

--- a/proxy/proxy.conf.template
+++ b/proxy/proxy.conf.template
@@ -1,5 +1,10 @@
 resolver ${NGINX_RESOLVER};
 
+limit_req_zone
+  $binary_remote_addr
+  zone=ip_limit:10m
+  rate=10r/s;
+
 proxy_cache_path /var/cache/nginx/
                  levels=1:2
                  max_size=10g
@@ -139,6 +144,10 @@ map $request_uri $tiles_upstream {
 server {
   listen 8000 default_server;
   server_name localhost;
+
+  limit_req zone=ip_limit burst=50;
+  limit_req_status 429;
+  limit_req_log_level warn;
 
   location = / {
     root /etc/nginx/public;


### PR DESCRIPTION
Limit: 10 req/sec per IP, with a burst of 50.

This should allow normal loading of the map, including quite some tiles.

Fixes https://github.com/hiddewie/OpenRailwayMap-vector/issues/323

Docs in https://nginx.org/en/docs/http/ngx_http_limit_req_module.html