### PR TITLE
Set replication timestamp in tile metadata

### DIFF
--- a/.github/workflows/deploy-tiles.yml
+++ b/.github/workflows/deploy-tiles.yml
@@ -65,10 +65,26 @@ jobs:
           docker compose pull db
           docker compose up --no-build --pull never --wait db
 
+      - name: Determine replication timestamp
+        id: replication-timestamp
+        continue-on-error: true
+        run: |
+          {
+            echo -n 'timestamp='
+            docker compose exec db \
+              psql \
+                --dbname gis \
+                --user postgres \
+                --pset format=csv \
+                --pset tuples_only=on \
+                --command "select \"value\" from osm2pgsql_properties where property='replication_timestamp'"
+          } >> $GITHUB_OUTPUT
+
       - name: Generate tiles
         env:
           TILES: high
           BBOX: ${{ matrix.bbox }}
+          REPLICATION_TIMESTAMP: ${{ steps.replication-timestamp.outputs.timestamp }}
         run: |
           docker compose run --no-deps martin-cp
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,10 +56,26 @@ jobs:
           docker compose pull db
           docker compose up --no-build --pull never --wait db
 
+      - name: Determine replication timestamp
+        id: replication-timestamp
+        continue-on-error: true
+        run: |
+          {
+            echo -n 'timestamp='
+            docker compose exec db \
+              psql \
+                --dbname gis \
+                --user postgres \
+                --pset format=csv \
+                --pset tuples_only=on \
+                --command "select \"value\" from osm2pgsql_properties where property='replication_timestamp'"
+          } >> $GITHUB_OUTPUT
+
       - name: Generate tiles
         env:
           TILES: low-med
           BBOX: -180,-80,180,80
+          REPLICATION_TIMESTAMP: ${{ steps.replication-timestamp.outputs.timestamp }}
         run: |
           docker compose run --no-deps martin-cp
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
       - MIN_ZOOM=0
       - MAX_ZOOM=14
       - DATABASE_URL=postgresql://postgres@db:5432/gis
+      - REPLICATION_TIMESTAMP
 
   martin:
     build:

--- a/tiles/tiles.sh
+++ b/tiles/tiles.sh
@@ -13,7 +13,7 @@
 set -e
 
 OUTPUT_DIR="/tiles"
-echo "Exporting tiles for bounding box $BBOX into output directory $OUTPUT_DIR"
+echo "Exporting tiles for bounding box $BBOX into output directory $OUTPUT_DIR. Replication timestamp: ${REPLICATION_TIMESTAMP:-unknown}."
 
 export MARTIN="martin-cp --config /config/configuration.yml --mbtiles-type flat --on-duplicate abort --skip-agg-tiles-hash --bbox=$BBOX"
 
@@ -24,46 +24,54 @@ if [[ "${TILES}" != 'high' ]]; then
 
   rm -f "$OUTPUT_DIR/railway_line_high.mbtiles"
   $MARTIN --min-zoom 0 --max-zoom 7 --source railway_line_high --output-file "$OUTPUT_DIR/railway_line_high.mbtiles"
+  mbtiles meta-set "$OUTPUT_DIR/railway_line_high.mbtiles" replication_timestamp "$REPLICATION_TIMESTAMP"
   mbtiles summary "$OUTPUT_DIR/railway_line_high.mbtiles"
 
   rm -f "$OUTPUT_DIR/standard_railway_text_stations_low.mbtiles"
   $MARTIN --min-zoom 0 --max-zoom 6 --source standard_railway_text_stations_low --output-file "$OUTPUT_DIR/standard_railway_text_stations_low.mbtiles"
+  mbtiles meta-set "$OUTPUT_DIR/standard_railway_text_stations_low.mbtiles" replication_timestamp "$REPLICATION_TIMESTAMP"
   mbtiles summary "$OUTPUT_DIR/standard_railway_text_stations_low.mbtiles"
 
   rm -f "$OUTPUT_DIR/standard_railway_text_stations_med.mbtiles"
   $MARTIN --min-zoom 7 --max-zoom 7 --source standard_railway_text_stations_med --output-file "$OUTPUT_DIR/standard_railway_text_stations_med.mbtiles"
+  mbtiles meta-set "$OUTPUT_DIR/standard_railway_text_stations_med.mbtiles" replication_timestamp "$REPLICATION_TIMESTAMP"
   mbtiles summary "$OUTPUT_DIR/standard_railway_text_stations_med.mbtiles"
 fi
 
 if [[ "${TILES}" != 'low-med' ]]; then
   echo "Tiles: high"
 
-  rm -f /tiles/high.mbtiles
-  $MARTIN --min-zoom 8 --max-zoom "$MAX_ZOOM" --source railway_line_high,railway_text_km --output-file /tiles/high.mbtiles
-  mbtiles summary /tiles/high.mbtiles
+  rm -f "$OUTPUT_DIR/high.mbtiles"
+  $MARTIN --min-zoom 8 --max-zoom "$MAX_ZOOM" --source railway_line_high,railway_text_km --output-file "$OUTPUT_DIR/high.mbtiles"
+  mbtiles meta-set "$OUTPUT_DIR/high.mbtiles" replication_timestamp "$REPLICATION_TIMESTAMP"
+  mbtiles summary "$OUTPUT_DIR/high.mbtiles"
 
   echo "Tiles: standard"
 
   rm -f "$OUTPUT_DIR/standard.mbtiles"
   $MARTIN --min-zoom 8 --max-zoom "$MAX_ZOOM" --source standard_railway_turntables,standard_railway_text_stations,standard_railway_grouped_stations,standard_railway_symbols,standard_railway_switch_ref --output-file "$OUTPUT_DIR/standard.mbtiles"
+  mbtiles meta-set "$OUTPUT_DIR/standard.mbtiles" replication_timestamp "$REPLICATION_TIMESTAMP"
   mbtiles summary "$OUTPUT_DIR/standard.mbtiles"
 
   echo "Tiles: speed"
 
   rm -f "$OUTPUT_DIR/speed.mbtiles"
   $MARTIN --min-zoom 8 --max-zoom "$MAX_ZOOM" --source speed_railway_signals --output-file "$OUTPUT_DIR/speed.mbtiles"
+  mbtiles meta-set "$OUTPUT_DIR/speed.mbtiles" replication_timestamp "$REPLICATION_TIMESTAMP"
   mbtiles summary "$OUTPUT_DIR/speed.mbtiles"
 
   echo "Tiles: signals"
 
   rm -f "$OUTPUT_DIR/signals.mbtiles"
   $MARTIN --min-zoom 8 --max-zoom "$MAX_ZOOM" --source signals_railway_signals,signals_signal_boxes --output-file "$OUTPUT_DIR/signals.mbtiles"
+  mbtiles meta-set "$OUTPUT_DIR/signals.mbtiles" replication_timestamp "$REPLICATION_TIMESTAMP"
   mbtiles summary "$OUTPUT_DIR/signals.mbtiles"
 
   echo "Tiles: electrification"
 
   rm -f "$OUTPUT_DIR/electrification.mbtiles"
   $MARTIN --min-zoom 8 --max-zoom "$MAX_ZOOM" --source electrification_signals --output-file "$OUTPUT_DIR/electrification.mbtiles"
+  mbtiles meta-set "$OUTPUT_DIR/electrification.mbtiles" replication_timestamp "$REPLICATION_TIMESTAMP"
   mbtiles summary "$OUTPUT_DIR/electrification.mbtiles"
 fi
 


### PR DESCRIPTION
From https://github.com/hiddewie/OpenRailwayMap-vector/issues/260#issuecomment-2713286861

The comment indicates that showing the freshness of the OSM data on OpenRailwayMap is useful.

The replication timestamp is stored in the Osmium metadata during download. of the OSM data. The Osmium metadata is imported into the properties table of Osm2psql. 

During tile generation the replication timestamp can be extracted and stored in the tile metadata.

Merging and conversion to PMTiles should keep tile metadata intact.

Then, it has to be shown in the UI.