### PR TITLE
Fix duplicated signals if more than one type

### DIFF
--- a/import/sql/signal_features.sql.js
+++ b/import/sql/signal_features.sql.js
@@ -3,9 +3,11 @@ import yaml from 'yaml'
 
 const signals_railway_signals = yaml.parse(fs.readFileSync('signals_railway_signals.yaml', 'utf8'))
 
-const layerByType = Object.fromEntries(
-  signals_railway_signals.types.map(type => [type.type, type.layer])
-);
+// Determine a single signal type such that combined matching does not try to match other signal types for the same feature
+const signalsWithSignalType = signals_railway_signals.features.map(feature => ({
+  ...feature,
+  signalType: signals_railway_signals.types.find(type => feature.tags.find(it => it.tag === `railway:signal:${type.type}`))?.type,
+}));
 
 /**
  * Template that builds the SQL view taking the YAML configuration into account
@@ -28,17 +30,20 @@ CREATE OR REPLACE VIEW signal_features_view AS
     SELECT
       id as signal_id,
       ${signals_railway_signals.types.map(type => `
-      CASE ${signals_railway_signals.features.map((feature, index) => ({...feature, rank: index })).filter(feature => feature.tags.find(it => it.tag === `railway:signal:${type.type}`)).map(feature => `
-        -- ${feature.country ? `(${feature.country}) ` : ''}${feature.description}
-        WHEN ${feature.tags.map(tag => `"${tag.tag}" ${tag.value ? `= '${tag.value}'`: tag.values ? `IN (${tag.values.map(value => `'${value}'`).join(', ')})` : ''}`).join(' AND ')}
-          THEN ${feature.icon.match ? `CASE ${feature.icon.cases.map(iconCase => `
-            WHEN "${feature.icon.match}" ~ '${iconCase.regex}' THEN ${iconCase.value.includes('{}') ? `ARRAY[CONCAT('${iconCase.value.replace(/\{}.*$/, '{')}', "${feature.icon.match}", '${iconCase.value.replace(/^.*\{}/, '}')}'), "${feature.icon.match}", ${feature.type ? `'${feature.type}'` : 'NULL'}, '${type.layer}', '${feature.rank}']` : `ARRAY['${iconCase.value}', NULL, ${feature.type ? `'${feature.type}'` : 'NULL'}, '${type.layer}', '${feature.rank}']`}`).join('')}
-            ${feature.icon.default ? `ELSE ARRAY['${feature.icon.default}', NULL, ${feature.type ? `'${feature.type}'` : 'NULL'}, '${type.layer}', '${feature.rank}']` : ''}
-          END` : `ARRAY['${feature.icon.default}', NULL, ${feature.type ? `'${feature.type}'` : 'NULL'}, '${type.layer}', '${feature.rank}']`}
-      `).join('')}
-        -- Unknown signal (${type.type})
+      CASE 
         WHEN "railway:signal:${type.type}" IS NOT NULL THEN
-          ARRAY['general/signal-unknown-${type.type}', NULL, NULL, '${type.layer}', NULL]
+          CASE ${signalsWithSignalType.map((feature, index) => ({...feature, rank: index })).filter(feature => feature.tags.find(it => it.tag === `railway:signal:${type.type}`)).map(feature => `
+            -- ${feature.country ? `(${feature.country}) ` : ''}${feature.description}
+            WHEN ${feature.tags.map(tag => `"${tag.tag}" ${tag.value ? `= '${tag.value}'`: tag.values ? `IN (${tag.values.map(value => `'${value}'`).join(', ')})` : ''}`).join(' AND ')}
+              THEN ${feature.signalType === type.type ? (feature.icon.match ? `CASE ${feature.icon.cases.map(iconCase => `
+                WHEN "${feature.icon.match}" ~ '${iconCase.regex}' THEN ${iconCase.value.includes('{}') ? `ARRAY[CONCAT('${iconCase.value.replace(/\{}.*$/, '{')}', "${feature.icon.match}", '${iconCase.value.replace(/^.*\{}/, '}')}'), "${feature.icon.match}", ${feature.type ? `'${feature.type}'` : 'NULL'}, '${type.layer}', '${feature.rank}']` : `ARRAY['${iconCase.value}', NULL, ${feature.type ? `'${feature.type}'` : 'NULL'}, '${type.layer}', '${feature.rank}']`}`).join('')}
+                ${feature.icon.default ? `ELSE ARRAY['${feature.icon.default}', NULL, ${feature.type ? `'${feature.type}'` : 'NULL'}, '${type.layer}', '${feature.rank}']` : ''}
+              END` : `ARRAY['${feature.icon.default}', NULL, ${feature.type ? `'${feature.type}'` : 'NULL'}, '${type.layer}', '${feature.rank}']`) : 'NULL'}
+          `).join('')}
+            -- Unknown signal (${type.type})
+            ELSE
+              ARRAY['general/signal-unknown-${type.type}', NULL, NULL, '${type.layer}', NULL]
+        END
       END as feature_${type.type}`).join(',')}
     FROM signals s
   ),


### PR DESCRIPTION
Problem: signals with two types (e.g. main and departure) are matched 2 times during import. This causes the same feature to be output twice for the same signal.

See e.g. https://openrailwaymap.fly.dev/#view=19.43/47.2588149/11.4025907&style=signals
![image](https://github.com/user-attachments/assets/808ae5dc-c477-4697-9c55-1c024d7d46db)

After:
![image](https://github.com/user-attachments/assets/1e8c52a2-76a1-4d7b-ba2f-26532e8d7076)
