### PR TITLE
Ordering of DE signals

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -1161,6 +1161,454 @@ features:
 
   # --- DE --- #
 
+  - description: shunting stop sign Ra 10
+    country: DE
+    icon: { default: 'de/ra10' }
+    tags:
+      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra10' }
+      - { tag: 'railway:signal:shunting:form', value: 'sign' }
+
+  - description: main signal invalid for shunting trains Zs 103 (sign)
+    country: DE
+    icon: { default: 'de/zs103' }
+    tags:
+      - { tag: 'railway:signal:shunting', value: 'DE-ESO:zs103' }
+      - { tag: 'railway:signal:shunting:form', value: 'sign' }
+
+  - description: shunting signal Ra 11 without Sh 1
+    country: DE
+    icon: { default: 'de/ra11-sign' }
+    tags:
+      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra11' }
+      - { tag: 'railway:signal:shunting:form', value: 'sign' }
+
+  - description: shunting signal Ra 11 with Sh 1
+    country: DE
+    icon: { default: 'de/ra11-sh1' }
+    tags:
+      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra11' }
+      - { tag: 'railway:signal:shunting:form', value: 'light' }
+
+  - description: shunting signal Ra 11b (without Sh 1)
+    country: DE
+    icon: { default: 'de/ra11b' }
+    tags:
+      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra11b' }
+      - { tag: 'railway:signal:shunting:form', value: 'sign' }
+
+  - description: tram minor stop sign Sh 1
+    country: DE
+    icon: { default: 'de/bostrab/sh1' }
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-BOStrab:sh1' }
+      - { tag: 'railway:signal:minor:form', value: 'sign' }
+
+  - description: minor light signals type Sh
+    country: DE
+    icon:
+      match: 'railway:signal:minor:height'
+      cases:
+        - { regex: '^normal$', value: 'de/sh1-light-normal', description: 'normal height' }
+      default: 'de/sh0-light-dwarf'
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh' }
+      - { tag: 'railway:signal:minor:form', value: 'light' }
+
+  - description: minor light signals type Sh attached to main signals
+    country: DE
+    icon:
+      default: 'de/sh1-light-dwarf'
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh1' }
+      - { tag: 'railway:signal:minor:form', value: 'light' }
+
+  - description: minor semaphore signals type Sh with wn7
+    country: DE
+    icon: { default: 'de/wn7-semaphore-normal' }
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh' }
+      - { tag: 'railway:signal:minor:form', value: 'semaphore' }
+      - { tag: 'railway:signal:minor:states', value: 'DE-ESO:sh0;DE-ESO:wn7' }
+
+  - description: minor semaphore signals type Sh
+    country: DE
+    icon:
+      match: 'railway:signal:minor:height'
+      cases:
+        - { regex: '^normal$', value: 'de/sh1-semaphore-normal' }
+      default: 'de/sh0-semaphore-dwarf'
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh' }
+      - { tag: 'railway:signal:minor:form', value: 'semaphore' }
+
+  - description: minor sign signal type Sh
+    country: DE
+    icon: { default: 'de/sh0-sign' }
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh0' }
+      - { tag: 'railway:signal:minor:form', value: 'sign' }
+
+  - description: Sh 2 buffer stop
+    country: DE
+    icon: { default: 'de/sh2' }
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh2' }
+      - { tag: 'railway:signal:minor:form', value: 'sign' }
+
+  - description: tram signal Sh 2
+    country: DE
+    icon: { default: 'de/bostrab/sh2' }
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-BOStrab:sh2' }
+      - { tag: 'railway:signal:minor:form', value: 'sign' }
+
+  - description: tram signal "start of train protection" So 1
+    country: DE
+    icon: { default: 'de/bostrab/so1' }
+    tags:
+      - { tag: 'railway:signal:train_protection', values: ['DE-BOStrab:so1', 'DE-AVG:so1'] }
+      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
+      - { tag: 'railway:signal:train_protection:type', value: 'start' }
+
+  - description: tram signal "end of train protection" So 2
+    country: DE
+    icon: { default: 'de/bostrab/so2' }
+    tags:
+      - { tag: 'railway:signal:train_protection', values: ['DE-BOStrab:so2', 'DE-AVG:so2'] }
+      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
+      - { tag: 'railway:signal:train_protection:type', value: 'end' }
+
+  - description: ETCS block marker Ne 14
+    country: DE
+    icon:
+      match: 'railway:signal:position'
+      cases:
+        - { regex: '^left$', value: 'de/ne14-right' }
+        - { regex: '^overhead$', value: 'de/ne14-down' }
+      default: 'de/ne14-left'
+    tags:
+      - { tag: 'railway:signal:train_protection', value: 'DE-ESO:ne14' }
+      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
+      - { tag: 'railway:signal:train_protection:type', value: 'block_marker' }
+
+  - description: LZB section start
+    country: DE
+    icon: { default: 'de/lzb-section-start' }
+    tags:
+      - { tag: 'railway:signal:train_protection', value: 'DE-ESO:lzb-bereichskennzeichen' }
+      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
+
+  - description: Blockkennzeichen
+    country: DE
+    icon:
+      match: 'ref_multiline'
+      cases:
+        - { regex: '^([^\n]{4}\n[^\n]{1,4})|([^\n]{1,4}\n[^\n]{4})$', value: 'de/blockkennzeichen-4x2' }
+        - { regex: '^[^\n]{4}$', value: 'de/blockkennzeichen-4x1' }
+        - { regex: '^([^\n]{3}\n[^\n]{1,3})|([^\n]{1,3}\n[^\n]{3})$', value: 'de/blockkennzeichen-3x2' }
+        - { regex: '^[^\n]{3}$', value: 'de/blockkennzeichen-3x1' }
+        - { regex: '^([^\n]{2}\n[^\n]{1,2})|([^\n]{1,2}\n[^\n]{2})$', value: 'de/blockkennzeichen-2x2' }
+        - { regex: '^[^\n]{2}$', value: 'de/blockkennzeichen-2x1' }
+        - { regex: '^[^\n]\n[^\n]$', value: 'de/blockkennzeichen-1x2' }
+        - { regex: '^[^\n]$', value: 'de/blockkennzeichen-1x1' }
+      default: 'de/blockkennzeichen'
+    tags:
+      - { tag: 'railway:signal:train_protection', value: 'DE-ESO:blockkennzeichen' }
+
+  - description: Signalhaltmelder Zugleitbetrieb
+    country: DE
+    icon: { default: 'de/zlb-haltmelder-light' }
+    tags:
+      - { tag: 'railway:signal:main_repeated', value: 'DE-DB:signalhaltmelder' }
+      - { tag: 'railway:signal:main_repeated:form', value: 'light' }
+
+  - description: Fahrtanzeiger
+    country: DE
+    icon: { default: 'de/fahrtanzeiger' }
+    tags:
+      - { tag: 'railway:signal:main_repeated', value: 'DE-ESO:fahrtanzeiger' }
+      - { tag: 'railway:signal:main_repeated:form', value: 'light' }
+
+  - description: tram passing prohibited sign So 5
+    country: DE
+    icon: { default: 'de/bostrab/so5' }
+    tags:
+      - { tag: 'railway:signal:passing', value: 'DE-BOStrab:so5' }
+      - { tag: 'railway:signal:passing:form', value: 'sign' }
+      - { tag: 'railway:signal:passing:type', value: 'no_passing' }
+
+  - description: tram passing prohibited end sign So 6
+    country: DE
+    icon: { default: 'de/bostrab/so6' }
+    tags:
+      - { tag: 'railway:signal:passing', value: 'DE-BOStrab:so6' }
+      - { tag: 'railway:signal:passing:form', value: 'sign' }
+      - { tag: 'railway:signal:passing:type', value: 'passing_allowed' }
+
+  - description: stop demand post Ne 5 (light)
+    country: DE
+    icon: { default: 'de/ne5-light' }
+    tags:
+      - { tag: 'railway:signal:stop_demand', value: 'DE-ESO:ne5' }
+      - { tag: 'railway:signal:stop_demand:form', value: 'light' }
+
+  - description: stop demand post Ne 5 (sign)
+    country: DE
+    icon: { default: 'de/ne5-sign' }
+    tags:
+      - { tag: 'railway:signal:stop', value: 'DE-ESO:ne5' }
+      - { tag: 'railway:signal:stop:form', value: 'sign' }
+
+  - description: stop demand post BOStrab Sh 7 (sign)
+    country: DE
+    icon: { default: 'de/bostrab/sh7' }
+    tags:
+      - { tag: 'railway:signal:stop', value: 'DE-BOStrab:sh7' }
+      - { tag: 'railway:signal:stop:form', value: 'sign' }
+
+  - description: station distant sign Ne 6
+    country: DE
+    icon: { default: 'de/ne6' }
+    tags:
+      - { tag: 'railway:signal:station_distant', value: 'DE-ESO:ne6' }
+      - { tag: 'railway:signal:station_distant:form', value: 'sign' }
+
+  # TODO support variants of same feature
+  - description: Bü 0/1 (sign, repeated)
+    country: DE
+    icon: { default: 'de/bue0-ds-repeated' }
+    tags:
+      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
+      - { tag: 'railway:signal:crossing:form', value: 'sign' }
+      - { tag: 'railway:signal:crossing:repeated', value: 'yes' }
+
+  - description: Bü 0/1 (sign)
+    country: DE
+    icon:
+      match: 'railway:signal:crossing:shortened'
+      cases:
+        - { regex: '^yes$', value: 'de/bue0-ds-shortened', description: 'shortened' }
+      default: 'de/bue0-ds'
+    tags:
+      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
+      - { tag: 'railway:signal:crossing:form', value: 'sign' }
+
+  - description: Bü 0/1 (light, repeated)
+    country: DE
+    icon: { default: 'de/bue1-ds-repeated' }
+    tags:
+      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
+      - { tag: 'railway:signal:crossing:repeated', value: 'yes' }
+
+  - description: Bü 0/1 (light)
+    country: DE
+    icon:
+      match: 'railway:signal:crossing:shortened'
+      cases:
+        - { regex: '^yes$', value: 'de/bue1-ds-shortened', description: 'shortened' }
+      default: 'de/bue1-ds'
+    tags:
+      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
+
+  - description: So 16a/b (repeated)
+    country: DE
+    icon: { default: 'de/bue1-dv-repeated' }
+    tags:
+      - { tag: 'railway:signal:crossing', value: 'DE-ESO:so16' }
+      - { tag: 'railway:signal:crossing:form', value: 'light' }
+      - { tag: 'railway:signal:crossing:repeated', value: 'yes' }
+
+  - description: So 16a/b
+    country: DE
+    icon:
+      match: 'railway:signal:crossing:shortened'
+      cases:
+        - { regex: '^yes$', value: 'de/bue1-dv-shortened', description: 'shortened' }
+      default: 'de/bue1-dv'
+    tags:
+      - { tag: 'railway:signal:crossing', value: 'DE-ESO:so16' }
+      - { tag: 'railway:signal:crossing:form', value: 'light' }
+
+  - description: crossing distant sign (warning board) So 15 (DV 301)
+    country: DE
+    icon: { default: 'de/so15' }
+    tags:
+      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:so15' }
+      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
+
+  - description: distant crossing So 14
+    country: DE
+    icon: { default: 'de/so14' }
+    tags:
+      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:so14' }
+      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
+
+  - description: crossing distant sign Bü 2
+    country: DE
+    icon:
+      match: 'railway:signal:crossing_distant:shortened'
+      cases:
+        - { regex: '^yes$', value: 'de/bue2-ds-reduced-distance', description: 'reduced distance' }
+      default: 'de/bue2-ds'
+    tags:
+      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:bü2' }
+      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
+
+  - description: crossing distant sign Bü 3
+    country: DE
+    icon: { default: 'de/bue3' }
+    tags:
+      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:bü3' }
+      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
+
+  - description: Bü 4 Whistle Sign
+    country: DE
+    icon:
+      match: 'railway:signal:whistle:only_transit'
+      cases:
+        - { regex: '^yes$', value: 'de/bue4-ds-only-transit', description: 'only transit' }
+      default: 'de/bue4-ds'
+    tags:
+      - { tag: 'railway:signal:whistle', value: 'DE-ESO:db:bü4' }
+      - { tag: 'railway:signal:whistle:form', value: 'sign' }
+
+  - description: whistle sign Pf 1 (DV 301)
+    country: DE
+    icon:
+      match: 'railway:signal:whistle:only_transit'
+      cases:
+        - { regex: '^yes$', value: 'de/pf1-dv-only-transit', description: 'only transit' }
+      default: 'de/pf1-dv'
+    tags:
+      - { tag: 'railway:signal:whistle', value: 'DE-ESO:dr:pf1' }
+      - { tag: 'railway:signal:whistle:form', value: 'sign' }
+
+  - description: whistle twice sign Pf 2 (DV 301)
+    country: DE
+    icon:
+      default: 'de/pf2-dv'
+    tags:
+      - { tag: 'railway:signal:whistle', value: 'DE-ESO:dr:pf2' }
+      - { tag: 'railway:signal:whistle:form', value: 'sign' }
+
+  - description: ring sign Bü 5
+    country: DE
+    icon:
+      match: 'railway:signal:ring:only_transit'
+      cases:
+        - { regex: '^yes$', value: 'de/bue5-only-transit', description: 'only transit' }
+      default: 'de/bue5'
+    tags:
+      - { tag: 'railway:signal:ring', value: 'DE-ESO:bü5' }
+      - { tag: 'railway:signal:ring:form', value: 'sign' }
+
+  - description: Lift / Fold snowplow Ne 7 (sign)
+    country: DE
+    icon:
+      match: 'railway:signal:snowplow:type'
+      cases:
+        - { regex: '^down$', value: 'de/ne7-yellow-down' }
+      default: 'de/ne7-yellow-up'
+    tags:
+      - { tag: 'railway:signal:snowplow', value: 'DE-ESO:ne7' }
+      - { tag: 'railway:signal:snowplow:form', value: 'sign' }
+
+  - description: Ne13 resetting switch signal
+    country: DE
+    icon: { default: 'de/ne13a' }
+    tags:
+      - { tag: 'railway:signal:resetting_switch', value: 'DE-ESO:ne13' }
+      - { tag: 'railway:signal:resetting_switch:form', value: 'light' }
+
+  - description: Ne12 resetting switch distant signal
+    country: DE
+    icon: { default: 'de/ne12' }
+    tags:
+      - { tag: 'railway:signal:resetting_switch_distant', value: 'DE-ESO:ne12' }
+      - { tag: 'railway:signal:resetting_switch_distant:form', value: 'sign' }
+
+  - description: humping signal Ra 6-9
+    country: DE
+    icon: { default: 'de/ra7' }
+    tags:
+      - { tag: 'railway:signal:humping', value: 'DE-ESO:ra' }
+      - { tag: 'railway:signal:humping:form', value: 'light' }
+
+  - description: tram läuten Sh 4
+    country: DE
+    icon: { default: 'de/bostrab/sh4' }
+    tags:
+      - { tag: 'railway:signal:ring', value: 'DE-BOStrab:sh4' }
+      - { tag: 'railway:signal:ring:form', value: 'sign' }
+
+  - description: helper engine signal Ts
+    country: DE
+    icon: { default: 'de/ts1' }
+    tags:
+      - { tag: 'railway:signal:helper_engine', value: 'DE-ESO:ts' }
+      - { tag: 'railway:signal:helper_engine:form', value: 'sign' }
+
+  - description: brake test signal Zp 6-8
+    country: DE
+    icon: { default: 'de/zp8' }
+    tags:
+      - { tag: 'railway:signal:brake_test', value: 'DE-ESO:zp' }
+      - { tag: 'railway:signal:brake_test:form', value: 'light' }
+
+  - description: Zp 9 (departure order) or Zp 10 (close doors)
+    country: DE
+    icon:
+      match: 'railway:signal:departure:states'
+      cases:
+        - { regex: '^DE-ESO:zp10$', value: 'de/zp10-db' }
+      default: 'de/zp9-db'
+    tags:
+      - { tag: 'railway:signal:departure', value: 'DE-ESO:zp' }
+      - { tag: 'railway:signal:departure:form', value: 'light' }
+
+  - description: tram departure signals
+    country: DE
+    icon:
+      match: 'railway:signal:departure:states'
+      cases:
+        - { regex: '^(.*;)?DE-BOStrab:a2(;.*)?$', value: 'de/bostrab/a2' }
+      default: 'de/bostrab/a1'
+    tags:
+      - { tag: 'railway:signal:departure', values: ['DE-BOStrab:a', 'DE-BOStrab:a1', 'DE-BOStrab:a2' ] }
+      - { tag: 'railway:signal:departure:form', value: 'light' }
+
+  - description: crossing info sign
+    country: DE
+    icon: { default: 'de/bue-crossing-info' }
+    tags:
+      - { tag: 'railway:signal:crossing_info', value: 'DE-ESO:bü-kennzeichentafel' }
+      - { tag: 'railway:signal:crossing_info:form', value: 'sign' }
+
+  - description: crossing anouncement sign
+    country: DE
+    icon: { default: 'de/bue-crossing-hint' }
+    tags:
+      - { tag: 'railway:signal:crossing_hint', value: 'DE-ESO:bü-ankündetafel' }
+      - { tag: 'railway:signal:crossing_hint:form', value: 'sign' }
+
+  - description: Karlsruhe AVG crossing signals
+    country: DE
+    icon:
+      match: 'railway:signal:crossing_distant:states'
+      cases:
+        - { regex: '^(.*;)?DE-AVG:bü201v(;.*)?$', value: 'de/avg/bue201v' }
+      default: 'de/avg/bue201'
+    tags:
+      - { tag: 'railway:signal:crossing_distant', value: 'DE-AVG:bü201' }
+      - { tag: 'railway:signal:crossing_distant:form', value: 'light' }
+
+  - description: Karlsruhe AVG Stop Demand
+    country: DE
+    icon: { default: 'de/avg/hw1' }
+    tags:
+      - { tag: 'railway:signal:stop_demand', value: 'DE-AVG:hw1' }
+      - { tag: 'railway:signal:stop_demand:form', value: 'light' }
+
   - description: wrong road signal Zs 6 (DB) (sign)
     country: DE
     icon: { default: 'de/zs6-sign' }
@@ -1713,454 +2161,6 @@ features:
     tags:
       - { tag: 'railway:signal:combined', value: 'DE-ESO:ks' }
       - { tag: 'railway:signal:combined:form', value: 'light' }
-
-  - description: tram signal "start of train protection" So 1
-    country: DE
-    icon: { default: 'de/bostrab/so1' }
-    tags:
-      - { tag: 'railway:signal:train_protection', values: ['DE-BOStrab:so1', 'DE-AVG:so1'] }
-      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
-      - { tag: 'railway:signal:train_protection:type', value: 'start' }
-
-  - description: tram signal "end of train protection" So 2
-    country: DE
-    icon: { default: 'de/bostrab/so2' }
-    tags:
-      - { tag: 'railway:signal:train_protection', values: ['DE-BOStrab:so2', 'DE-AVG:so2'] }
-      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
-      - { tag: 'railway:signal:train_protection:type', value: 'end' }
-
-  - description: ETCS block marker Ne 14
-    country: DE
-    icon:
-      match: 'railway:signal:position'
-      cases:
-        - { regex: '^left$', value: 'de/ne14-right' }
-        - { regex: '^overhead$', value: 'de/ne14-down' }
-      default: 'de/ne14-left'
-    tags:
-      - { tag: 'railway:signal:train_protection', value: 'DE-ESO:ne14' }
-      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
-      - { tag: 'railway:signal:train_protection:type', value: 'block_marker' }
-
-  - description: LZB section start
-    country: DE
-    icon: { default: 'de/lzb-section-start' }
-    tags:
-      - { tag: 'railway:signal:train_protection', value: 'DE-ESO:lzb-bereichskennzeichen' }
-      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
-
-  - description: Blockkennzeichen
-    country: DE
-    icon:
-      match: 'ref_multiline'
-      cases:
-        - { regex: '^([^\n]{4}\n[^\n]{1,4})|([^\n]{1,4}\n[^\n]{4})$', value: 'de/blockkennzeichen-4x2' }
-        - { regex: '^[^\n]{4}$', value: 'de/blockkennzeichen-4x1' }
-        - { regex: '^([^\n]{3}\n[^\n]{1,3})|([^\n]{1,3}\n[^\n]{3})$', value: 'de/blockkennzeichen-3x2' }
-        - { regex: '^[^\n]{3}$', value: 'de/blockkennzeichen-3x1' }
-        - { regex: '^([^\n]{2}\n[^\n]{1,2})|([^\n]{1,2}\n[^\n]{2})$', value: 'de/blockkennzeichen-2x2' }
-        - { regex: '^[^\n]{2}$', value: 'de/blockkennzeichen-2x1' }
-        - { regex: '^[^\n]\n[^\n]$', value: 'de/blockkennzeichen-1x2' }
-        - { regex: '^[^\n]$', value: 'de/blockkennzeichen-1x1' }
-      default: 'de/blockkennzeichen'
-    tags:
-      - { tag: 'railway:signal:train_protection', value: 'DE-ESO:blockkennzeichen' }
-
-  - description: Signalhaltmelder Zugleitbetrieb
-    country: DE
-    icon: { default: 'de/zlb-haltmelder-light' }
-    tags:
-      - { tag: 'railway:signal:main_repeated', value: 'DE-DB:signalhaltmelder' }
-      - { tag: 'railway:signal:main_repeated:form', value: 'light' }
-
-  - description: Fahrtanzeiger
-    country: DE
-    icon: { default: 'de/fahrtanzeiger' }
-    tags:
-      - { tag: 'railway:signal:main_repeated', value: 'DE-ESO:fahrtanzeiger' }
-      - { tag: 'railway:signal:main_repeated:form', value: 'light' }
-
-  - description: tram minor stop sign Sh 1
-    country: DE
-    icon: { default: 'de/bostrab/sh1' }
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-BOStrab:sh1' }
-      - { tag: 'railway:signal:minor:form', value: 'sign' }
-
-  - description: minor light signals type Sh
-    country: DE
-    icon:
-      match: 'railway:signal:minor:height'
-      cases:
-        - { regex: '^normal$', value: 'de/sh1-light-normal', description: 'normal height' }
-      default: 'de/sh0-light-dwarf'
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh' }
-      - { tag: 'railway:signal:minor:form', value: 'light' }
-
-  - description: minor light signals type Sh attached to main signals
-    country: DE
-    icon:
-      default: 'de/sh1-light-dwarf'
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh1' }
-      - { tag: 'railway:signal:minor:form', value: 'light' }
-
-  - description: minor semaphore signals type Sh with wn7
-    country: DE
-    icon: { default: 'de/wn7-semaphore-normal' }
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh' }
-      - { tag: 'railway:signal:minor:form', value: 'semaphore' }
-      - { tag: 'railway:signal:minor:states', value: 'DE-ESO:sh0;DE-ESO:wn7' }
-
-  - description: minor semaphore signals type Sh
-    country: DE
-    icon:
-      match: 'railway:signal:minor:height'
-      cases:
-        - { regex: '^normal$', value: 'de/sh1-semaphore-normal' }
-      default: 'de/sh0-semaphore-dwarf'
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh' }
-      - { tag: 'railway:signal:minor:form', value: 'semaphore' }
-
-  - description: minor sign signal type Sh
-    country: DE
-    icon: { default: 'de/sh0-sign' }
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh0' }
-      - { tag: 'railway:signal:minor:form', value: 'sign' }
-
-  - description: Sh 2 buffer stop
-    country: DE
-    icon: { default: 'de/sh2' }
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh2' }
-      - { tag: 'railway:signal:minor:form', value: 'sign' }
-
-  - description: tram signal Sh 2
-    country: DE
-    icon: { default: 'de/bostrab/sh2' }
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-BOStrab:sh2' }
-      - { tag: 'railway:signal:minor:form', value: 'sign' }
-
-  - description: shunting stop sign Ra 10
-    country: DE
-    icon: { default: 'de/ra10' }
-    tags:
-      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra10' }
-      - { tag: 'railway:signal:shunting:form', value: 'sign' }
-
-  - description: main signal invalid for shunting trains Zs 103 (sign)
-    country: DE
-    icon: { default: 'de/zs103' }
-    tags:
-      - { tag: 'railway:signal:shunting', value: 'DE-ESO:zs103' }
-      - { tag: 'railway:signal:shunting:form', value: 'sign' }
-
-  - description: shunting signal Ra 11 without Sh 1
-    country: DE
-    icon: { default: 'de/ra11-sign' }
-    tags:
-      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra11' }
-      - { tag: 'railway:signal:shunting:form', value: 'sign' }
-
-  - description: shunting signal Ra 11 with Sh 1
-    country: DE
-    icon: { default: 'de/ra11-sh1' }
-    tags:
-      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra11' }
-      - { tag: 'railway:signal:shunting:form', value: 'light' }
-
-  - description: shunting signal Ra 11b (without Sh 1)
-    country: DE
-    icon: { default: 'de/ra11b' }
-    tags:
-      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra11b' }
-      - { tag: 'railway:signal:shunting:form', value: 'sign' }
-
-  - description: tram passing prohibited sign So 5
-    country: DE
-    icon: { default: 'de/bostrab/so5' }
-    tags:
-      - { tag: 'railway:signal:passing', value: 'DE-BOStrab:so5' }
-      - { tag: 'railway:signal:passing:form', value: 'sign' }
-      - { tag: 'railway:signal:passing:type', value: 'no_passing' }
-
-  - description: tram passing prohibited end sign So 6
-    country: DE
-    icon: { default: 'de/bostrab/so6' }
-    tags:
-      - { tag: 'railway:signal:passing', value: 'DE-BOStrab:so6' }
-      - { tag: 'railway:signal:passing:form', value: 'sign' }
-      - { tag: 'railway:signal:passing:type', value: 'passing_allowed' }
-
-  - description: stop demand post Ne 5 (light)
-    country: DE
-    icon: { default: 'de/ne5-light' }
-    tags:
-      - { tag: 'railway:signal:stop_demand', value: 'DE-ESO:ne5' }
-      - { tag: 'railway:signal:stop_demand:form', value: 'light' }
-
-  - description: stop demand post Ne 5 (sign)
-    country: DE
-    icon: { default: 'de/ne5-sign' }
-    tags:
-      - { tag: 'railway:signal:stop', value: 'DE-ESO:ne5' }
-      - { tag: 'railway:signal:stop:form', value: 'sign' }
-
-  - description: stop demand post BOStrab Sh 7 (sign)
-    country: DE
-    icon: { default: 'de/bostrab/sh7' }
-    tags:
-      - { tag: 'railway:signal:stop', value: 'DE-BOStrab:sh7' }
-      - { tag: 'railway:signal:stop:form', value: 'sign' }
-
-  - description: station distant sign Ne 6
-    country: DE
-    icon: { default: 'de/ne6' }
-    tags:
-      - { tag: 'railway:signal:station_distant', value: 'DE-ESO:ne6' }
-      - { tag: 'railway:signal:station_distant:form', value: 'sign' }
-
-  # TODO support variants of same feature
-  - description: Bü 0/1 (sign, repeated)
-    country: DE
-    icon: { default: 'de/bue0-ds-repeated' }
-    tags:
-      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
-      - { tag: 'railway:signal:crossing:form', value: 'sign' }
-      - { tag: 'railway:signal:crossing:repeated', value: 'yes' }
-
-  - description: Bü 0/1 (sign)
-    country: DE
-    icon:
-      match: 'railway:signal:crossing:shortened'
-      cases:
-        - { regex: '^yes$', value: 'de/bue0-ds-shortened', description: 'shortened' }
-      default: 'de/bue0-ds'
-    tags:
-      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
-      - { tag: 'railway:signal:crossing:form', value: 'sign' }
-
-  - description: Bü 0/1 (light, repeated)
-    country: DE
-    icon: { default: 'de/bue1-ds-repeated' }
-    tags:
-      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
-      - { tag: 'railway:signal:crossing:repeated', value: 'yes' }
-
-  - description: Bü 0/1 (light)
-    country: DE
-    icon:
-      match: 'railway:signal:crossing:shortened'
-      cases:
-        - { regex: '^yes$', value: 'de/bue1-ds-shortened', description: 'shortened' }
-      default: 'de/bue1-ds'
-    tags:
-      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
-
-  - description: So 16a/b (repeated)
-    country: DE
-    icon: { default: 'de/bue1-dv-repeated' }
-    tags:
-      - { tag: 'railway:signal:crossing', value: 'DE-ESO:so16' }
-      - { tag: 'railway:signal:crossing:form', value: 'light' }
-      - { tag: 'railway:signal:crossing:repeated', value: 'yes' }
-
-  - description: So 16a/b
-    country: DE
-    icon:
-      match: 'railway:signal:crossing:shortened'
-      cases:
-        - { regex: '^yes$', value: 'de/bue1-dv-shortened', description: 'shortened' }
-      default: 'de/bue1-dv'
-    tags:
-      - { tag: 'railway:signal:crossing', value: 'DE-ESO:so16' }
-      - { tag: 'railway:signal:crossing:form', value: 'light' }
-
-  - description: crossing distant sign (warning board) So 15 (DV 301)
-    country: DE
-    icon: { default: 'de/so15' }
-    tags:
-      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:so15' }
-      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
-
-  - description: distant crossing So 14
-    country: DE
-    icon: { default: 'de/so14' }
-    tags:
-      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:so14' }
-      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
-
-  - description: crossing distant sign Bü 2
-    country: DE
-    icon:
-      match: 'railway:signal:crossing_distant:shortened'
-      cases:
-        - { regex: '^yes$', value: 'de/bue2-ds-reduced-distance', description: 'reduced distance' }
-      default: 'de/bue2-ds'
-    tags:
-      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:bü2' }
-      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
-
-  - description: crossing distant sign Bü 3
-    country: DE
-    icon: { default: 'de/bue3' }
-    tags:
-      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:bü3' }
-      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
-
-  - description: Bü 4 Whistle Sign
-    country: DE
-    icon:
-      match: 'railway:signal:whistle:only_transit'
-      cases:
-        - { regex: '^yes$', value: 'de/bue4-ds-only-transit', description: 'only transit' }
-      default: 'de/bue4-ds'
-    tags:
-      - { tag: 'railway:signal:whistle', value: 'DE-ESO:db:bü4' }
-      - { tag: 'railway:signal:whistle:form', value: 'sign' }
-
-  - description: whistle sign Pf 1 (DV 301)
-    country: DE
-    icon:
-      match: 'railway:signal:whistle:only_transit'
-      cases:
-        - { regex: '^yes$', value: 'de/pf1-dv-only-transit', description: 'only transit' }
-      default: 'de/pf1-dv'
-    tags:
-      - { tag: 'railway:signal:whistle', value: 'DE-ESO:dr:pf1' }
-      - { tag: 'railway:signal:whistle:form', value: 'sign' }
-
-  - description: whistle twice sign Pf 2 (DV 301)
-    country: DE
-    icon:
-      default: 'de/pf2-dv'
-    tags:
-      - { tag: 'railway:signal:whistle', value: 'DE-ESO:dr:pf2' }
-      - { tag: 'railway:signal:whistle:form', value: 'sign' }
-
-  - description: ring sign Bü 5
-    country: DE
-    icon:
-      match: 'railway:signal:ring:only_transit'
-      cases:
-        - { regex: '^yes$', value: 'de/bue5-only-transit', description: 'only transit' }
-      default: 'de/bue5'
-    tags:
-      - { tag: 'railway:signal:ring', value: 'DE-ESO:bü5' }
-      - { tag: 'railway:signal:ring:form', value: 'sign' }
-
-  - description: Lift / Fold snowplow Ne 7 (sign)
-    country: DE
-    icon:
-      match: 'railway:signal:snowplow:type'
-      cases:
-        - { regex: '^down$', value: 'de/ne7-yellow-down' }
-      default: 'de/ne7-yellow-up'
-    tags:
-      - { tag: 'railway:signal:snowplow', value: 'DE-ESO:ne7' }
-      - { tag: 'railway:signal:snowplow:form', value: 'sign' }
-
-  - description: Ne13 resetting switch signal
-    country: DE
-    icon: { default: 'de/ne13a' }
-    tags:
-      - { tag: 'railway:signal:resetting_switch', value: 'DE-ESO:ne13' }
-      - { tag: 'railway:signal:resetting_switch:form', value: 'light' }
-
-  - description: Ne12 resetting switch distant signal
-    country: DE
-    icon: { default: 'de/ne12' }
-    tags:
-      - { tag: 'railway:signal:resetting_switch_distant', value: 'DE-ESO:ne12' }
-      - { tag: 'railway:signal:resetting_switch_distant:form', value: 'sign' }
-
-  - description: humping signal Ra 6-9
-    country: DE
-    icon: { default: 'de/ra7' }
-    tags:
-      - { tag: 'railway:signal:humping', value: 'DE-ESO:ra' }
-      - { tag: 'railway:signal:humping:form', value: 'light' }
-
-  - description: tram läuten Sh 4
-    country: DE
-    icon: { default: 'de/bostrab/sh4' }
-    tags:
-      - { tag: 'railway:signal:ring', value: 'DE-BOStrab:sh4' }
-      - { tag: 'railway:signal:ring:form', value: 'sign' }
-
-  - description: helper engine signal Ts
-    country: DE
-    icon: { default: 'de/ts1' }
-    tags:
-      - { tag: 'railway:signal:helper_engine', value: 'DE-ESO:ts' }
-      - { tag: 'railway:signal:helper_engine:form', value: 'sign' }
-
-  - description: brake test signal Zp 6-8
-    country: DE
-    icon: { default: 'de/zp8' }
-    tags:
-      - { tag: 'railway:signal:brake_test', value: 'DE-ESO:zp' }
-      - { tag: 'railway:signal:brake_test:form', value: 'light' }
-
-  - description: Zp 9 (departure order) or Zp 10 (close doors)
-    country: DE
-    icon:
-      match: 'railway:signal:departure:states'
-      cases:
-        - { regex: '^DE-ESO:zp10$', value: 'de/zp10-db' }
-      default: 'de/zp9-db'
-    tags:
-      - { tag: 'railway:signal:departure', value: 'DE-ESO:zp' }
-      - { tag: 'railway:signal:departure:form', value: 'light' }
-
-  - description: tram departure signals
-    country: DE
-    icon:
-      match: 'railway:signal:departure:states'
-      cases:
-        - { regex: '^(.*;)?DE-BOStrab:a2(;.*)?$', value: 'de/bostrab/a2' }
-      default: 'de/bostrab/a1'
-    tags:
-      - { tag: 'railway:signal:departure', values: ['DE-BOStrab:a', 'DE-BOStrab:a1', 'DE-BOStrab:a2' ] }
-      - { tag: 'railway:signal:departure:form', value: 'light' }
-
-  - description: crossing info sign
-    country: DE
-    icon: { default: 'de/bue-crossing-info' }
-    tags:
-      - { tag: 'railway:signal:crossing_info', value: 'DE-ESO:bü-kennzeichentafel' }
-      - { tag: 'railway:signal:crossing_info:form', value: 'sign' }
-
-  - description: crossing anouncement sign
-    country: DE
-    icon: { default: 'de/bue-crossing-hint' }
-    tags:
-      - { tag: 'railway:signal:crossing_hint', value: 'DE-ESO:bü-ankündetafel' }
-      - { tag: 'railway:signal:crossing_hint:form', value: 'sign' }
-
-  - description: Karlsruhe AVG crossing signals
-    country: DE
-    icon:
-      match: 'railway:signal:crossing_distant:states'
-      cases:
-        - { regex: '^(.*;)?DE-AVG:bü201v(;.*)?$', value: 'de/avg/bue201v' }
-      default: 'de/avg/bue201'
-    tags:
-      - { tag: 'railway:signal:crossing_distant', value: 'DE-AVG:bü201' }
-      - { tag: 'railway:signal:crossing_distant:form', value: 'light' }
-
-  - description: Karlsruhe AVG Stop Demand
-    country: DE
-    icon: { default: 'de/avg/hw1' }
-    tags:
-      - { tag: 'railway:signal:stop_demand', value: 'DE-AVG:hw1' }
-      - { tag: 'railway:signal:stop_demand:form', value: 'light' }
 
   - description: Speed signals (Zs 3) (light)
     country: DE

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -1685,47 +1685,6 @@ features:
       - { tag: 'railway:signal:route_distant', value: 'DE-ESO:zs2v' }
       - { tag: 'railway:signal:route_distant:form', value: 'light' }
 
-  - description: Richtungsanzeiger (Zs 2)
-    country: DE
-    icon:
-      match: 'railway:signal:route:states'
-      # TODO allow extracting match from group
-      cases:
-        - { regex: '^(.*;)?ẞ(;.*)?$', value: 'de/zs2-ẞ' }
-        - { regex: '^(.*;)?Ü(;.*)?$', value: 'de/zs2-Ü' }
-        - { regex: '^(.*;)?Ö(;.*)?$', value: 'de/zs2-Ö' }
-        - { regex: '^(.*;)?Ä(;.*)?$', value: 'de/zs2-Ä' }
-        - { regex: '^(.*;)?Z(;.*)?$', value: 'de/zs2-Z' }
-        - { regex: '^(.*;)?Y(;.*)?$', value: 'de/zs2-Y' }
-        - { regex: '^(.*;)?X(;.*)?$', value: 'de/zs2-X' }
-        - { regex: '^(.*;)?W(;.*)?$', value: 'de/zs2-W' }
-        - { regex: '^(.*;)?V(;.*)?$', value: 'de/zs2-V' }
-        - { regex: '^(.*;)?U(;.*)?$', value: 'de/zs2-U' }
-        - { regex: '^(.*;)?T(;.*)?$', value: 'de/zs2-T' }
-        - { regex: '^(.*;)?S(;.*)?$', value: 'de/zs2-S' }
-        - { regex: '^(.*;)?R(;.*)?$', value: 'de/zs2-R' }
-        - { regex: '^(.*;)?Q(;.*)?$', value: 'de/zs2-Q' }
-        - { regex: '^(.*;)?P(;.*)?$', value: 'de/zs2-P' }
-        - { regex: '^(.*;)?O(;.*)?$', value: 'de/zs2-O' }
-        - { regex: '^(.*;)?N(;.*)?$', value: 'de/zs2-N' }
-        - { regex: '^(.*;)?M(;.*)?$', value: 'de/zs2-M' }
-        - { regex: '^(.*;)?L(;.*)?$', value: 'de/zs2-L' }
-        - { regex: '^(.*;)?K(;.*)?$', value: 'de/zs2-K' }
-        - { regex: '^(.*;)?J(;.*)?$', value: 'de/zs2-J' }
-        - { regex: '^(.*;)?I(;.*)?$', value: 'de/zs2-I' }
-        - { regex: '^(.*;)?H(;.*)?$', value: 'de/zs2-H' }
-        - { regex: '^(.*;)?G(;.*)?$', value: 'de/zs2-G' }
-        - { regex: '^(.*;)?F(;.*)?$', value: 'de/zs2-F' }
-        - { regex: '^(.*;)?E(;.*)?$', value: 'de/zs2-E' }
-        - { regex: '^(.*;)?D(;.*)?$', value: 'de/zs2-D' }
-        - { regex: '^(.*;)?C(;.*)?$', value: 'de/zs2-C' }
-        - { regex: '^(.*;)?B(;.*)?$', value: 'de/zs2-B' }
-        - { regex: '^(.*;)?A(;.*)?$', value: 'de/zs2-A' }
-      default: 'de/zs2-unknown'
-    tags:
-      - { tag: 'railway:signal:route', value: 'DE-ESO:zs2' }
-      - { tag: 'railway:signal:route:form', value: 'light' }
-
   - description: Speed signals (Zs 3v) (sign)
     country: DE
     icon:
@@ -2314,6 +2273,47 @@ features:
     tags:
       - { tag: 'railway:signal:speed_limit', value: 'DE-ESO:db:zs10' }
       - { tag: 'railway:signal:speed_limit:form', value: 'light' }
+
+  - description: Richtungsanzeiger (Zs 2)
+    country: DE
+    icon:
+      match: 'railway:signal:route:states'
+      # TODO allow extracting match from group
+      cases:
+        - { regex: '^(.*;)?ẞ(;.*)?$', value: 'de/zs2-ẞ' }
+        - { regex: '^(.*;)?Ü(;.*)?$', value: 'de/zs2-Ü' }
+        - { regex: '^(.*;)?Ö(;.*)?$', value: 'de/zs2-Ö' }
+        - { regex: '^(.*;)?Ä(;.*)?$', value: 'de/zs2-Ä' }
+        - { regex: '^(.*;)?Z(;.*)?$', value: 'de/zs2-Z' }
+        - { regex: '^(.*;)?Y(;.*)?$', value: 'de/zs2-Y' }
+        - { regex: '^(.*;)?X(;.*)?$', value: 'de/zs2-X' }
+        - { regex: '^(.*;)?W(;.*)?$', value: 'de/zs2-W' }
+        - { regex: '^(.*;)?V(;.*)?$', value: 'de/zs2-V' }
+        - { regex: '^(.*;)?U(;.*)?$', value: 'de/zs2-U' }
+        - { regex: '^(.*;)?T(;.*)?$', value: 'de/zs2-T' }
+        - { regex: '^(.*;)?S(;.*)?$', value: 'de/zs2-S' }
+        - { regex: '^(.*;)?R(;.*)?$', value: 'de/zs2-R' }
+        - { regex: '^(.*;)?Q(;.*)?$', value: 'de/zs2-Q' }
+        - { regex: '^(.*;)?P(;.*)?$', value: 'de/zs2-P' }
+        - { regex: '^(.*;)?O(;.*)?$', value: 'de/zs2-O' }
+        - { regex: '^(.*;)?N(;.*)?$', value: 'de/zs2-N' }
+        - { regex: '^(.*;)?M(;.*)?$', value: 'de/zs2-M' }
+        - { regex: '^(.*;)?L(;.*)?$', value: 'de/zs2-L' }
+        - { regex: '^(.*;)?K(;.*)?$', value: 'de/zs2-K' }
+        - { regex: '^(.*;)?J(;.*)?$', value: 'de/zs2-J' }
+        - { regex: '^(.*;)?I(;.*)?$', value: 'de/zs2-I' }
+        - { regex: '^(.*;)?H(;.*)?$', value: 'de/zs2-H' }
+        - { regex: '^(.*;)?G(;.*)?$', value: 'de/zs2-G' }
+        - { regex: '^(.*;)?F(;.*)?$', value: 'de/zs2-F' }
+        - { regex: '^(.*;)?E(;.*)?$', value: 'de/zs2-E' }
+        - { regex: '^(.*;)?D(;.*)?$', value: 'de/zs2-D' }
+        - { regex: '^(.*;)?C(;.*)?$', value: 'de/zs2-C' }
+        - { regex: '^(.*;)?B(;.*)?$', value: 'de/zs2-B' }
+        - { regex: '^(.*;)?A(;.*)?$', value: 'de/zs2-A' }
+      default: 'de/zs2-unknown'
+    tags:
+      - { tag: 'railway:signal:route', value: 'DE-ESO:zs2' }
+      - { tag: 'railway:signal:route:form', value: 'light' }
 
   - description: power off advance sign El 1v
     country: DE

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -1161,159 +1161,226 @@ features:
 
   # --- DE --- #
 
-  - description: main entry sign Ne 1
+  - description: wrong road signal Zs 6 (DB) (sign)
     country: DE
-    icon: { default: 'de/ne1' }
+    icon: { default: 'de/zs6-sign' }
     tags:
-      - { tag: 'railway:signal:main', value: 'DE-ESO:ne1' }
-      - { tag: 'railway:signal:main:form', value: 'sign' }
+      - { tag: 'railway:signal:wrong_road', value: 'DE-ESO:db:zs6' }
+      - { tag: 'railway:signal:wrong_road:form', value: 'sign' }
 
-  - description: main semaphore signals type Hp
+  - description: wrong road signal Zs 6 (DB) (light)
+    country: DE
+    icon: { default: 'de/zs6-db-light' }
+    tags:
+      - { tag: 'railway:signal:wrong_road', value: 'DE-ESO:db:zs6' }
+      - { tag: 'railway:signal:wrong_road:form', value: 'light' }
+
+  - description: wrong road signal Zs 7 (DR) (light)
+    country: DE
+    icon: { default: 'de/zs7-dr-light' }
+    tags:
+      - { tag: 'railway:signal:wrong_road', value: 'DE-ESO:dr:zs7' }
+      - { tag: 'railway:signal:wrong_road:form', value: 'light' }
+
+  - description: entry into dead-end / early stop marker Zs 13 (sign)
+    country: DE
+    icon: { default: 'de/zs13-sign' }
+    tags:
+      - { tag: 'railway:signal:short_route', value: 'DE-ESO:zs13' }
+      - { tag: 'railway:signal:short_route:form', value: 'sign' }
+
+  - description: entry into dead-end / early stop marker Zs 13 (light)
+    country: DE
+    icon: { default: 'de/zs13-light' }
+    tags:
+      - { tag: 'railway:signal:short_route', value: 'DE-ESO:zs13' }
+      - { tag: 'railway:signal:short_route:form', value: 'light' }
+
+  - description: Richtungsvoranzeiger (Zs 2v)
     country: DE
     icon:
-      match: 'railway:signal:main:states'
+      match: 'railway:signal:route_distant:states'
+      # TODO allow extracting match from group
       cases:
-        - { regex: '^(.*;)?DE-ESO:hp2(;.*)?$', value: 'de/hp2-semaphore' }
-        - { regex: '^(.*;)?DE-ESO:hp1(;.*)?$', value: 'de/hp1-semaphore' }
-      default: 'de/hp0-semaphore'
+        - { regex: '^(.*;)?ẞ(;.*)?$', value: 'de/zs2v-ẞ' }
+        - { regex: '^(.*;)?Ü(;.*)?$', value: 'de/zs2v-Ü' }
+        - { regex: '^(.*;)?Ö(;.*)?$', value: 'de/zs2v-Ö' }
+        - { regex: '^(.*;)?Ä(;.*)?$', value: 'de/zs2v-Ä' }
+        - { regex: '^(.*;)?Z(;.*)?$', value: 'de/zs2v-Z' }
+        - { regex: '^(.*;)?Y(;.*)?$', value: 'de/zs2v-Y' }
+        - { regex: '^(.*;)?X(;.*)?$', value: 'de/zs2v-X' }
+        - { regex: '^(.*;)?W(;.*)?$', value: 'de/zs2v-W' }
+        - { regex: '^(.*;)?V(;.*)?$', value: 'de/zs2v-V' }
+        - { regex: '^(.*;)?U(;.*)?$', value: 'de/zs2v-U' }
+        - { regex: '^(.*;)?T(;.*)?$', value: 'de/zs2v-T' }
+        - { regex: '^(.*;)?S(;.*)?$', value: 'de/zs2v-S' }
+        - { regex: '^(.*;)?R(;.*)?$', value: 'de/zs2v-R' }
+        - { regex: '^(.*;)?Q(;.*)?$', value: 'de/zs2v-Q' }
+        - { regex: '^(.*;)?P(;.*)?$', value: 'de/zs2v-P' }
+        - { regex: '^(.*;)?O(;.*)?$', value: 'de/zs2v-O' }
+        - { regex: '^(.*;)?N(;.*)?$', value: 'de/zs2v-N' }
+        - { regex: '^(.*;)?M(;.*)?$', value: 'de/zs2v-M' }
+        - { regex: '^(.*;)?L(;.*)?$', value: 'de/zs2v-L' }
+        - { regex: '^(.*;)?K(;.*)?$', value: 'de/zs2v-K' }
+        - { regex: '^(.*;)?J(;.*)?$', value: 'de/zs2v-J' }
+        - { regex: '^(.*;)?I(;.*)?$', value: 'de/zs2v-I' }
+        - { regex: '^(.*;)?H(;.*)?$', value: 'de/zs2v-H' }
+        - { regex: '^(.*;)?G(;.*)?$', value: 'de/zs2v-G' }
+        - { regex: '^(.*;)?F(;.*)?$', value: 'de/zs2v-F' }
+        - { regex: '^(.*;)?E(;.*)?$', value: 'de/zs2v-E' }
+        - { regex: '^(.*;)?D(;.*)?$', value: 'de/zs2v-D' }
+        - { regex: '^(.*;)?C(;.*)?$', value: 'de/zs2v-C' }
+        - { regex: '^(.*;)?B(;.*)?$', value: 'de/zs2v-B' }
+        - { regex: '^(.*;)?A(;.*)?$', value: 'de/zs2v-A' }
+      default: 'de/zs2v-unknown'
     tags:
-      - { tag: 'railway:signal:main', value: 'DE-ESO:hp' }
-      - { tag: 'railway:signal:main:form', value: 'semaphore' }
+      - { tag: 'railway:signal:route_distant', value: 'DE-ESO:zs2v' }
+      - { tag: 'railway:signal:route_distant:form', value: 'light' }
 
-  - description: main light signals type Hp
+  - description: Richtungsanzeiger (Zs 2)
     country: DE
     icon:
-      match: 'railway:signal:main:states'
+      match: 'railway:signal:route:states'
+      # TODO allow extracting match from group
       cases:
-        - { regex: '^(.*;)?DE-ESO:hp2(;.*)?$', value: 'de/hp2-light' }
-        - { regex: '^(.*;)?DE-ESO:hp1(;.*)?$', value: 'de/hp1-light' }
-      default: 'de/hp0-light'
+        - { regex: '^(.*;)?ẞ(;.*)?$', value: 'de/zs2-ẞ' }
+        - { regex: '^(.*;)?Ü(;.*)?$', value: 'de/zs2-Ü' }
+        - { regex: '^(.*;)?Ö(;.*)?$', value: 'de/zs2-Ö' }
+        - { regex: '^(.*;)?Ä(;.*)?$', value: 'de/zs2-Ä' }
+        - { regex: '^(.*;)?Z(;.*)?$', value: 'de/zs2-Z' }
+        - { regex: '^(.*;)?Y(;.*)?$', value: 'de/zs2-Y' }
+        - { regex: '^(.*;)?X(;.*)?$', value: 'de/zs2-X' }
+        - { regex: '^(.*;)?W(;.*)?$', value: 'de/zs2-W' }
+        - { regex: '^(.*;)?V(;.*)?$', value: 'de/zs2-V' }
+        - { regex: '^(.*;)?U(;.*)?$', value: 'de/zs2-U' }
+        - { regex: '^(.*;)?T(;.*)?$', value: 'de/zs2-T' }
+        - { regex: '^(.*;)?S(;.*)?$', value: 'de/zs2-S' }
+        - { regex: '^(.*;)?R(;.*)?$', value: 'de/zs2-R' }
+        - { regex: '^(.*;)?Q(;.*)?$', value: 'de/zs2-Q' }
+        - { regex: '^(.*;)?P(;.*)?$', value: 'de/zs2-P' }
+        - { regex: '^(.*;)?O(;.*)?$', value: 'de/zs2-O' }
+        - { regex: '^(.*;)?N(;.*)?$', value: 'de/zs2-N' }
+        - { regex: '^(.*;)?M(;.*)?$', value: 'de/zs2-M' }
+        - { regex: '^(.*;)?L(;.*)?$', value: 'de/zs2-L' }
+        - { regex: '^(.*;)?K(;.*)?$', value: 'de/zs2-K' }
+        - { regex: '^(.*;)?J(;.*)?$', value: 'de/zs2-J' }
+        - { regex: '^(.*;)?I(;.*)?$', value: 'de/zs2-I' }
+        - { regex: '^(.*;)?H(;.*)?$', value: 'de/zs2-H' }
+        - { regex: '^(.*;)?G(;.*)?$', value: 'de/zs2-G' }
+        - { regex: '^(.*;)?F(;.*)?$', value: 'de/zs2-F' }
+        - { regex: '^(.*;)?E(;.*)?$', value: 'de/zs2-E' }
+        - { regex: '^(.*;)?D(;.*)?$', value: 'de/zs2-D' }
+        - { regex: '^(.*;)?C(;.*)?$', value: 'de/zs2-C' }
+        - { regex: '^(.*;)?B(;.*)?$', value: 'de/zs2-B' }
+        - { regex: '^(.*;)?A(;.*)?$', value: 'de/zs2-A' }
+      default: 'de/zs2-unknown'
     tags:
-      - { tag: 'railway:signal:main', value: 'DE-ESO:hp' }
-      - { tag: 'railway:signal:main:form', value: 'light' }
+      - { tag: 'railway:signal:route', value: 'DE-ESO:zs2' }
+      - { tag: 'railway:signal:route:form', value: 'light' }
 
-  - description: main light signals type Hl
+  - description: Speed signals (Zs 3v) (sign)
     country: DE
     icon:
-      match: 'railway:signal:main:states'
+      match: 'railway:signal:speed_limit_distant:speed'
       cases:
-        - { regex: '^(.*;)?DE-ESO:hl2(;.*)?$', value: 'de/hl2' }
-        - { regex: '^(.*;)?DE-ESO:hl3b(;.*)?$', value: 'de/hl3b' }
-        - { regex: '^(.*;)?DE-ESO:hl3a(;.*)?$', value: 'de/hl3a' }
-        - { regex: '^(.*;)?DE-ESO:hl1(;.*)?$', value: 'de/hl1' }
-      default: 'de/hl0-main'
+        - { regex: '^(1[0-6]|[1-9])0$', value: 'de/zs3v-sign-down-{}', example: 'de/zs3v-sign-down-{60}' }
+      default: 'de/zs3v-empty-sign-down'
     tags:
-      - { tag: 'railway:signal:main', value: 'DE-ESO:hl' }
-      - { tag: 'railway:signal:main:form', value: 'light' }
+      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:zs3v' }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
 
-  - description: tram Fahrsignal mit Anmeldung LSA
+  - description: Speed signals (Zs 3v) (light)
     country: DE
     icon:
-      match: 'railway:signal:main:states'
+      match: 'railway:signal:speed_limit_distant:speed'
       cases:
-        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f5(;.*)?$', value: 'de/bostrab/f5-st9' }
-        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f3(;.*)?$', value: 'de/bostrab/f3-st9' }
-        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f2(;.*)?$', value: 'de/bostrab/f2-st9' }
-        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f1(;.*)?$', value: 'de/bostrab/f1-st9' }
-      default: 'de/bostrab/f0-st9'
+        - { regex: '^([1-9]|1[0-6]|20)0$', value: 'de/zs3v-light-{}', example: 'de/zs3v-light-{20}' }
+      default: 'de/zs3v-light-unknown'
     tags:
-      - { tag: 'railway:signal:main', values: ['DE-AVG:f', 'DE-BOStrab:f'] }
-      - { tag: 'railway:signal:main:form', value: 'light' }
-      - { tag: 'railway:signal:main:PT_priority', value: 'requested;off' }
+      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:zs3v' }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'light' }
 
-  - description: tram Fahrsignal
+  - description: West German branch line speed signals (Lf 4 DS 301)
+    country: DE
+    type: line
+    icon:
+      match: 'railway:signal:speed_limit_distant:speed'
+      cases:
+        - { regex: '^([2-8]0|1?[05])$', value: 'de/lf4-ds301-sign-down-{}', example: 'de/lf4-ds301-sign-down-{80}' }
+      default: 'de/lf4-ds301-empty-sign-down'
+    tags:
+      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:db:lf4' }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
+
+  - description: East German branch line speed signals (Lf 4)
     country: DE
     icon:
-      match: 'railway:signal:main:states'
+      match: 'railway:signal:speed_limit_distant:speed'
       cases:
-        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f5(;.*)?$', value: 'de/bostrab/f5' }
-        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f3(;.*)?$', value: 'de/bostrab/f3' }
-        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f2(;.*)?$', value: 'de/bostrab/f2' }
-        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f1(;.*)?$', value: 'de/bostrab/f1' }
-      default: 'de/bostrab/f0'
+        - { regex: '^(100|[2-8]0|1?[05])$', value: 'de/lf4-dr-sign-down-{}', example: 'de/lf4-dr-sign-down-{70}' }
+      default: 'de/lf4-dr-sign-down-empty'
     tags:
-      - { tag: 'railway:signal:main', values: ['DE-AVG:f', 'DE-BOStrab:f'] }
-      - { tag: 'railway:signal:main:form', value: 'light' }
+      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:dr:lf4' }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
 
-  - description: BOStrab Hauptsignal
+  - description: German line speed signals (Lf 6)
+    country: DE
+    type: line
+    icon:
+      match: 'railway:signal:speed_limit_distant:speed'
+      cases:
+        - { regex: '^((1[0-9]|[1-9])0|5|15)$', value: 'de/lf6-sign-down-{}', example: 'de/lf6-sign-down-{30}' }
+      default: 'de/lf6-empty-sign-down'
+    tags:
+      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:lf6' }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
+
+  - description: Langsamfahrscheibe
     country: DE
     icon:
-      match: 'railway:signal:main:states'
+      match: 'railway:signal:speed_limit_distant:speed'
       cases:
-        - { regex: '^(.*;)?DE-BOStrab:h2(;.*)?$', value: 'de/bostrab/h2' }
-        - { regex: '^(.*;)?DE-BOStrab:h1(;.*)?$', value: 'de/bostrab/h1' }
-        - { regex: '^(.*;)?DE-VAGN:hp2(;.*)?$', value: 'de/vag-nuremberg/hp2' }
-        - { regex: '^(.*;)?DE-VAGN:hp1(;.*)?$', value: 'de/vag-nuremberg/hp1' }
-        - { regex: '^(.*;)?DE-VAGN:(.*);off(;.*)?$', value: 'de/vag-nuremberg/off' }
-        - { regex: '^(.*;)?DE-VAGN:hp3(;.*)?$', value: 'de/vag-nuremberg/hp3' }
-        - { regex: '^(.*;)?DE-VAGN:hp0(;.*)?$', value: 'de/vag-nuremberg/hp0' }
-      default: 'de/bostrab/h0'
+        - { regex: '^(5|15|[1-9]0|1[0-9]0|200)$', value: 'de/lf1-sign-down-{}', example: 'de/lf1-sign-down-{200}' }
+      default: 'de/lf1-empty-sign-down'
     tags:
-      - { tag: 'railway:signal:main', value: 'DE-BOStrab:h' }
-      - { tag: 'railway:signal:main:form', value: 'light' }
+      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:lf1' }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
 
-  - description: Hamburger Hochbahn main signal
+  - description: Hamburger Hochbahn L1
     country: DE
+    type: line
     icon:
-      match: 'railway:signal:main:states'
+      match: 'railway:signal:speed_limit_distant:speed'
       cases:
-        - { regex: '^.*$', value: 'de/hha/h0' }
-      default: 'de/hha/h1'
+        - { regex: '^([3-7]0)$', value: 'de/hha/l1-sign-{}', example: 'de/hha/l1-sign-{70}' }
+      default: 'de/hha/l1-empty-sign'
     tags:
-      - { tag: 'railway:signal:main', value: 'DE-HHA:h' }
-      - { tag: 'railway:signal:main:form', value: 'light' }
+      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-HHA:l1' }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
 
-  - description: main signals type Ks
+  - description: Tram distance speed limit (G 1a) (sign)
     country: DE
-    icon: { default: 'de/ks-main' }
-    tags:
-      - { tag: 'railway:signal:main', value: 'DE-ESO:ks' }
-      - { tag: 'railway:signal:main:form', value: 'light' }
-
-  - description: combined light signals type Hl
-    country: DE
+    type: tram
     icon:
-      match: 'railway:signal:combined:states'
+      match: 'railway:signal:speed_limit_distant:speed'
       cases:
-        - { regex: '^(.*;)?DE-ESO:hl11(;.*)?$', value: 'de/hl11' }
-        - { regex: '^(.*;)?DE-ESO:hl12b(;.*)?$', value: 'de/hl12b' }
-        - { regex: '^(.*;)?DE-ESO:hl12a(;.*)?$', value: 'de/hl12a' }
-        - { regex: '^(.*;)?DE-ESO:hl10(;.*)?$', value: 'de/hl10' }
-      default: 'de/hl0-combined'
+        - { regex: '^(5|[1-7][0-5])$', value: 'de/bostrab/g1a-{}', example: 'de/bostrab/g1a-{40}' }
+      default: 'de/bostrab/g1a-empty'
     tags:
-      - { tag: 'railway:signal:combined', value: 'DE-ESO:hl' }
-      - { tag: 'railway:signal:combined:form', value: 'light' }
+      - { tag: 'railway:signal:speed_limit_distant', values: ['DE-BOStrab:g1', 'DE-BOStrab:g1a', 'DE-BSVG:g1a'] }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
 
-  - description: combined light signals type Sv
+  - description: Tram distance speed limit (G 1b) (light)
     country: DE
+    type: tram
     icon:
-      # TODO add shortened
-      match: 'railway:signal:combined:states'
+      match: 'railway:signal:speed_limit_distant:speed'
       cases:
-        - { regex: '^(.*;)?DE-ESO:hp0(;.*)?$', value: 'de/sv-hp0' }
-        - { regex: '^(.*;)?DE-ESO:sv0(;.*)?$', value: 'de/sv-sv0' }
-      default: ''
+        - { regex: '^[1-7]0$', value: 'de/bostrab/g1b-{}', example: 'de/bostrab/g1b-{40}' }
+      default: 'de/bostrab/g1b-empty'
     tags:
-      - { tag: 'railway:signal:combined', value: 'DE-ESO:sv' }
-      - { tag: 'railway:signal:combined:form', value: 'light' }
-
-  - description: tram Hauptsignal mit Vorsignal
-    country: DE
-    icon: { default: 'de/bostrab/h' }
-    tags:
-      - { tag: 'railway:signal:combined', value: 'DE-BOStrab:h' }
-      - { tag: 'railway:signal:combined:form', value: 'light' }
-
-  - description: combined signals type Ks
-    country: DE
-    icon:
-      match: 'railway:signal:combined:shortened'
-      cases:
-        - { regex: '^yes$', value: 'de/ks-combined-shortened' }
-      default: 'de/ks-combined'
-    tags:
-      - { tag: 'railway:signal:combined', value: 'DE-ESO:ks' }
-      - { tag: 'railway:signal:combined:form', value: 'light' }
+      - { tag: 'railway:signal:speed_limit_distant', values: ['DE-BOStrab:g1', 'DE-BOStrab:g1b'] }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'light' }
 
   - description: distant signal announcement signs Ne 3 (normal)
     country: DE
@@ -1492,6 +1559,160 @@ features:
     tags:
       - { tag: 'railway:signal:distant', value: 'DE-ESO:ks' }
       - { tag: 'railway:signal:distant:form', value: 'light' }
+
+  - description: main entry sign Ne 1
+    country: DE
+    icon: { default: 'de/ne1' }
+    tags:
+      - { tag: 'railway:signal:main', value: 'DE-ESO:ne1' }
+      - { tag: 'railway:signal:main:form', value: 'sign' }
+
+  - description: main semaphore signals type Hp
+    country: DE
+    icon:
+      match: 'railway:signal:main:states'
+      cases:
+        - { regex: '^(.*;)?DE-ESO:hp2(;.*)?$', value: 'de/hp2-semaphore' }
+        - { regex: '^(.*;)?DE-ESO:hp1(;.*)?$', value: 'de/hp1-semaphore' }
+      default: 'de/hp0-semaphore'
+    tags:
+      - { tag: 'railway:signal:main', value: 'DE-ESO:hp' }
+      - { tag: 'railway:signal:main:form', value: 'semaphore' }
+
+  - description: main light signals type Hp
+    country: DE
+    icon:
+      match: 'railway:signal:main:states'
+      cases:
+        - { regex: '^(.*;)?DE-ESO:hp2(;.*)?$', value: 'de/hp2-light' }
+        - { regex: '^(.*;)?DE-ESO:hp1(;.*)?$', value: 'de/hp1-light' }
+      default: 'de/hp0-light'
+    tags:
+      - { tag: 'railway:signal:main', value: 'DE-ESO:hp' }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+
+  - description: main light signals type Hl
+    country: DE
+    icon:
+      match: 'railway:signal:main:states'
+      cases:
+        - { regex: '^(.*;)?DE-ESO:hl2(;.*)?$', value: 'de/hl2' }
+        - { regex: '^(.*;)?DE-ESO:hl3b(;.*)?$', value: 'de/hl3b' }
+        - { regex: '^(.*;)?DE-ESO:hl3a(;.*)?$', value: 'de/hl3a' }
+        - { regex: '^(.*;)?DE-ESO:hl1(;.*)?$', value: 'de/hl1' }
+      default: 'de/hl0-main'
+    tags:
+      - { tag: 'railway:signal:main', value: 'DE-ESO:hl' }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+
+  - description: tram Fahrsignal mit Anmeldung LSA
+    country: DE
+    icon:
+      match: 'railway:signal:main:states'
+      cases:
+        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f5(;.*)?$', value: 'de/bostrab/f5-st9' }
+        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f3(;.*)?$', value: 'de/bostrab/f3-st9' }
+        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f2(;.*)?$', value: 'de/bostrab/f2-st9' }
+        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f1(;.*)?$', value: 'de/bostrab/f1-st9' }
+      default: 'de/bostrab/f0-st9'
+    tags:
+      - { tag: 'railway:signal:main', values: ['DE-AVG:f', 'DE-BOStrab:f'] }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+      - { tag: 'railway:signal:main:PT_priority', value: 'requested;off' }
+
+  - description: tram Fahrsignal
+    country: DE
+    icon:
+      match: 'railway:signal:main:states'
+      cases:
+        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f5(;.*)?$', value: 'de/bostrab/f5' }
+        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f3(;.*)?$', value: 'de/bostrab/f3' }
+        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f2(;.*)?$', value: 'de/bostrab/f2' }
+        - { regex: '^(.*;)?(DE-AVG|DE-BOStrab):f1(;.*)?$', value: 'de/bostrab/f1' }
+      default: 'de/bostrab/f0'
+    tags:
+      - { tag: 'railway:signal:main', values: ['DE-AVG:f', 'DE-BOStrab:f'] }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+
+  - description: BOStrab Hauptsignal
+    country: DE
+    icon:
+      match: 'railway:signal:main:states'
+      cases:
+        - { regex: '^(.*;)?DE-BOStrab:h2(;.*)?$', value: 'de/bostrab/h2' }
+        - { regex: '^(.*;)?DE-BOStrab:h1(;.*)?$', value: 'de/bostrab/h1' }
+        - { regex: '^(.*;)?DE-VAGN:hp2(;.*)?$', value: 'de/vag-nuremberg/hp2' }
+        - { regex: '^(.*;)?DE-VAGN:hp1(;.*)?$', value: 'de/vag-nuremberg/hp1' }
+        - { regex: '^(.*;)?DE-VAGN:(.*);off(;.*)?$', value: 'de/vag-nuremberg/off' }
+        - { regex: '^(.*;)?DE-VAGN:hp3(;.*)?$', value: 'de/vag-nuremberg/hp3' }
+        - { regex: '^(.*;)?DE-VAGN:hp0(;.*)?$', value: 'de/vag-nuremberg/hp0' }
+      default: 'de/bostrab/h0'
+    tags:
+      - { tag: 'railway:signal:main', value: 'DE-BOStrab:h' }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+
+  - description: Hamburger Hochbahn main signal
+    country: DE
+    icon:
+      match: 'railway:signal:main:states'
+      cases:
+        - { regex: '^.*$', value: 'de/hha/h0' }
+      default: 'de/hha/h1'
+    tags:
+      - { tag: 'railway:signal:main', value: 'DE-HHA:h' }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+
+  - description: main signals type Ks
+    country: DE
+    icon: { default: 'de/ks-main' }
+    tags:
+      - { tag: 'railway:signal:main', value: 'DE-ESO:ks' }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+
+  - description: combined light signals type Hl
+    country: DE
+    icon:
+      match: 'railway:signal:combined:states'
+      cases:
+        - { regex: '^(.*;)?DE-ESO:hl11(;.*)?$', value: 'de/hl11' }
+        - { regex: '^(.*;)?DE-ESO:hl12b(;.*)?$', value: 'de/hl12b' }
+        - { regex: '^(.*;)?DE-ESO:hl12a(;.*)?$', value: 'de/hl12a' }
+        - { regex: '^(.*;)?DE-ESO:hl10(;.*)?$', value: 'de/hl10' }
+      default: 'de/hl0-combined'
+    tags:
+      - { tag: 'railway:signal:combined', value: 'DE-ESO:hl' }
+      - { tag: 'railway:signal:combined:form', value: 'light' }
+
+  - description: combined light signals type Sv
+    country: DE
+    icon:
+      # TODO add shortened
+      match: 'railway:signal:combined:states'
+      cases:
+        - { regex: '^(.*;)?DE-ESO:hp0(;.*)?$', value: 'de/sv-hp0' }
+        - { regex: '^(.*;)?DE-ESO:sv0(;.*)?$', value: 'de/sv-sv0' }
+      default: ''
+    tags:
+      - { tag: 'railway:signal:combined', value: 'DE-ESO:sv' }
+      - { tag: 'railway:signal:combined:form', value: 'light' }
+
+  - description: tram Hauptsignal mit Vorsignal
+    country: DE
+    icon: { default: 'de/bostrab/h' }
+    tags:
+      - { tag: 'railway:signal:combined', value: 'DE-BOStrab:h' }
+      - { tag: 'railway:signal:combined:form', value: 'light' }
+
+  - description: combined signals type Ks
+    country: DE
+    icon:
+      match: 'railway:signal:combined:shortened'
+      cases:
+        - { regex: '^yes$', value: 'de/ks-combined-shortened' }
+      default: 'de/ks-combined'
+    tags:
+      - { tag: 'railway:signal:combined', value: 'DE-ESO:ks' }
+      - { tag: 'railway:signal:combined:form', value: 'light' }
 
   - description: tram signal "start of train protection" So 1
     country: DE
@@ -1859,41 +2080,6 @@ features:
       - { tag: 'railway:signal:resetting_switch_distant', value: 'DE-ESO:ne12' }
       - { tag: 'railway:signal:resetting_switch_distant:form', value: 'sign' }
 
-  - description: wrong road signal Zs 6 (DB) (sign)
-    country: DE
-    icon: { default: 'de/zs6-sign' }
-    tags:
-      - { tag: 'railway:signal:wrong_road', value: 'DE-ESO:db:zs6' }
-      - { tag: 'railway:signal:wrong_road:form', value: 'sign' }
-
-  - description: wrong road signal Zs 6 (DB) (light)
-    country: DE
-    icon: { default: 'de/zs6-db-light' }
-    tags:
-      - { tag: 'railway:signal:wrong_road', value: 'DE-ESO:db:zs6' }
-      - { tag: 'railway:signal:wrong_road:form', value: 'light' }
-
-  - description: wrong road signal Zs 7 (DR) (light)
-    country: DE
-    icon: { default: 'de/zs7-dr-light' }
-    tags:
-      - { tag: 'railway:signal:wrong_road', value: 'DE-ESO:dr:zs7' }
-      - { tag: 'railway:signal:wrong_road:form', value: 'light' }
-
-  - description: entry into dead-end / early stop marker Zs 13 (sign)
-    country: DE
-    icon: { default: 'de/zs13-sign' }
-    tags:
-      - { tag: 'railway:signal:short_route', value: 'DE-ESO:zs13' }
-      - { tag: 'railway:signal:short_route:form', value: 'sign' }
-
-  - description: entry into dead-end / early stop marker Zs 13 (light)
-    country: DE
-    icon: { default: 'de/zs13-light' }
-    tags:
-      - { tag: 'railway:signal:short_route', value: 'DE-ESO:zs13' }
-      - { tag: 'railway:signal:short_route:form', value: 'light' }
-
   - description: humping signal Ra 6-9
     country: DE
     icon: { default: 'de/ra7' }
@@ -1976,110 +2162,6 @@ features:
       - { tag: 'railway:signal:stop_demand', value: 'DE-AVG:hw1' }
       - { tag: 'railway:signal:stop_demand:form', value: 'light' }
 
-  - description: Richtungsanzeiger (Zs 2)
-    country: DE
-    icon:
-      match: 'railway:signal:route:states'
-      # TODO allow extracting match from group
-      cases:
-        - { regex: '^(.*;)?ẞ(;.*)?$', value: 'de/zs2-ẞ' }
-        - { regex: '^(.*;)?Ü(;.*)?$', value: 'de/zs2-Ü' }
-        - { regex: '^(.*;)?Ö(;.*)?$', value: 'de/zs2-Ö' }
-        - { regex: '^(.*;)?Ä(;.*)?$', value: 'de/zs2-Ä' }
-        - { regex: '^(.*;)?Z(;.*)?$', value: 'de/zs2-Z' }
-        - { regex: '^(.*;)?Y(;.*)?$', value: 'de/zs2-Y' }
-        - { regex: '^(.*;)?X(;.*)?$', value: 'de/zs2-X' }
-        - { regex: '^(.*;)?W(;.*)?$', value: 'de/zs2-W' }
-        - { regex: '^(.*;)?V(;.*)?$', value: 'de/zs2-V' }
-        - { regex: '^(.*;)?U(;.*)?$', value: 'de/zs2-U' }
-        - { regex: '^(.*;)?T(;.*)?$', value: 'de/zs2-T' }
-        - { regex: '^(.*;)?S(;.*)?$', value: 'de/zs2-S' }
-        - { regex: '^(.*;)?R(;.*)?$', value: 'de/zs2-R' }
-        - { regex: '^(.*;)?Q(;.*)?$', value: 'de/zs2-Q' }
-        - { regex: '^(.*;)?P(;.*)?$', value: 'de/zs2-P' }
-        - { regex: '^(.*;)?O(;.*)?$', value: 'de/zs2-O' }
-        - { regex: '^(.*;)?N(;.*)?$', value: 'de/zs2-N' }
-        - { regex: '^(.*;)?M(;.*)?$', value: 'de/zs2-M' }
-        - { regex: '^(.*;)?L(;.*)?$', value: 'de/zs2-L' }
-        - { regex: '^(.*;)?K(;.*)?$', value: 'de/zs2-K' }
-        - { regex: '^(.*;)?J(;.*)?$', value: 'de/zs2-J' }
-        - { regex: '^(.*;)?I(;.*)?$', value: 'de/zs2-I' }
-        - { regex: '^(.*;)?H(;.*)?$', value: 'de/zs2-H' }
-        - { regex: '^(.*;)?G(;.*)?$', value: 'de/zs2-G' }
-        - { regex: '^(.*;)?F(;.*)?$', value: 'de/zs2-F' }
-        - { regex: '^(.*;)?E(;.*)?$', value: 'de/zs2-E' }
-        - { regex: '^(.*;)?D(;.*)?$', value: 'de/zs2-D' }
-        - { regex: '^(.*;)?C(;.*)?$', value: 'de/zs2-C' }
-        - { regex: '^(.*;)?B(;.*)?$', value: 'de/zs2-B' }
-        - { regex: '^(.*;)?A(;.*)?$', value: 'de/zs2-A' }
-      default: 'de/zs2-unknown'
-    tags:
-      - { tag: 'railway:signal:route', value: 'DE-ESO:zs2' }
-      - { tag: 'railway:signal:route:form', value: 'light' }
-
-  - description: Richtungsvoranzeiger (Zs 2v)
-    country: DE
-    icon:
-      match: 'railway:signal:route_distant:states'
-      # TODO allow extracting match from group
-      cases:
-        - { regex: '^(.*;)?ẞ(;.*)?$', value: 'de/zs2v-ẞ' }
-        - { regex: '^(.*;)?Ü(;.*)?$', value: 'de/zs2v-Ü' }
-        - { regex: '^(.*;)?Ö(;.*)?$', value: 'de/zs2v-Ö' }
-        - { regex: '^(.*;)?Ä(;.*)?$', value: 'de/zs2v-Ä' }
-        - { regex: '^(.*;)?Z(;.*)?$', value: 'de/zs2v-Z' }
-        - { regex: '^(.*;)?Y(;.*)?$', value: 'de/zs2v-Y' }
-        - { regex: '^(.*;)?X(;.*)?$', value: 'de/zs2v-X' }
-        - { regex: '^(.*;)?W(;.*)?$', value: 'de/zs2v-W' }
-        - { regex: '^(.*;)?V(;.*)?$', value: 'de/zs2v-V' }
-        - { regex: '^(.*;)?U(;.*)?$', value: 'de/zs2v-U' }
-        - { regex: '^(.*;)?T(;.*)?$', value: 'de/zs2v-T' }
-        - { regex: '^(.*;)?S(;.*)?$', value: 'de/zs2v-S' }
-        - { regex: '^(.*;)?R(;.*)?$', value: 'de/zs2v-R' }
-        - { regex: '^(.*;)?Q(;.*)?$', value: 'de/zs2v-Q' }
-        - { regex: '^(.*;)?P(;.*)?$', value: 'de/zs2v-P' }
-        - { regex: '^(.*;)?O(;.*)?$', value: 'de/zs2v-O' }
-        - { regex: '^(.*;)?N(;.*)?$', value: 'de/zs2v-N' }
-        - { regex: '^(.*;)?M(;.*)?$', value: 'de/zs2v-M' }
-        - { regex: '^(.*;)?L(;.*)?$', value: 'de/zs2v-L' }
-        - { regex: '^(.*;)?K(;.*)?$', value: 'de/zs2v-K' }
-        - { regex: '^(.*;)?J(;.*)?$', value: 'de/zs2v-J' }
-        - { regex: '^(.*;)?I(;.*)?$', value: 'de/zs2v-I' }
-        - { regex: '^(.*;)?H(;.*)?$', value: 'de/zs2v-H' }
-        - { regex: '^(.*;)?G(;.*)?$', value: 'de/zs2v-G' }
-        - { regex: '^(.*;)?F(;.*)?$', value: 'de/zs2v-F' }
-        - { regex: '^(.*;)?E(;.*)?$', value: 'de/zs2v-E' }
-        - { regex: '^(.*;)?D(;.*)?$', value: 'de/zs2v-D' }
-        - { regex: '^(.*;)?C(;.*)?$', value: 'de/zs2v-C' }
-        - { regex: '^(.*;)?B(;.*)?$', value: 'de/zs2v-B' }
-        - { regex: '^(.*;)?A(;.*)?$', value: 'de/zs2v-A' }
-      default: 'de/zs2v-unknown'
-    tags:
-      - { tag: 'railway:signal:route_distant', value: 'DE-ESO:zs2v' }
-      - { tag: 'railway:signal:route_distant:form', value: 'light' }
-
-  - description: Speed signals (Zs 3v) (sign)
-    country: DE
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^(1[0-6]|[1-9])0$', value: 'de/zs3v-sign-down-{}', example: 'de/zs3v-sign-down-{60}' }
-      default: 'de/zs3v-empty-sign-down'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:zs3v' }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
-
-  - description: Speed signals (Zs 3v) (light)
-    country: DE
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^([1-9]|1[0-6]|20)0$', value: 'de/zs3v-light-{}', example: 'de/zs3v-light-{20}' }
-      default: 'de/zs3v-light-unknown'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:zs3v' }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'light' }
-
   - description: Speed signals (Zs 3) (light)
     country: DE
     icon:
@@ -2101,88 +2183,6 @@ features:
     tags:
       - { tag: 'railway:signal:speed_limit', value: 'DE-ESO:zs3' }
       - { tag: 'railway:signal:speed_limit:form', value: 'light' }
-
-  - description: West German branch line speed signals (Lf 4 DS 301)
-    country: DE
-    type: line
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^([2-8]0|1?[05])$', value: 'de/lf4-ds301-sign-down-{}', example: 'de/lf4-ds301-sign-down-{80}' }
-      default: 'de/lf4-ds301-empty-sign-down'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:db:lf4' }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
-
-  - description: East German branch line speed signals (Lf 4)
-    country: DE
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^(100|[2-8]0|1?[05])$', value: 'de/lf4-dr-sign-down-{}', example: 'de/lf4-dr-sign-down-{70}' }
-      default: 'de/lf4-dr-sign-down-empty'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:dr:lf4' }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
-
-  - description: German line speed signals (Lf 6)
-    country: DE
-    type: line
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^((1[0-9]|[1-9])0|5|15)$', value: 'de/lf6-sign-down-{}', example: 'de/lf6-sign-down-{30}' }
-      default: 'de/lf6-empty-sign-down'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:lf6' }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
-
-  - description: Langsamfahrscheibe
-    country: DE
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^(5|15|[1-9]0|1[0-9]0|200)$', value: 'de/lf1-sign-down-{}', example: 'de/lf1-sign-down-{200}' }
-      default: 'de/lf1-empty-sign-down'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:lf1' }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
-
-  - description: Hamburger Hochbahn L1
-    country: DE
-    type: line
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^([3-7]0)$', value: 'de/hha/l1-sign-{}', example: 'de/hha/l1-sign-{70}' }
-      default: 'de/hha/l1-empty-sign'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-HHA:l1' }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
-
-  - description: Tram distance speed limit (G 1a) (sign)
-    country: DE
-    type: tram
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^(5|[1-7][0-5])$', value: 'de/bostrab/g1a-{}', example: 'de/bostrab/g1a-{40}' }
-      default: 'de/bostrab/g1a-empty'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', values: ['DE-BOStrab:g1', 'DE-BOStrab:g1a', 'DE-BSVG:g1a'] }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
-
-  - description: Tram distance speed limit (G 1b) (light)
-    country: DE
-    type: tram
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^[1-7]0$', value: 'de/bostrab/g1b-{}', example: 'de/bostrab/g1b-{40}' }
-      default: 'de/bostrab/g1b-empty'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', values: ['DE-BOStrab:g1', 'DE-BOStrab:g1b'] }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'light' }
 
   - description: Tram speed limit (G 2a) (sign)
     country: DE


### PR DESCRIPTION
Fixes #269

On signal mast, from bottom to top:
- Shunting / minor signals
- Wrong road Zs 6
- Dead end Zs 13
- Distant Route direction Zs 2v
- Distant speed signals Zs 3v
- Distant signal Vr, Hl, Ks
- Main / combined signal
- Speed signal Zs 3
- Route direction Zs 2

The conditional placement of Zs 2 below the main/combined signal in case Zs 3 is present, is not implemented. 

### Testing

Distant signals are below main signals
http://localhost:8000/#view=17.15/51.939655/7.633332&style=signals
![image](https://github.com/user-attachments/assets/aa02f9f3-7814-4328-8023-fa35d2bdb9f0)

Route signal on top, shunting on the bottom
http://localhost:8000/#view=18.79/51.9434865/7.6322188&style=signals
![image](https://github.com/user-attachments/assets/2043ea9b-d51e-4838-9fcb-d3bf4f47fd6f)

Wrong road, distant route and combined Ks signal
http://localhost:8000/#view=18.71/50.9496012/6.9523263&style=signals
![image](https://github.com/user-attachments/assets/cc4c40f1-4b69-4b88-9b0e-d48e1c5964fa)

Departure, distant, main and route signals
http://localhost:8000/#view=18.93/50.944902/6.9568253&style=signals
![image](https://github.com/user-attachments/assets/26bf45ad-6273-46ca-bb52-1bc9a3bfc103)
