### PR TITLE
Missing DE signals

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -1548,6 +1548,13 @@ features:
       - { tag: 'railway:signal:minor', value: 'DE-BOStrab:sh2' }
       - { tag: 'railway:signal:minor:form', value: 'sign' }
 
+  - description: Hamburger Hochbahn Sh 3
+    country: DE
+    icon: { default: 'de/hha/sh3' }
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-HHA:sh3' }
+      - { tag: 'railway:signal:minor:form', value: 'light' }
+
   - description: tram signal "start of train protection" So 1
     country: DE
     icon: { default: 'de/bostrab/so1' }

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -1916,18 +1916,18 @@ features:
       - { tag: 'railway:signal:wrong_road', value: 'DE-ESO:dr:zs7' }
       - { tag: 'railway:signal:wrong_road:form', value: 'light' }
 
-  - description: entry into dead-end / early stop marker Zs 13 (sign)
+  - description: entry into dead-end / early stop marker Zs 13 / Zs 6 (DR) (sign)
     country: DE
     icon: { default: 'de/zs13-sign' }
     tags:
-      - { tag: 'railway:signal:short_route', value: 'DE-ESO:zs13' }
+      - { tag: 'railway:signal:short_route', values: ['DE-ESO:zs13', 'DE-ESO:dr:zs6'] }
       - { tag: 'railway:signal:short_route:form', value: 'sign' }
 
-  - description: entry into dead-end / early stop marker Zs 13 (light)
+  - description: entry into dead-end / early stop marker Zs 13 / Zs 6 (DR) (light)
     country: DE
     icon: { default: 'de/zs13-light' }
     tags:
-      - { tag: 'railway:signal:short_route', value: 'DE-ESO:zs13' }
+      - { tag: 'railway:signal:short_route', values: ['DE-ESO:zs13', 'DE-ESO:dr:zs6'] }
       - { tag: 'railway:signal:short_route:form', value: 'light' }
 
   - description: Richtungsvoranzeiger (Zs 2v)

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -1747,6 +1747,20 @@ features:
       - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:bü3' }
       - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
 
+  - description: tram crossing light Bü
+    country: DE
+    icon: { default: 'de/bostrab/bü' }
+    tags:
+      - { tag: 'railway:signal:crossing', value: 'DE-BOStrab:bü' }
+      - { tag: 'railway:signal:crossing:form', value: 'light' }
+
+  - description: tram distant crossing light Bü 2
+    country: DE
+    icon: { default: 'de/bostrab/bü2' }
+    tags:
+      - { tag: 'railway:signal:crossing_distant', value: 'DE-BOStrab:bü2' }
+      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
+
   - description: Bü 4 Whistle Sign
     country: DE
     icon:

--- a/symbols/de/bostrab/bü.svg
+++ b/symbols/de/bostrab/bü.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="9" height="31.95" viewBox="0 0 9 31.95">
+<path fill-rule="nonzero" fill="rgb(54.901961%, 54.901961%, 54.901961%)" fill-opacity="1" d="M 0 0 L 9 0 L 9 14.398438 L 0 14.398438 Z M 0 0 "/>
+<path fill-rule="nonzero" fill="rgb(100%, 100%, 100%)" fill-opacity="1" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 0%, 0%)" stroke-opacity="1" stroke-miterlimit="4" d="M 16.996528 10 C 16.996528 13.862847 13.862847 16.996528 10 16.996528 C 6.128472 16.996528 3.003472 13.862847 3.003472 10 C 3.003472 6.128472 6.128472 3.003472 10 3.003472 C 13.862847 3.003472 16.996528 6.128472 16.996528 10 Z M 16.996528 10 " transform="matrix(0.45, 0, 0, 0.45, 0, 0)"/>
+<path fill-rule="nonzero" fill="rgb(100%, 100%, 100%)" fill-opacity="1" stroke-width="0.25" stroke-linecap="butt" stroke-linejoin="miter" stroke="rgb(0%, 0%, 0%)" stroke-opacity="1" stroke-miterlimit="4" d="M 6.623264 34.123264 L 13.376736 34.123264 L 13.376736 70.876736 L 6.623264 70.876736 Z M 6.623264 34.123264 " transform="matrix(0.45, 0, 0, 0.45, 0, 0)"/>
+<path fill-rule="nonzero" fill="rgb(0%, 0%, 0%)" fill-opacity="1" d="M 2.992188 15.363281 L 6.019531 16.96875 L 6.019531 15.363281 Z M 2.976562 18.265625 L 2.976562 21.351562 L 6.019531 22.972656 L 6.019531 19.875 Z M 2.976562 24.253906 L 2.976562 27.355469 L 6.019531 28.976562 L 6.019531 25.875 Z M 2.976562 30.273438 L 2.976562 31.890625 L 6 31.890625 Z M 2.976562 30.273438 "/>
+</svg>

--- a/symbols/de/bostrab/bü2.svg
+++ b/symbols/de/bostrab/bü2.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="3.655259" height="24" viewBox="0 0 3.655259 24">
+<path fill-rule="nonzero" fill="rgb(0%, 0%, 0%)" fill-opacity="1" d="M 0.00390625 0 L 3.648438 0 L 3.648438 24 L 0.00390625 24 Z M 0.00390625 0 "/>
+<path fill-rule="nonzero" fill="rgb(100%, 100%, 100%)" fill-opacity="1" d="M 1.828125 0 L 3.65625 3 L 1.828125 6 L 0 3 Z M 1.828125 0 "/>
+<path fill-rule="nonzero" fill="rgb(100%, 100%, 100%)" fill-opacity="1" d="M 1.828125 6 L 3.65625 9 L 1.828125 12 L 0 9 Z M 1.828125 6 "/>
+<path fill-rule="nonzero" fill="rgb(100%, 100%, 100%)" fill-opacity="1" d="M 1.828125 12 L 3.65625 15 L 1.828125 18 L 0 15 Z M 1.828125 12 "/>
+<path fill-rule="nonzero" fill="rgb(100%, 100%, 100%)" fill-opacity="1" d="M 1.828125 18 L 3.65625 21 L 1.828125 24 L 0 21 Z M 1.828125 18 "/>
+</svg>

--- a/symbols/de/hha/sh3.svg
+++ b/symbols/de/hha/sh3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="15" height="15" viewBox="0 0 15 15">
-<rect x="-1.5" y="-1.5" width="18" height="18" fill="rgb(0%, 0%, 0%)" fill-opacity="1"/>
-<path fill-rule="nonzero" fill="rgb(100%, 0%, 0%)" fill-opacity="1" d="M 2.753906 7.300781 C 2.753906 9.824219 4.835938 11.871094 7.402344 11.871094 C 9.964844 11.871094 12.046875 9.824219 12.046875 7.300781 C 12.046875 4.773438 9.964844 2.726562 7.402344 2.726562 C 4.835938 2.726562 2.753906 4.773438 2.753906 7.300781 Z M 2.753906 7.300781 "/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="10" height="10" viewBox="0 0 10 10">
+<rect x="-1" y="-1" width="12" height="12" fill="rgb(0%, 0%, 0%)" fill-opacity="1"/>
+<path fill-rule="nonzero" fill="rgb(100%, 0%, 0%)" fill-opacity="1" d="M 1.835938 4.867188 C 1.835938 6.546875 3.222656 7.914062 4.9375 7.914062 C 6.644531 7.914062 8.03125 6.546875 8.03125 4.867188 C 8.03125 3.183594 6.644531 1.816406 4.9375 1.816406 C 3.222656 1.816406 1.835938 3.183594 1.835938 4.867188 Z M 1.835938 4.867188 "/>
 </svg>


### PR DESCRIPTION
## DE Zs 6 (DR) sign/light

http://localhost:8000/#view=17/54.298121/13.088004&style=signals
![image](https://github.com/user-attachments/assets/056c251d-7bdc-4b67-963a-36418791fcc7)

See https://youtu.be/kEKcYJp7yzs?feature=shared&t=7185 and https://wiki.openstreetmap.org/wiki/DE:OpenRailwayMap/Tagging_in_Germany#Zs_6_ex-DR_Stumpfgleis-_und_Fr%C3%BChhaltanzeiger

## BOStrab bü
http://localhost:8000/#view=16.38/49.647191/8.486991&style=signals
![image](https://github.com/user-attachments/assets/0de15023-1452-433a-b82c-0861ba21fea7)


See https://wiki.openstreetmap.org/wiki/DE:OpenRailwayMap/Tagging_Trams_in_Germany#%C3%9Cberwachungssignale_f%C3%BCr_Bahn%C3%BCberg%C3%A4nge_(B%C3%BC)

## HHA Sh 3
http://localhost:8000/#view=16.8/53.547396/9.987211&style=signals
![image](https://github.com/user-attachments/assets/79f5d3e3-36ab-4994-ad2e-603d45b59a6a)
