### PR TITLE
Ordering of PL signals

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -3990,6 +3990,18 @@ features:
       - { tag: 'railway:signal:minor', value: 'PL-PKP:d1' }
       - { tag: 'railway:signal:minor:form', value: 'sign' }
 
+  - description: Wskaźnik jazdy pociągu towarowego (W22)
+    country: PL
+    icon: { default: 'pl/w22' }
+    tags:
+      - { tag: 'railway:signal:passing', value: 'PL-PKP:w22' }
+
+  - description: Wskaźnik SBL (W18)
+    country: PL
+    icon: { default: 'pl/w18' }
+    tags:
+      - { tag: 'railway:signal:station_distant', value: 'PL-PKP:w18' }
+
   - description: Wskaźniki kierunku jazdy (W2, W26a,  W26b)
     country: PL
     icon:
@@ -4095,12 +4107,6 @@ features:
       default: 'pl/w19'
     tags:
       - { tag: 'railway:signal:short_route', values: ['PL-PKP:w19', 'PL-PKP:w20', 'PL-PKP:w19;PL-PKP:w20'] }
-
-  - description: Wskaźnik jazdy pociągu towarowego (W22)
-    country: PL
-    icon: { default: 'pl/w22' }
-    tags:
-      - { tag: 'railway:signal:passing', value: 'PL-PKP:w22' }
 
   - description: Wskaźnik kierunku przeciwnego (W24)
     country: PL
@@ -4290,12 +4296,6 @@ features:
     tags:
       - { tag: 'railway:signal:speed_limit', value: 'PL-tram:bt-2' }
       - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
-
-  - description: Wskaźnik SBL (W18)
-    country: PL
-    icon: { default: 'pl/w18' }
-    tags:
-      - { tag: 'railway:signal:station_distant', value: 'PL-PKP:w18' }
 
   - description: Semafor kształtowy
     country: PL

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -3749,12 +3749,6 @@ features:
       - { tag: 'railway:signal:distant', value: 'PL-PKP:w1' }
       - { tag: 'railway:signal:distant:form', value: 'sign' }
 
-  - description: Wskaźnik SBL (W18)
-    country: PL
-    icon: { default: 'pl/w18' }
-    tags:
-      - { tag: 'railway:signal:station_distant', value: 'PL-PKP:w18' }
-
   - description: Sygnalizator powtarzający (Sp)
     country: PL
     icon:
@@ -4296,6 +4290,12 @@ features:
     tags:
       - { tag: 'railway:signal:speed_limit', value: 'PL-tram:bt-2' }
       - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
+
+  - description: Wskaźnik SBL (W18)
+    country: PL
+    icon: { default: 'pl/w18' }
+    tags:
+      - { tag: 'railway:signal:station_distant', value: 'PL-PKP:w18' }
 
   - description: Semafor kształtowy
     country: PL

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -3742,77 +3742,18 @@ features:
 
   # --- PL --- #
 
-  - description: Semafor kształtowy
+  - description: Wskaźnik usytuowania (W1)
     country: PL
-    icon:
-      match: 'railway:signal:main:states'
-      cases:
-        - { regex: '^(.*;)?PL-PKP:sr3(;.*)?$', value: 'pl/sr3' }
-        - { regex: '^PL-PKP:sr1;PL-PKP:sr2$', value: 'pl/sr2' }
-      default: 'pl/sr1'
+    icon: { default: 'pl/w1' }
     tags:
-      - { tag: 'railway:signal:main', value: 'PL-PKP:sr' }
-      - { tag: 'railway:signal:main:form', value: 'semaphore' }
+      - { tag: 'railway:signal:distant', value: 'PL-PKP:w1' }
+      - { tag: 'railway:signal:distant:form', value: 'sign' }
 
-  - description: Semafory półsamoczynne
+  - description: Wskaźnik SBL (W18)
     country: PL
-    icon:
-      match: 'railway:signal:main:states'
-      cases:
-        - { regex: '^(.*;)?PL-PKP:s[23];(.*;)?PL-PKP:s[45](;.*)?$', value: 'pl/s1-4' }
-        - { regex: '^PL-PKP:s1;PL-PKP:s[45](;.*)?$', value: 'pl/s5-3' }
-      default: 'pl/s2-3'
+    icon: { default: 'pl/w18' }
     tags:
-    - { tag: 'railway:signal:main', value: 'PL-PKP:s' }
-    - { tag: 'railway:signal:main:form', value: 'light' }
-    - { tag: 'railway:signal:main:substitute_signal', value: 'PL-PKP:sz' }
-
-  - description: Semafory SBL i półsamoczynne
-    country: PL
-    icon:
-      match: 'railway:signal:main:states'
-      cases:
-        - { regex: '^(.*;)?PL-PKP:s1a(;.*)?$', value: 'pl/s1a-4' }
-        - { regex: '^(.*;)?PL-PKP:s[23];(.*;)?PL-PKP:s[45](;.*)?$', value: 'pl/s1-3' }
-        - { regex: '^(.*;)?PL-PKP:s1;PL-PKP:s[45](;.*)?$', value: 'pl/s1-2' }
-      default: 'pl/s2-2'
-    tags:
-      - { tag: 'railway:signal:main', value: 'PL-PKP:s' }
-      - { tag: 'railway:signal:main:form', value: 'light' }
-
-  - description: Semafory półsamoczynne (4- i 5-komorowe)
-    country: PL
-    icon:
-      match: 'railway:signal:combined:states'
-      cases:
-        - { regex: '^(.*;)?PL-PKP:s[67];(.*;)?PL-PKP:s1[23]a(;.*)?$', value: 'pl/s6-10a-5' }
-        - { regex: '^(.*;)?PL-PKP:s[67];(.*;)?PL-PKP:s[89](;.*)?$', value: 'pl/s6-5' }
-        - { regex: '^(.*;)?PL-PKP:s1[01]a;(.*;)?PL-PKP:s1[23]a(;.*)?$', value: 'pl/s10a-5' }
-        - { regex: '^(.*;)?PL-PKP:s1[01];(.*;)?PL-PKP:s1[23](;.*)?$', value: 'pl/s10-5' }
-        - { regex: '^(.*;)?PL-PKP:s[67];(.*;)?PL-PKP:s1[01]a(;.*)?$', value: 'pl/s6-10a-4' }
-        - { regex: '^(.*;)?PL-PKP:s[67](;.*)?$', value: 'pl/s6-4' }
-        - { regex: '^(.*;)?PL-PKP:s[89](;.*)?$', value: 'pl/s9-4' }
-        - { regex: '^(.*;)?PL-PKP:s1[01]a(;.*)?$', value: 'pl/s10a-4' }
-        - { regex: '^(.*;)?PL-PKP:s1[23]a(;.*)?$', value: 'pl/s13a-4' }
-        - { regex: '^(.*;)?PL-PKP:s1[01](;.*)?$', value: 'pl/s10-4' }
-      default: 'pl/s13-4'
-    tags:
-      - { tag: 'railway:signal:combined', value: 'PL-PKP:s' }
-      - { tag: 'railway:signal:combined:form', value: 'light' }
-      - { tag: 'railway:signal:combined:substitute_signal', value: 'PL-PKP:sz' }
-
-  - description: Semafory półsamoczynne (3-komorowe)
-    country: PL
-    icon:
-      match: 'railway:signal:combined:states'
-      cases:
-        - { regex: '^(.*;)?PL-PKP:s1[01]a(;.*)?$', value: 'pl/s10a-3' }
-        - { regex: '^(.*;)?PL-PKP:s1[23]a(;.*)?$', value: 'pl/s13a-3' }
-        - { regex: '^(.*;)?PL-PKP:s1[01](;.*)?$', value: 'pl/s10-3' }
-      default: 'pl/s13-3'
-    tags:
-      - { tag: 'railway:signal:combined', value: 'PL-PKP:s' }
-      - { tag: 'railway:signal:combined:form', value: 'light' }
+      - { tag: 'railway:signal:station_distant', value: 'PL-PKP:w18' }
 
   - description: Sygnalizator powtarzający (Sp)
     country: PL
@@ -4055,13 +3996,6 @@ features:
       - { tag: 'railway:signal:minor', value: 'PL-PKP:d1' }
       - { tag: 'railway:signal:minor:form', value: 'sign' }
 
-  - description: Wskaźnik usytuowania (W1)
-    country: PL
-    icon: { default: 'pl/w1' }
-    tags:
-      - { tag: 'railway:signal:distant', value: 'PL-PKP:w1' }
-      - { tag: 'railway:signal:distant:form', value: 'sign' }
-
   - description: Wskaźniki kierunku jazdy (W2, W26a,  W26b)
     country: PL
     icon:
@@ -4156,12 +4090,6 @@ features:
     icon: { default: 'pl/w17' }
     tags:
       - { tag: 'railway:signal:fouling_point', value: 'PL-PKP:w17' }
-
-  - description: Wskaźnik SBL (W18)
-    country: PL
-    icon: { default: 'pl/w18' }
-    tags:
-      - { tag: 'railway:signal:station_distant', value: 'PL-PKP:w18' }
 
   - description: Wskaźniki braku drogi hamowania (W19 i W20)
     country: PL
@@ -4368,6 +4296,78 @@ features:
     tags:
       - { tag: 'railway:signal:speed_limit', value: 'PL-tram:bt-2' }
       - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
+
+  - description: Semafor kształtowy
+    country: PL
+    icon:
+      match: 'railway:signal:main:states'
+      cases:
+        - { regex: '^(.*;)?PL-PKP:sr3(;.*)?$', value: 'pl/sr3' }
+        - { regex: '^PL-PKP:sr1;PL-PKP:sr2$', value: 'pl/sr2' }
+      default: 'pl/sr1'
+    tags:
+      - { tag: 'railway:signal:main', value: 'PL-PKP:sr' }
+      - { tag: 'railway:signal:main:form', value: 'semaphore' }
+
+  - description: Semafory półsamoczynne
+    country: PL
+    icon:
+      match: 'railway:signal:main:states'
+      cases:
+        - { regex: '^(.*;)?PL-PKP:s[23];(.*;)?PL-PKP:s[45](;.*)?$', value: 'pl/s1-4' }
+        - { regex: '^PL-PKP:s1;PL-PKP:s[45](;.*)?$', value: 'pl/s5-3' }
+      default: 'pl/s2-3'
+    tags:
+      - { tag: 'railway:signal:main', value: 'PL-PKP:s' }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+      - { tag: 'railway:signal:main:substitute_signal', value: 'PL-PKP:sz' }
+
+  - description: Semafory SBL i półsamoczynne
+    country: PL
+    icon:
+      match: 'railway:signal:main:states'
+      cases:
+        - { regex: '^(.*;)?PL-PKP:s1a(;.*)?$', value: 'pl/s1a-4' }
+        - { regex: '^(.*;)?PL-PKP:s[23];(.*;)?PL-PKP:s[45](;.*)?$', value: 'pl/s1-3' }
+        - { regex: '^(.*;)?PL-PKP:s1;PL-PKP:s[45](;.*)?$', value: 'pl/s1-2' }
+      default: 'pl/s2-2'
+    tags:
+      - { tag: 'railway:signal:main', value: 'PL-PKP:s' }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+
+  - description: Semafory półsamoczynne (4- i 5-komorowe)
+    country: PL
+    icon:
+      match: 'railway:signal:combined:states'
+      cases:
+        - { regex: '^(.*;)?PL-PKP:s[67];(.*;)?PL-PKP:s1[23]a(;.*)?$', value: 'pl/s6-10a-5' }
+        - { regex: '^(.*;)?PL-PKP:s[67];(.*;)?PL-PKP:s[89](;.*)?$', value: 'pl/s6-5' }
+        - { regex: '^(.*;)?PL-PKP:s1[01]a;(.*;)?PL-PKP:s1[23]a(;.*)?$', value: 'pl/s10a-5' }
+        - { regex: '^(.*;)?PL-PKP:s1[01];(.*;)?PL-PKP:s1[23](;.*)?$', value: 'pl/s10-5' }
+        - { regex: '^(.*;)?PL-PKP:s[67];(.*;)?PL-PKP:s1[01]a(;.*)?$', value: 'pl/s6-10a-4' }
+        - { regex: '^(.*;)?PL-PKP:s[67](;.*)?$', value: 'pl/s6-4' }
+        - { regex: '^(.*;)?PL-PKP:s[89](;.*)?$', value: 'pl/s9-4' }
+        - { regex: '^(.*;)?PL-PKP:s1[01]a(;.*)?$', value: 'pl/s10a-4' }
+        - { regex: '^(.*;)?PL-PKP:s1[23]a(;.*)?$', value: 'pl/s13a-4' }
+        - { regex: '^(.*;)?PL-PKP:s1[01](;.*)?$', value: 'pl/s10-4' }
+      default: 'pl/s13-4'
+    tags:
+      - { tag: 'railway:signal:combined', value: 'PL-PKP:s' }
+      - { tag: 'railway:signal:combined:form', value: 'light' }
+      - { tag: 'railway:signal:combined:substitute_signal', value: 'PL-PKP:sz' }
+
+  - description: Semafory półsamoczynne (3-komorowe)
+    country: PL
+    icon:
+      match: 'railway:signal:combined:states'
+      cases:
+        - { regex: '^(.*;)?PL-PKP:s1[01]a(;.*)?$', value: 'pl/s10a-3' }
+        - { regex: '^(.*;)?PL-PKP:s1[23]a(;.*)?$', value: 'pl/s13a-3' }
+        - { regex: '^(.*;)?PL-PKP:s1[01](;.*)?$', value: 'pl/s10-3' }
+      default: 'pl/s13-3'
+    tags:
+      - { tag: 'railway:signal:combined', value: 'PL-PKP:s' }
+      - { tag: 'railway:signal:combined:form', value: 'light' }
 
   - description: Wskaźniki uprzedzające o opuszczeniu pantografu (We1)
     country: PL


### PR DESCRIPTION
Part of https://github.com/hiddewie/OpenRailwayMap-vector/issues/269

Signals on mast from bottom to top:
- W1 
- W18
- W22
- W18
- W2/W26a/W26b
- W20/W19
- W24 
- W21
- Main / combined signals

### Testing

W1 and route indicator below main signal
W18 below the main signal
http://localhost:8000/#view=16.62/52.213161/20.939129&style=signals
![image](https://github.com/user-attachments/assets/5867ef33-dfb3-4708-b672-606d0796c5b7)

http://localhost:8000/#view=18.89/52.2090341/20.9242024&style=signals
![image](https://github.com/user-attachments/assets/d14ba092-a54f-493d-9f6d-c2c8bbc00cbb)

