### PR TITLE
Ordering of north american train protection

### DIFF
--- a/features/train_protection.yaml
+++ b/features/train_protection.yaml
@@ -42,9 +42,6 @@ train_protections:
   - { train_protection: 'other', legend: '(other)', color: 'black' }
 
 features:
-  - train_protection: ptc
-    tags:
-      - { tag: 'railway:ptc', value: 'yes' }
 
   - train_protection: etcs
     tags:
@@ -65,6 +62,30 @@ features:
   - train_protection: etcs_2
     tags:
       - { tag: 'railway:etcs', value: '3' }
+
+  - train_protection: acses
+    tags:
+      - { tag: 'railway:acses', value: 'yes' }
+
+  - train_protection: itcs
+    tags:
+      - { tag: 'railway:itcs', value: 'yes' }
+
+  - train_protection: etms
+    tags:
+      - { tag: 'railway:etms', value: 'yes' }
+
+  - train_protection: cbtc
+    tags:
+      - { tag: 'railway:cbtc', values: ['yes', 'uto', 'sto', 'dto'] }
+
+  - train_protection: ptc
+    tags:
+      - { tag: 'railway:ptc', value: 'yes' }
+
+  - train_protection: atc
+    tags:
+      - { tag: 'railway:atc', value: 'yes' }
 
   - train_protection: asfa
     tags:
@@ -94,10 +115,6 @@ features:
     tags:
       - { tag: 'railway:nexteo', value: 'yes' }
 
-  - train_protection: atc
-    tags:
-      - { tag: 'railway:atc', value: 'yes' }
-
   - train_protection: atb
     tags:
       - { tag: 'railway:atb', value: 'yes' }
@@ -125,10 +142,6 @@ features:
   - train_protection: pzb
     tags:
       - { tag: 'railway:pzb', value: 'yes' }
-
-  - train_protection: acses
-    tags:
-      - { tag: 'railway:acses', value: 'yes' }
 
   - train_protection: als
     tags:
@@ -182,10 +195,6 @@ features:
     tags:
       - { tag: 'railway:tcb', value: 'yes' }
 
-  - train_protection: cbtc
-    tags:
-      - { tag: 'railway:cbtc', values: ['yes', 'uto', 'sto', 'dto'] }
-
   - train_protection: ctcs
     tags:
       - { tag: 'railway:ctcs', values: ['yes', '0', '1', '2', '3D', '4'] }
@@ -194,17 +203,9 @@ features:
     tags:
       - { tag: 'railway:ebicab', values: ['yes', '700', '900'] }
 
-  - train_protection: etms
-    tags:
-      - { tag: 'railway:etms', value: 'yes' }
-
   - train_protection: evm
     tags:
       - { tag: 'railway:evm', value: 'yes' }
-
-  - train_protection: itcs
-    tags:
-      - { tag: 'railway:itcs', value: 'yes' }
 
   - train_protection: ls
     tags:

--- a/features/train_protection.yaml
+++ b/features/train_protection.yaml
@@ -310,6 +310,22 @@ features:
 
   - train_protection: none
     tags:
+      - { tag: 'railway:atc', value: 'no' }
+
+  - train_protection: none
+    tags:
+      - { tag: 'railway:ctc', value: 'no' }
+
+  - train_protection: none
+    tags:
+      - { tag: 'railway:etms', value: 'no' }
+
+  - train_protection: none
+    tags:
+      - { tag: 'railway:ptc', value: 'no' }
+
+  - train_protection: none
+    tags:
       - { tag: 'railway:scmt', value: 'no' }
       - { tag: 'railway:etcs', value: 'no' }
 

--- a/features/train_protection.yaml
+++ b/features/train_protection.yaml
@@ -11,10 +11,11 @@ train_protections:
   - { train_protection: 'asfa', legend: 'Anuncio de Señales y Frenado Automático (ASFA)', color: '#ff9092' }
   - { train_protection: 'scmt', legend: 'Sistema Controllo Marcia Treno (SCMT)', color: '#dd11ff' }
   - { train_protection: 'atc', legend: 'Automatic train control (ATC)', color: '#6600cc' }
+  - { train_protection: 'ctc', legend: 'Centralized traffic control (CTC)', color: '#4b8dd6' }
   - { train_protection: 'atb', legend: 'Automatische treinbeïnvloeding (ATB)', color: '#ff8c00' }
   - { train_protection: 'lzb', legend: 'Linienzugbeeinflussung (LZB)', color: 'red' }
   - { train_protection: 'pzb', legend: 'Punktförmige Zugbeeinflussung (PZB)', color: '#ffb900' }
-  - { train_protection: 'acses', legend: 'Advanced Civil Speed Enforcement System (ACSES)', color: 'pink' }
+  - { train_protection: 'acses', legend: 'Advanced Civil Speed Enforcement System (ACSES)', color: '#43b54d' }
   - { train_protection: 'als', legend: 'Автоматическая локомотивная сигнализация (ALS)', color: 'hsl(284, 100%, 40%)' }
   - { train_protection: 'atp', legend: 'Automatic Train Protection (ATP)', color: 'hsl(305, 100%, 40%)' }
   - { train_protection: 'aws', legend: 'Automatic Warning System (AWS)', color: 'hsl(50, 100%, 40%)' }
@@ -86,6 +87,10 @@ features:
   - train_protection: atc
     tags:
       - { tag: 'railway:atc', value: 'yes' }
+
+  - train_protection: ctc
+    tags:
+      - { tag: 'railway:ctc', value: 'yes' }
 
   - train_protection: asfa
     tags:

--- a/features/train_protection.yaml
+++ b/features/train_protection.yaml
@@ -11,7 +11,6 @@ train_protections:
   - { train_protection: 'asfa', legend: 'Anuncio de Señales y Frenado Automático (ASFA)', color: '#ff9092' }
   - { train_protection: 'scmt', legend: 'Sistema Controllo Marcia Treno (SCMT)', color: '#dd11ff' }
   - { train_protection: 'atc', legend: 'Automatic train control (ATC)', color: '#6600cc' }
-  - { train_protection: 'ctc', legend: 'Centralized traffic control (CTC)', color: '#4b8dd6' }
   - { train_protection: 'atb', legend: 'Automatische treinbeïnvloeding (ATB)', color: '#ff8c00' }
   - { train_protection: 'lzb', legend: 'Linienzugbeeinflussung (LZB)', color: 'red' }
   - { train_protection: 'pzb', legend: 'Punktförmige Zugbeeinflussung (PZB)', color: '#ffb900' }
@@ -87,10 +86,6 @@ features:
   - train_protection: atc
     tags:
       - { tag: 'railway:atc', value: 'yes' }
-
-  - train_protection: ctc
-    tags:
-      - { tag: 'railway:ctc', value: 'yes' }
 
   - train_protection: asfa
     tags:
@@ -311,10 +306,6 @@ features:
   - train_protection: none
     tags:
       - { tag: 'railway:atc', value: 'no' }
-
-  - train_protection: none
-    tags:
-      - { tag: 'railway:ctc', value: 'no' }
 
   - train_protection: none
     tags:


### PR DESCRIPTION
See discussion in https://github.com/hiddewie/OpenRailwayMap-vector/discussions/449

https://openrailwaymap.app/#view=4.16/41.84/-94.04&style=signals

We could also change the coloring if that improves the differences or grouping between different train protection systems.

cc @DarkTrueNinja1 can you have a look if these changes makes sense?

Before:
![image](https://github.com/user-attachments/assets/0f14ae02-1a8e-4c33-b8b6-e6ba7fe01f5a)

After:
![image](https://github.com/user-attachments/assets/abfcbcff-9b93-46aa-a827-16731278ce72)
