### PR TITLE
Improve import speed for stations

### DIFF
--- a/api/openrailwaymap_api/facility_api.py
+++ b/api/openrailwaymap_api/facility_api.py
@@ -8,15 +8,18 @@ class FacilityAPI:
         self.database = database
 
     def eliminate_duplicates(self, data, limit):
-        data.sort(key=lambda k: k['osm_ids'])
-        i = 1
-        while i < len(data):
-            if data[i]['osm_ids'] == data[i - 1]['osm_ids']:
-                data.pop(i)
-            i += 1
-        if len(data) > limit:
-            return data[:limit]
-        return data
+        seen_osm_ids = set()
+        results = []
+        for item in data:
+            osm_ids = tuple(item['osm_ids'])
+            if osm_ids not in seen_osm_ids:
+                seen_osm_ids.add(osm_ids)
+                results.append(item)
+
+                if len(results) == limit:
+                    break
+
+        return results
 
     async def __call__(self, *, q, name, ref, uic_ref, limit):
         # Validate search arguments

--- a/api/test/api.hurl
+++ b/api/test/api.hurl
@@ -192,10 +192,10 @@ jsonpath "$[0].name" == "Landsberger Allee/Petersburger Straße"
 jsonpath "$[0].railway" == "tram_stop"
 jsonpath "$[0].rank" == 32
 jsonpath "$[0].osm_ids" count == 4
-jsonpath "$[0].osm_ids[0]" == 1787945074
+jsonpath "$[0].osm_ids[0]" == 244129991
 jsonpath "$[0].osm_ids[1]" == 271777826
-jsonpath "$[0].osm_ids[2]" == 244129991
-jsonpath "$[0].osm_ids[3]" == 1679221136
+jsonpath "$[0].osm_ids[2]" == 1679221136
+jsonpath "$[0].osm_ids[3]" == 1787945074
 jsonpath "$[2].railway_ref" == "BLST"
 jsonpath "$[2].station" == "light_rail"
 jsonpath "$[2].uic_ref" == "8089020"

--- a/api/test/api.hurl
+++ b/api/test/api.hurl
@@ -192,9 +192,9 @@ jsonpath "$[0].name" == "Landsberger Allee/Petersburger Straße"
 jsonpath "$[0].railway" == "tram_stop"
 jsonpath "$[0].rank" == 32
 jsonpath "$[0].osm_ids" count == 4
-jsonpath "$[0].osm_ids[0]" == 271777826
-jsonpath "$[0].osm_ids[1]" == 244129991
-jsonpath "$[0].osm_ids[2]" == 1787945074
+jsonpath "$[0].osm_ids[0]" == 1787945074
+jsonpath "$[0].osm_ids[1]" == 271777826
+jsonpath "$[0].osm_ids[2]" == 244129991
 jsonpath "$[0].osm_ids[3]" == 1679221136
 jsonpath "$[2].railway_ref" == "BLST"
 jsonpath "$[2].station" == "light_rail"

--- a/import/sql/get_station_importance.sql
+++ b/import/sql/get_station_importance.sql
@@ -134,18 +134,18 @@ CREATE INDEX IF NOT EXISTS stations_with_route_count_idx
 CREATE MATERIALIZED VIEW IF NOT EXISTS grouped_stations_with_route_count AS
   SELECT
     -- Aggregated station columns
-    array_agg(station_id) as station_ids,
+    array_agg(station_id ORDER BY station_id) as station_ids,
     hstore(string_agg(nullif(name_tags::text, ''), ',')) as name_tags,
-    array_agg(osm_id ORDER by osm_id) as osm_ids,
-    array_remove(array_agg(DISTINCT s.operator), null) as operator,
-    array_remove(array_agg(DISTINCT s.network), null) as network,
-    array_remove(array_agg(DISTINCT s.wikidata), null) as wikidata,
-    array_remove(array_agg(DISTINCT s.wikimedia_commons), null) as wikimedia_commons,
-    array_remove(array_agg(DISTINCT s.wikipedia), null) as wikipedia,
-    array_remove(array_agg(DISTINCT s.image), null) as image,
-    array_remove(array_agg(DISTINCT s.mapillary), null) as mapillary,
-    array_remove(array_agg(DISTINCT s.note), null) as note,
-    array_remove(array_agg(DISTINCT s.description), null) as description,
+    array_agg(osm_id ORDER BY osm_id) as osm_ids,
+    array_remove(array_agg(DISTINCT s.operator ORDER BY s.operator), null) as operator,
+    array_remove(array_agg(DISTINCT s.network ORDER BY s.network), null) as network,
+    array_remove(array_agg(DISTINCT s.wikidata ORDER BY s.wikidata), null) as wikidata,
+    array_remove(array_agg(DISTINCT s.wikimedia_commons ORDER BY s.wikimedia_commons), null) as wikimedia_commons,
+    array_remove(array_agg(DISTINCT s.wikipedia ORDER BY s.wikipedia), null) as wikipedia,
+    array_remove(array_agg(DISTINCT s.image ORDER BY s.image), null) as image,
+    array_remove(array_agg(DISTINCT s.mapillary ORDER BY s.mapillary), null) as mapillary,
+    array_remove(array_agg(DISTINCT s.note ORDER BY s.note), null) as note,
+    array_remove(array_agg(DISTINCT s.description ORDER BY s.description), null) as description,
     -- Aggregated route count columns
     max(sr.route_count) as route_count,
     -- Re-grouped clustered stations columns

--- a/import/sql/get_station_importance.sql
+++ b/import/sql/get_station_importance.sql
@@ -136,7 +136,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS grouped_stations_with_route_count AS
     -- Aggregated station columns
     array_agg(station_id) as station_ids,
     hstore(string_agg(nullif(name_tags::text, ''), ',')) as name_tags,
-    array_agg(osm_id) as osm_ids,
+    array_agg(osm_id ORDER by osm_id) as osm_ids,
     array_remove(array_agg(DISTINCT s.operator), null) as operator,
     array_remove(array_agg(DISTINCT s.network), null) as network,
     array_remove(array_agg(DISTINCT s.wikidata), null) as wikidata,

--- a/import/sql/get_station_importance.sql
+++ b/import/sql/get_station_importance.sql
@@ -92,7 +92,7 @@ CREATE INDEX IF NOT EXISTS stations_clustered_station_ids
   ON stations_clustered
     USING gin(station_ids);
 
-CREATE OR REPLACE VIEW stations_with_route_count AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS stations_with_route_count AS
   SELECT
     id,
     max(route_count) as route_count
@@ -124,6 +124,10 @@ CREATE OR REPLACE VIEW stations_with_route_count AS
   ) all_stations_with_route_count
   GROUP BY id;
 
+CREATE INDEX IF NOT EXISTS stations_with_route_count_idx
+  ON stations_with_route_count
+    USING btree(id);
+
 -- Final table with station nodes and the number of route relations
 -- needs about 3 to 4 minutes for whole Germany
 -- or about 20 to 30 minutes for the whole planet
@@ -133,15 +137,15 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS grouped_stations_with_route_count AS
     array_agg(station_id) as station_ids,
     hstore(string_agg(nullif(name_tags::text, ''), ',')) as name_tags,
     array_agg(osm_id) as osm_ids,
-    array_remove(array_agg(s.operator), null) as operator,
-    array_remove(array_agg(s.network), null) as network,
-    array_remove(array_agg(s.wikidata), null) as wikidata,
-    array_remove(array_agg(s.wikimedia_commons), null) as wikimedia_commons,
-    array_remove(array_agg(s.wikipedia), null) as wikipedia,
-    array_remove(array_agg(s.image), null) as image,
-    array_remove(array_agg(s.mapillary), null) as mapillary,
-    array_remove(array_agg(s.note), null) as note,
-    array_remove(array_agg(s.description), null) as description,
+    array_remove(array_agg(DISTINCT s.operator), null) as operator,
+    array_remove(array_agg(DISTINCT s.network), null) as network,
+    array_remove(array_agg(DISTINCT s.wikidata), null) as wikidata,
+    array_remove(array_agg(DISTINCT s.wikimedia_commons), null) as wikimedia_commons,
+    array_remove(array_agg(DISTINCT s.wikipedia), null) as wikipedia,
+    array_remove(array_agg(DISTINCT s.image), null) as image,
+    array_remove(array_agg(DISTINCT s.mapillary), null) as mapillary,
+    array_remove(array_agg(DISTINCT s.note), null) as note,
+    array_remove(array_agg(DISTINCT s.description), null) as description,
     -- Aggregated route count columns
     max(sr.route_count) as route_count,
     -- Re-grouped clustered stations columns


### PR DESCRIPTION
Changes:
- make `stations_with_route_count` a materialized view
- index the view by `id` for more efficient joining during building of `grouped_stations_with_route_count`
- add only distinct values in the aggregated station fields.

I thought this would not be needed: let Postgres use a full table scan with join in a temporary table to build `grouped_stations_with_route_count`, and then query the unnested `stations_clustered` for each station ID (that view is also materialized and indexed). But it does make a difference to have both views materialized and indexed.

Query plan for `CREATE MATERIALIZED VIEW IF NOT EXISTS grouped_stations_with_route_count` (Europe):
```
GroupAggregate  (cost=33344.86..59354.47 rows=105530 width=628) (actual time=160.622..2050.760 rows=105530 loops=1)
  Group Key: sc.id
  ->  Gather Merge  (cost=33344.86..45635.57 rows=105530 width=1042) (actual time=160.473..209.712 rows=126581 loops=1)
        Workers Planned: 2
        Workers Launched: 2
        ->  Sort  (cost=32344.84..32454.76 rows=43971 width=1042) (actual time=135.565..155.752 rows=42194 loops=3)
              Sort Key: sc.id, s.operator
              Sort Method: external merge  Disk: 33504kB
              Worker 0:  Sort Method: external merge  Disk: 31048kB
              Worker 1:  Sort Method: external merge  Disk: 31056kB
              ->  Hash Join  (cost=8220.40..20033.49 rows=43971 width=1042) (actual time=37.797..89.853 rows=42194 loops=3)
                    Hash Cond: ((unnest(sc.station_ids)) = sr.id)
                    ->  Parallel Hash Join  (cost=4668.33..15876.81 rows=43971 width=1038) (actual time=15.883..50.841 rows=42194 loops=3)
                          Hash Cond: ((unnest(sc.station_ids)) = s.id)
                          ->  ProjectSet  (cost=0.00..10653.35 rows=43971 width=694) (actual time=0.014..20.566 rows=42194 loops=3)
                                ->  Parallel Seq Scan on stations_clustered sc  (cost=0.00..10103.71 rows=43971 width=683) (actual time=0.007..7.049 rows=35177 loops=3)
                          ->  Parallel Hash  (cost=3737.59..3737.59 rows=74459 width=376) (actual time=15.520..15.521 rows=42194 loops=3)
                                Buckets: 131072  Batches: 1  Memory Usage: 17792kB
                                ->  Parallel Seq Scan on stations s  (cost=0.00..3737.59 rows=74459 width=376) (actual time=0.009..7.616 rows=63290 loops=2)
                    ->  Hash  (cost=1969.81..1969.81 rows=126581 width=12) (actual time=21.433..21.434 rows=126581 loops=3)
                          Buckets: 131072  Batches: 1  Memory Usage: 6464kB
                          ->  Seq Scan on stations_with_route_count sr  (cost=0.00..1969.81 rows=126581 width=12) (actual time=0.024..7.169 rows=126581 loops=3)
Planning Time: 1.292 ms
Execution Time: 2060.931 ms
```