### PR TITLE
Preset: fix duplicate tags for vacancy detection

### DIFF
--- a/proxy/preset.py
+++ b/proxy/preset.py
@@ -416,11 +416,12 @@ def preset_items_signals_for_country(features):
                ):
         pass
 
-      with tag('key',
-               key='railway',
-               value='signal',
-               ):
-        pass
+      if not any(ftag['tag'] == 'railway' for ftag in feature['tags']):
+        with tag('key',
+                 key='railway',
+                 value='signal',
+                 ):
+          pass
 
       for ftag in feature['tags']:
         if 'value' in ftag:


### PR DESCRIPTION
Fixes #402

Vacancy detection already has a `railway` tag value, so does not need `railway=signal`.

![image](https://github.com/user-attachments/assets/e07eda56-1a09-446e-a5f7-d8e04b7f53da)
