### PR TITLE
Fix missing imported signal tags

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -13,6 +13,7 @@ tags:
   - 'railway:signal:crossing:repeated'
   - 'railway:signal:crossing:shortened'
   - 'railway:signal:crossing_distant'
+  - 'railway:signal:crossing_distant:states'
   - 'railway:signal:crossing_distant:shortened'
   - 'railway:signal:crossing_distant:form'
   - 'railway:signal:crossing_hint'
@@ -79,6 +80,9 @@ tags:
   - 'railway:signal:route:design'
   - 'railway:signal:route:form'
   - 'railway:signal:route:states'
+  - 'railway:signal:route_distant'
+  - 'railway:signal:route_distant:form'
+  - 'railway:signal:route_distant:states'
   - 'railway:signal:short_route'
   - 'railway:signal:short_route:form'
   - 'railway:signal:shunting'
@@ -119,7 +123,6 @@ tags:
   - 'railway:vacancy_detection'
   - 'railway:signal:position'
 
-# Define an ordering for determining importance of signal types
 types:
   - { type: main }
   - { type: combined }
@@ -129,6 +132,7 @@ types:
   - { type: speed_limit, layer: speed }
   - { type: speed_limit_distant, layer: speed }
   - { type: minor }
+  - { type: minor_distant }
   - { type: passing }
   - { type: shunting }
   - { type: radio }
@@ -150,8 +154,12 @@ types:
   - { type: wrong_road }
   - { type: short_route }
   - { type: route }
+  - { type: route_distant }
   - { type: brake_test }
   - { type: helper_engine }
+  - { type: steam_locomotive }
+  - { type: fouling_point }
+  - { type: preheating }
 
 features:
 
@@ -1874,13 +1882,13 @@ features:
   - description: Karlsruhe AVG crossing signals
     country: DE
     icon:
-      match: 'railway:signal:distant_crossing:states'
+      match: 'railway:signal:crossing_distant:states'
       cases:
         - { regex: '^(.*;)?DE-AVG:bü201v(;.*)?$', value: 'de/avg/bue201v' }
       default: 'de/avg/bue201'
     tags:
-      - { tag: 'railway:signal:distant_crossing', value: 'DE-AVG:bü201' }
-      - { tag: 'railway:signal:distant_crossing:form', value: 'light' }
+      - { tag: 'railway:signal:crossing_distant', value: 'DE-AVG:bü201' }
+      - { tag: 'railway:signal:crossing_distant:form', value: 'light' }
 
   - description: Karlsruhe AVG Stop Demand
     country: DE


### PR DESCRIPTION
Extracted form https://github.com/hiddewie/OpenRailwayMap-vector/pull/369

Some signal types and tags were missing from the list.