### PR TITLE
Train protection: change *other* to *no train protection*

### DIFF
--- a/features/train_protection.yaml
+++ b/features/train_protection.yaml
@@ -39,7 +39,7 @@ train_protections:
   - { train_protection: 'zsl90', legend: 'Zugsicherung mit Linienleiter 1990 (ZSL 90)', color: 'pink' }
   - { train_protection: 'zub', legend: 'Zugbeeinflussung (ZUB)', color: 'hsl(118, 100%, 30%)' }
   - { train_protection: 'satp', legend: 'Автоматическая блокировка (SATP)', color: 'hsl(187, 100%, 40%)' }
-  - { train_protection: 'other', legend: '(other)', color: 'black' }
+  - { train_protection: 'none', legend: 'No train protection', color: 'black' }
 
 features:
   - train_protection: ptc
@@ -286,43 +286,43 @@ features:
     tags:
       - { tag: 'railway:atp4b', value: 'yes' }
 
-  - train_protection: other
+  - train_protection: none
     tags:
       - { tag: 'railway:pzb', value: 'no' }
       - { tag: 'railway:lzb', value: 'no' }
       - { tag: 'railway:etcs', value: 'no' }
 
-  - train_protection: other
+  - train_protection: none
     tags:
       - { tag: 'railway:atb', value: 'no' }
       - { tag: 'railway:etcs', value: 'no' }
 
-  - train_protection: other
+  - train_protection: none
     tags:
       - { tag: 'railway:atc', value: 'no' }
       - { tag: 'railway:etcs', value: 'no' }
 
-  - train_protection: other
+  - train_protection: none
     tags:
       - { tag: 'railway:scmt', value: 'no' }
       - { tag: 'railway:etcs', value: 'no' }
 
-  - train_protection: other
+  - train_protection: none
     tags:
       - { tag: 'railway:asfa', value: 'no' }
       - { tag: 'railway:etcs', value: 'no' }
 
-  - train_protection: other
+  - train_protection: none
     tags:
       - { tag: 'railway:kvb', value: 'no' }
       - { tag: 'railway:tvm', value: 'no' }
       - { tag: 'railway:etcs', value: 'no' }
 
-  - train_protection: other
+  - train_protection: none
     tags:
       - { tag: 'railway:ls', value: 'no' }
       - { tag: 'railway:etcs', value: 'no' }
 
-  - train_protection: other
+  - train_protection: none
     tags:
       - { tag: 'railway:zsi127', value: 'no' }


### PR DESCRIPTION
Fixes https://github.com/hiddewie/OpenRailwayMap-vector/issues/448

![image](https://github.com/user-attachments/assets/6b6beb49-84d1-4516-9c8c-0c7eb015cd8c)
