### PR TITLE
Show replication timestamp in the UI

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -1219,7 +1219,7 @@ fetch(`${origin}/high`)
       const timestamp = new Date(source.replication_timestamp)
       const timespan = new Date().getTime() - timestamp.getTime();
 
-      attributionOptions.customAttribution = `${attributionOptions.customAttribution} &mdash; data updated ${formatTimespan(timespan)} ago`
+      attributionOptions.customAttribution = `${attributionOptions.customAttribution} &mdash; data updated <abbr title="${timestamp}">${formatTimespan(timespan)} ago</abbr>`
 
       // Forcefully update the control, even if the map does not fire events.
       attributionControl._updateAttributions();

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -673,13 +673,13 @@ const onStyleChange = () => {
             layers: next.layers.map(layer =>
               layerHasDateFilter(layer)
                 ? {
-                  ...layer,
-                  filter: ['let', 'date', selectedDate, ...layer.filter.slice(3)],
-                }
+                    ...layer,
+                    filter: ['let', 'date', selectedDate, ...layer.filter.slice(3)],
+                  }
                 : layer,
             )
           })
-          : undefined,
+        : undefined,
     });
 
     legendMap.setStyle(legendStyles[selectedTheme][mapStyle], {


### PR DESCRIPTION
Part of #260

On page load, the data source is queried for the replication timestamp. If it exists in the metadata, it shows the relative timestamp in the information balloon next to the data attribution.

Hover shows the full timestamp when the data was updated.

![image](https://github.com/user-attachments/assets/46f0ea23-4c85-4091-bb66-9e63892cacdf)

![image](https://github.com/user-attachments/assets/5db819b7-423c-4204-9cbb-cae9ffd3f34b)

