### PR TITLE
Always provide OpenStreetMap attribution

### DIFF
--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -713,8 +713,6 @@ const trackClassFillColor = ['match', ['get', 'track_class'],
   'gray',
 ];
 
-const attribution = '<a href="https://github.com/hiddewie/OpenRailwayMap-vector" target="_blank">&copy; OpenRailwayMap contributors</a> | <a href="https://www.openstreetmap.org/about" target="_blank">&copy; OpenStreetMap contributors</a>';
-
 const sources = {
   search: {
     type: 'geojson',
@@ -726,49 +724,41 @@ const sources = {
   openrailwaymap_low: {
     type: 'vector',
     url: `${origin}/railway_line_high`,
-    attribution,
     promoteId: 'id',
   },
   standard_railway_text_stations_low: {
     type: 'vector',
     url: `${origin}/standard_railway_text_stations_low`,
-    attribution,
     promoteId: 'id',
   },
   standard_railway_text_stations_med: {
     type: 'vector',
     url: `${origin}/standard_railway_text_stations_med`,
-    attribution,
     promoteId: 'id',
   },
   high: {
     type: 'vector',
     url: `${origin}/high`,
-    attribution,
     promoteId: 'id',
   },
   openrailwaymap_standard: {
     type: 'vector',
     url: `${origin}/standard`,
-    attribution,
     promoteId: 'id',
   },
   openrailwaymap_speed: {
     type: 'vector',
     url: `${origin}/speed`,
-    attribution,
     promoteId: 'id',
   },
   openrailwaymap_signals: {
     type: 'vector',
     url: `${origin}/signals`,
-    attribution,
     promoteId: 'id',
   },
   openrailwaymap_electrification: {
     type: 'vector',
     url: `${origin}/electrification`,
-    attribution,
     promoteId: 'id',
   },
   openhistoricalmap: {

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -607,6 +607,10 @@ const map = new maplibregl.Map({
   maxZoom: globalMaxZoom,
   minPitch: 0,
   maxPitch: 0,
+  attributionControl: {
+    compact: true,
+    customAttribution: '<a href="https://maplibre.org/" target="_blank">MapLibre</a> | <a href="https://github.com/hiddewie/OpenRailwayMap-vector" target="_blank">&copy; OpenRailwayMap contributors</a> | <a href="https://www.openstreetmap.org/about" target="_blank">&copy; OpenStreetMap contributors</a>',
+  },
 });
 
 function selectStyle(style) {


### PR DESCRIPTION
Fixes https://github.com/hiddewie/OpenRailwayMap-vector/issues/351

See default attribution control options in https://github.com/maplibre/maplibre-gl-js/blob/3a1f71f00913bf85d614d9693f5abcdd8f8bae8e/src/ui/control/attribution_control.ts

Problem: when only historical layers are shown, no attribution is provided to .

The background map layers do not provide any attribution to the shown layers / style. Ideally the background map layers would provide attribution to the main map. This is not feasible at the moment with two separate maps (one for the main OpenRailwayMap style and one for the background map style).

Solution: always provide attribution to OpenStreetMap, MapLibre and OpenRailwayMap.

Attribution to OpenHistoricalMap is added automatically when historical layers are shown.

![image](https://github.com/user-attachments/assets/3c47048a-1dfc-46f9-b9a6-7114fed81bef)
![image](https://github.com/user-attachments/assets/c76b8aca-8166-4ab0-9da8-00dc8e625109)
