### PR TITLE
OpenHistoricalMap: use transport centroid points layer

### DIFF
--- a/proxy/js/features.mjs
+++ b/proxy/js/features.mjs
@@ -378,7 +378,7 @@ const features = {
       },
     },
   },
-  'openhistoricalmap-transport_points': {
+  'openhistoricalmap-transport_points_centroids': {
     featureProperty: 'type',
     labelProperty: 'name',
     featureLinks: featureLinks.openhistoricalmap,

--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -2467,7 +2467,7 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
       type: 'symbol',
       minzoom: 14,
       source: 'openhistoricalmap',
-      'source-layer': 'transport_points',
+      'source-layer': 'transport_points_centroids',
       filter: ['let', 'date', defaultDate,
         ['all',
           ['<=', ['coalesce', ['get', 'start_decdate'], 0.0], ['var', 'date']],
@@ -4535,7 +4535,7 @@ const legendData = {
         }
       },
     ],
-    'openhistoricalmap-transport_points': [
+    'openhistoricalmap-transport_points_centroids': [
       {
         legend: 'Station',
         properties: {


### PR DESCRIPTION
Fixes #408

Stations still work fine:
http://localhost:8000/#view=14.01/51.38781/-0.06701&date=1969
![image](https://github.com/user-attachments/assets/1ec73dd0-32d5-4c64-b937-25dfa69f77bb)
