### PR TITLE
Fix date missing from historical layers when loading map

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -395,7 +395,6 @@ function hashToObject(hash) {
 
 function determineParametersFromHash(hash) {
   const hashObject = hashToObject(hash);
-  console.info(hashObject);
 
   const style = (hashObject.style && hashObject.style in knownStyles)
     ? hashObject.style
@@ -404,11 +403,6 @@ function determineParametersFromHash(hash) {
   const date = (hashObject.date && !isNaN(parseFloat(hashObject.date)))
     ? parseFloat(hashObject.date)
     : defaultDate;
-
-  console.info({
-    style,
-    date,
-  });
 
   return {
     style,
@@ -647,10 +641,8 @@ const onStyleChange = () => {
   const mapStyle = dateActive
     ? knownStyles[selectedStyle].styles.date
     : knownStyles[selectedStyle].styles.default
-  console.info(selectedStyle,supportsDate, mapStyle,lastSetMapStyle)
 
   if (mapStyle !== lastSetMapStyle) {
-    console.info('setting map style to', mapStyle)
     lastSetMapStyle = mapStyle;
 
     // Change styles


### PR DESCRIPTION
Fixes https://github.com/hiddewie/OpenRailwayMap-vector/issues/350

Problem: during map load, the historical style is configured, before the map is loaded or the date is changes. As such, there is no code that configures the historical style to put the configured date into the style layers.

Solution: if the historical view is active, configure the style to take the date filtering into account.