### PR TITLE
Fix POIs with zoom levels > 14 not output to tiles

### DIFF
--- a/features/poi.yaml
+++ b/features/poi.yaml
@@ -139,40 +139,10 @@ features:
     tags:
       - { tag: 'railway', value: 'rolling_highway' }
 
-  - description: Phone
-    minzoom: 16
-    feature: 'general/phone'
-    tags:
-      - { tag: 'railway', value: 'phone' }
-
-  - description: Subway entrance
-    feature: 'general/subway-entrance'
-    minzoom: 16
-    tags:
-      - { tag: 'railway', value: 'subway_entrance' }
-
-  - description: Buffer stop
-    feature: 'general/buffer_stop'
-    minzoom: 16
-    tags:
-      - { tag: 'railway', value: 'buffer_stop' }
-
-  - description: Derailer
-    feature: 'general/derail'
-    minzoom: 16
-    tags:
-      - { tag: 'railway', value: 'derail' }
-
-  - description: Retarder
-    feature: 'general/retarder'
-    minzoom: 16
-    tags:
-      - { tag: 'railway', value: 'rail_brake' }
-
   - description: Crossing
     feature: 'general/crossing'
     colored_icon: true
-    minzoom: 16
+    minzoom: 15
     tags:
       - { tag: 'railway', value: 'crossing' }
     variants:
@@ -203,3 +173,33 @@ features:
         colored_icon: true
         tags:
           - { tag: 'railway', value: 'level_crossing' }
+
+  - description: Phone
+    minzoom: 16
+    feature: 'general/phone'
+    tags:
+      - { tag: 'railway', value: 'phone' }
+
+  - description: Subway entrance
+    feature: 'general/subway-entrance'
+    minzoom: 16
+    tags:
+      - { tag: 'railway', value: 'subway_entrance' }
+
+  - description: Buffer stop
+    feature: 'general/buffer_stop'
+    minzoom: 16
+    tags:
+      - { tag: 'railway', value: 'buffer_stop' }
+
+  - description: Derailer
+    feature: 'general/derail'
+    minzoom: 16
+    tags:
+      - { tag: 'railway', value: 'derail' }
+
+  - description: Retarder
+    feature: 'general/retarder'
+    minzoom: 16
+    tags:
+      - { tag: 'railway', value: 'rail_brake' }

--- a/import/sql/tile_views.sql
+++ b/import/sql/tile_views.sql
@@ -405,7 +405,8 @@ RETURN (
       description
     FROM pois
     WHERE way && ST_TileEnvelope(z, x, y)
-      AND z >= minzoom
+      -- Tiles are generated from zoom 14 onwards
+      AND (z >= 14 OR z >= minzoom)
     ORDER BY rank DESC
   ) as tile
   WHERE way IS NOT NULL
@@ -423,6 +424,7 @@ DO $do$ BEGIN
           "osm_type": "string",
           "feature": "string",
           "ref": "string",
+          "minzoom": "integer",
           "wikidata": "string",
           "wikimedia_commons": "string",
           "image": "string",


### PR DESCRIPTION
Fixes #401 

The railway crossings, phones, subway entrances, buffer stops, derailer and retarders were not output in tiles.

The tiles are generated up to and including zoom level 14. Higher zoom levels are not output.

The standard POIs are now all output from zoom 14 and up. The map style is conditioned on zoom levels, showing just the features that need to be shown according to their minimum allowed zoom level.

Additionally, crossings are moved to zoom 15 instead of zoom 16.