### PR TITLE
NEXTEO train protection

### DIFF
--- a/features/train_protection.yaml
+++ b/features/train_protection.yaml
@@ -7,6 +7,7 @@ train_protections:
   - { train_protection: 'ptc', legend: 'Positive train control (PTC)', color: '#cc0033' }
   - { train_protection: 'tvm', legend: 'Transmission Voie-Machine (TVM)', color: '#009966' }
   - { train_protection: 'kvb', legend: 'Contrôle de vitesse par balises (KVB)', color: '#66cc33' }
+  - { train_protection: 'nexteo', legend: 'Nouveau système d''EXploitation des Trains Est-Ouest (NEXTEO)', color: '#9133cc' }
   - { train_protection: 'asfa', legend: 'Anuncio de Señales y Frenado Automático (ASFA)', color: '#ff9092' }
   - { train_protection: 'scmt', legend: 'Sistema Controllo Marcia Treno (SCMT)', color: '#dd11ff' }
   - { train_protection: 'atc', legend: 'Automatic train control (ATC)', color: '#6600cc' }
@@ -88,6 +89,10 @@ features:
   - train_protection: kvb
     tags:
       - { tag: 'railway:kvb', value: 'yes' }
+
+  - train_protection: nexteo
+    tags:
+      - { tag: 'railway:nexteo', value: 'yes' }
 
   - train_protection: atc
     tags:


### PR DESCRIPTION
From https://wiki.openstreetmap.org/w/index.php?title=OpenRailwayMap/Tagging&diff=next&oldid=2823775

http://localhost:8000/#view=9.32/48.7996/2.4718&style=signals
![image](https://github.com/user-attachments/assets/acd7a27c-6274-4006-aeb4-dd66b5fa6ef7)

http://localhost:8000/#view=12.09/48.74155/2.27244&style=signals
![image](https://github.com/user-attachments/assets/9e6bddfc-41ff-4d82-b393-bb53eca2bdb7)

http://localhost:8000/#view=14.77/48.71097/2.24001&style=signals
![image](https://github.com/user-attachments/assets/f652aca2-7b25-443e-a93e-e0535a7e0085)

