### PR TITLE
Add redirect from `openrailwaymap.fly.dev` to `openrailwaymap.app`

### DIFF
--- a/proxy/proxy.conf.template
+++ b/proxy/proxy.conf.template
@@ -131,6 +131,12 @@ map $request_uri $tiles_upstream {
 }
 
 server {
+  listen 8000;
+  server_name openrailwaymap.fly.dev;
+  return 301 https://openrailwaymap.app$request_uri;
+}
+
+server {
   listen 8000 default_server;
   server_name localhost;
 


### PR DESCRIPTION
Part of #431 

This pull request redirects all users that use the `openrailwaymap.fly.dev` domain to `openrailwaymap.app` (proxied through Cloudflare).

![image](https://github.com/user-attachments/assets/8ac71bf1-81f9-4b11-b630-8f20ce71bba9)
