### PR TITLE
Resetting switches with custom icon color

### DIFF
--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -102,6 +102,7 @@ const colors = {
         switch: {
           default: '#003687',
           localOperated: '#005129',
+          resetting: '#414925',
         },
         symbols: 'black',
       },
@@ -182,6 +183,7 @@ const colors = {
         switch: {
           default: '#a7c6fc',
           localOperated: '#85f5bd',
+          resetting: '#bdc2ab',
         },
         symbols: 'white',
       },
@@ -1807,6 +1809,7 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
       paint: {
         'icon-color': ['case',
           ['get', 'local_operated'], colors[theme].styles.standard.switch.localOperated,
+          ['get', 'resetting'], colors[theme].styles.standard.switch.resetting,
           colors[theme].styles.standard.switch.default,
         ],
         'icon-halo-color': ['case',
@@ -1823,6 +1826,7 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
         ],
         'text-color': ['case',
           ['get', 'local_operated'], colors[theme].styles.standard.switch.localOperated,
+          ['get', 'local_operated'], colors[theme].styles.standard.switch.resetting,
           colors[theme].styles.standard.switch.default,
         ],
         'text-halo-color': ['case',


### PR DESCRIPTION
Render Resetting switches with a yellowish color for the icon.

http://localhost:8000//#view=17.61/49.179085/8.644021&style=standard
![image](https://github.com/user-attachments/assets/7e896d97-70eb-42bf-a3d4-e74b4b1c612c)
![image](https://github.com/user-attachments/assets/f1c1f136-3e29-4fdc-81fa-4c1c6108397a)

Also see https://github.com/OpenRailwayMap/OpenRailwayMap/issues/900