### PR TITLE
Fix CI Berlin data cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,8 @@ jobs:
         id: cache-data
         with:
           path: |
-            data/germany.osm.pbf
-            data/filtered/germany.osm.pbf
+            data/berlin.osm.pbf
+            data/filtered/berlin.osm.pbf
           key: data-${{ steps.get-date.outputs.date }}-berlin
 
       - name: Download Berlin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,10 @@ jobs:
             data/berlin.osm.pbf
             data/filtered/berlin.osm.pbf
           key: data-${{ steps.get-date.outputs.date }}-berlin
+          enableCrossOsArchive: true
 
       - name: Download Berlin
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.cache-data.outputs.cache-hit != 'true' }}
         run: |
           curl --location --fail --output data/berlin.osm.pbf https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf
 


### PR DESCRIPTION
The wrong files were cached.

e.g. https://github.com/hiddewie/OpenRailwayMap-vector/actions/runs/15511274470/job/43672557791

```
Post job cleanup.
Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

After, cache works:
https://github.com/hiddewie/OpenRailwayMap-vector/actions/runs/15511428649
![image](https://github.com/user-attachments/assets/33e331fb-e6f3-4859-a85e-7da813791509)
