### PR TITLE
Serve styles and tiles from `openrailwaymap.app` domain

### DIFF
--- a/proxy.fly.toml
+++ b/proxy.fly.toml
@@ -6,7 +6,7 @@ primary_region = 'ams'
 
 [build.args]
   PUBLIC_PROTOCOL="https"
-  PUBLIC_HOST="openrailwaymap.fly.dev"
+  PUBLIC_HOST="openrailwaymap.app"
 
 [http_service]
   internal_port = 8000
@@ -26,7 +26,7 @@ primary_region = 'ams'
   TILES_UPSTREAM_SOUTH_AMERICA = "ams.openrailwaymap-tiles-south-america.internal:3000"
   API_UPSTREAM = "ams.openrailwaymap-api.internal:5000"
   PUBLIC_PROTOCOL = "https"
-  PUBLIC_HOST = "openrailwaymap.fly.dev"
+  PUBLIC_HOST = "openrailwaymap.app"
   NGINX_RESOLVER = "[fdaa::3] valid=10m ipv6=on"
   NGINX_CACHE_TTL = "86400"
   CLIENT_CACHE_TTL_ASSETS_FRESH = "3600"


### PR DESCRIPTION
Part of https://github.com/hiddewie/OpenRailwayMap-vector/issues/431

Hosting the UI and tiles on Fly.io is getting expensive. Instead, let Cloudflare proxy and cache all assets and tiles. This should improve both latency, cache hit rates and data transfer.

There will be some graceful migration period were both openrailwaymap.fly.dev and openrailwaymap.app work, and after that a redirect.

Additionally: HTTP/3 support :) 
![image](https://github.com/user-attachments/assets/a2e6d5e0-4a38-4559-b41f-e0bdb2424fe0)
