### PR TITLE
Set news hash explicitly

### DIFF
--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -44,6 +44,7 @@ RUN --mount=type=bind,source=symbols,target=symbols \
 
 FROM nginx:1-alpine
 
+COPY proxy/script/with-news-hash.sh /with-news-hash.sh
 COPY proxy/proxy.conf.template /etc/nginx/templates/proxy.conf.template
 COPY proxy/manifest.json /etc/nginx/public/manifest.json
 COPY proxy/index.html /etc/nginx/public/index.html
@@ -63,4 +64,5 @@ COPY --from=build-preset \
 COPY --from=build-features \
   /build/features.json /etc/nginx/public/features.json
 
-CMD ["env", "NEWS_HASH=$(sha1sum /etc/nginx/public/news.html | awk '{print $1}')", "nginx", "-g", "daemon off;"]
+ENTRYPOINT ["/with-news-hash.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -44,7 +44,6 @@ RUN --mount=type=bind,source=symbols,target=symbols \
 
 FROM nginx:1-alpine
 
-COPY proxy/script/with-news-hash.sh /with-news-hash.sh
 COPY proxy/proxy.conf.template /etc/nginx/templates/proxy.conf.template
 COPY proxy/manifest.json /etc/nginx/public/manifest.json
 COPY proxy/index.html /etc/nginx/public/index.html
@@ -64,5 +63,4 @@ COPY --from=build-preset \
 COPY --from=build-features \
   /build/features.json /etc/nginx/public/features.json
 
-ENTRYPOINT ["/with-news-hash.sh"]
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["env", "NEWS_HASH=$(sha1sum /etc/nginx/public/news.html | awk '{print $1}')", "nginx", "-g", "daemon off;"]

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -44,6 +44,7 @@ RUN --mount=type=bind,source=symbols,target=symbols \
 
 FROM nginx:1-alpine
 
+COPY proxy/script/with-news-hash.sh /with-news-hash.sh
 COPY proxy/proxy.conf.template /etc/nginx/templates/proxy.conf.template
 COPY proxy/manifest.json /etc/nginx/public/manifest.json
 COPY proxy/index.html /etc/nginx/public/index.html
@@ -62,3 +63,6 @@ COPY --from=build-preset \
 
 COPY --from=build-features \
   /build/features.json /etc/nginx/public/features.json
+
+ENTRYPOINT ["/with-news-hash.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -991,7 +991,7 @@ class AboutControl {
     fetch(`${location.origin}/news.html`)
       .then(news => {
         // Attach news hash to the button
-        this._newsHash = news.headers.get('etag');
+        this._newsHash = news.headers.get('x-content-hash');
         if (this._newsHash && !configuration.newsHash || this._newsHash !== configuration.newsHash) {
           button.classList.add('news-updated');
           console.info('News has been updated');

--- a/proxy/proxy.conf.template
+++ b/proxy/proxy.conf.template
@@ -152,6 +152,7 @@ server {
 
   location = /news.html {
     root /etc/nginx/public;
+    add_header X-Content-Hash ${NEWS_HASH};
     add_header Cache-Control "public, max-age=${CLIENT_CACHE_TTL_ASSETS_FRESH}, stale-if-error=${CLIENT_CACHE_TTL_ASSETS_STALE}";
   }
 

--- a/proxy/script/with-news-hash.sh
+++ b/proxy/script/with-news-hash.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+exec \
+  env \
+    "NEWS_HASH=$(sha1sum /etc/nginx/public/news.html | awk '{print $1}')" \
+    /docker-entrypoint.sh "$@"

--- a/proxy/script/with-news-hash.sh
+++ b/proxy/script/with-news-hash.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env sh
-
-exec \
-  env \
-    "NEWS_HASH=$(sha1sum /etc/nginx/public/news.html | awk '{print $1}')" \
-    /docker-entrypoint.sh "$@"

--- a/proxy/test/proxy.hurl
+++ b/proxy/test/proxy.hurl
@@ -11,6 +11,7 @@ HTTP 200
 Content-Type: text/html
 [Asserts]
 body contains "<em class=\"flex-fill\">April 2025</em>"
+header "X-Content-Hash" matches "^[0-9a-f]{40}$"
 
 # Manifest
 GET {{base_url}}/manifest.json


### PR DESCRIPTION
Currently the news hash changes too often, also on redeployment when the content of the news does not change.

Solution: calculate the news hash on startup using a SHA1, and expose a custom header `x-content-hash`.

First reload:
![image](https://github.com/user-attachments/assets/d61c4237-6bd1-4864-b3dd-a783e352c6d7)

Reload, hash `68fe36f654263e549302c3317aaab0ad32c5ebc3` is picked up: 
![image](https://github.com/user-attachments/assets/81282321-21af-414f-8c27-dae2e9312eb1)

