### PR TITLE
Simplify API database views

### DIFF
--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -255,6 +255,8 @@ local stations = osm2pgsql.define_table({
     -- For joining grouped_stations_with_route_count with metadata from this table
     { column = 'id', method = 'btree', unique = true },
     { column = 'way', method = 'gist' },
+    { column = 'uic_ref', method = 'btree', where = 'uic_ref IS NOT NULL' },
+    { column = 'railway_ref', method = 'btree', where = 'railway_ref IS NOT NULL' },
   },
 })
 

--- a/import/sql/api_facility_functions.sql
+++ b/import/sql/api_facility_functions.sql
@@ -160,28 +160,28 @@ CREATE OR REPLACE FUNCTION query_facilities_by_ref(
     RETURN QUERY
       -- We do not sort the result, although we use DISTINCT ON because osm_ids is sufficient to sort out duplicates.
       SELECT
-        DISTINCT ON (osm_id)
-        ARRAY[osm_id] as osm_ids,
-        name,
-        feature,
-        state,
-        railway_ref,
-        station,
-        uic_ref,
-        ARRAY[operator] AS operator,
-        ARRAY[network] AS network,
-        ARRAY[wikidata] AS wikidata,
-        ARRAY[wikimedia_commons] AS wikimedia_commons,
-        ARRAY[wikimedia_commons_file] AS wikimedia_commons_file,
-        ARRAY[image] AS image,
-        ARRAY[mapillary] AS mapillary,
-        ARRAY[wikipedia] AS wikipedia,
-        ARRAY[note] AS note,
-        ARRAY[description] AS description,
-        ST_X(ST_Transform(way, 4326)) AS latitude,
-        ST_Y(ST_Transform(way, 4326)) AS longitude
-      FROM stations
-      WHERE railway_ref = input_ref
+        DISTINCT ON (s.osm_id)
+        ARRAY[s.osm_id] as osm_ids,
+        s.name,
+        s.feature,
+        s.state,
+        s.railway_ref,
+        s.station,
+        s.uic_ref,
+        ARRAY[s.operator] AS operator,
+        ARRAY[s.network] AS network,
+        ARRAY[s.wikidata] AS wikidata,
+        ARRAY[s.wikimedia_commons] AS wikimedia_commons,
+        ARRAY[s.wikimedia_commons_file] AS wikimedia_commons_file,
+        ARRAY[s.image] AS image,
+        ARRAY[s.mapillary] AS mapillary,
+        ARRAY[s.wikipedia] AS wikipedia,
+        ARRAY[s.note] AS note,
+        ARRAY[s.description] AS description,
+        ST_X(ST_Transform(s.way, 4326)) AS latitude,
+        ST_Y(ST_Transform(s.way, 4326)) AS longitude
+      FROM stations s
+      WHERE s.railway_ref = input_ref
       LIMIT input_limit;
   END
 $$ LANGUAGE plpgsql
@@ -216,28 +216,28 @@ CREATE OR REPLACE FUNCTION query_facilities_by_uic_ref(
     RETURN QUERY
       -- We do not sort the result, although we use DISTINCT ON because osm_ids is sufficient to sort out duplicates.
       SELECT
-        DISTINCT ON (osm_id)
-        ARRAY[osm_id] as osm_ids,
-        name,
-        feature,
-        state,
-        railway_ref,
-        station,
-        uic_ref,
-        ARRAY[operator] AS operator,
-        ARRAY[network] AS network,
-        ARRAY[wikidata] AS wikidata,
-        ARRAY[wikimedia_commons] AS wikimedia_commons,
-        ARRAY[wikimedia_commons_file] AS wikimedia_commons_file,
-        ARRAY[image] AS image,
-        ARRAY[mapillary] AS mapillary,
-        ARRAY[wikipedia] AS wikipedia,
-        ARRAY[note] AS note,
-        ARRAY[description] AS description,
-        ST_X(ST_Transform(way, 4326)) AS latitude,
-        ST_Y(ST_Transform(way, 4326)) AS longitude
-      FROM stations
-      WHERE uic_ref = input_uic_ref
+        DISTINCT ON (s.osm_id)
+        ARRAY[s.osm_id] as osm_ids,
+        s.name,
+        s.feature,
+        s.state,
+        s.railway_ref,
+        s.station,
+        s.uic_ref,
+        ARRAY[s.operator] AS operator,
+        ARRAY[s.network] AS network,
+        ARRAY[s.wikidata] AS wikidata,
+        ARRAY[s.wikimedia_commons] AS wikimedia_commons,
+        ARRAY[s.wikimedia_commons_file] AS wikimedia_commons_file,
+        ARRAY[s.image] AS image,
+        ARRAY[s.mapillary] AS mapillary,
+        ARRAY[s.wikipedia] AS wikipedia,
+        ARRAY[s.note] AS note,
+        ARRAY[s.description] AS description,
+        ST_X(ST_Transform(s.way, 4326)) AS latitude,
+        ST_Y(ST_Transform(s.way, 4326)) AS longitude
+      FROM stations s
+      WHERE s.uic_ref = input_uic_ref
       LIMIT input_limit;
   END
 $$ LANGUAGE plpgsql

--- a/import/sql/api_facility_functions.sql
+++ b/import/sql/api_facility_functions.sql
@@ -160,28 +160,28 @@ CREATE OR REPLACE FUNCTION query_facilities_by_ref(
     RETURN QUERY
       -- We do not sort the result, although we use DISTINCT ON because osm_ids is sufficient to sort out duplicates.
       SELECT
-        DISTINCT ON (osm_ids)
-        r.osm_ids,
-        r.name,
-        r.feature,
-        r.state,
-        r.railway_ref,
-        r.station,
-        r.uic_ref,
-        r.operator,
-        r.network,
-        r.wikidata,
-        r.wikimedia_commons,
-        r.wikimedia_commons_file,
-        r.image,
-        r.mapillary,
-        r.wikipedia,
-        r.note,
-        r.description,
-        ST_X(ST_Transform(r.geom, 4326)) AS latitude,
-        ST_Y(ST_Transform(r.geom, 4326)) AS longitude
-      FROM openrailwaymap_ref r
-      WHERE r.railway_ref = input_ref
+        DISTINCT ON (osm_id)
+        ARRAY[osm_id] as osm_ids,
+        name,
+        feature,
+        state,
+        railway_ref,
+        station,
+        uic_ref,
+        ARRAY[operator] AS operator,
+        ARRAY[network] AS network,
+        ARRAY[wikidata] AS wikidata,
+        ARRAY[wikimedia_commons] AS wikimedia_commons,
+        ARRAY[wikimedia_commons_file] AS wikimedia_commons_file,
+        ARRAY[image] AS image,
+        ARRAY[mapillary] AS mapillary,
+        ARRAY[wikipedia] AS wikipedia,
+        ARRAY[note] AS note,
+        ARRAY[description] AS description,
+        ST_X(ST_Transform(way, 4326)) AS latitude,
+        ST_Y(ST_Transform(way, 4326)) AS longitude
+      FROM stations
+      WHERE railway_ref = input_ref
       LIMIT input_limit;
   END
 $$ LANGUAGE plpgsql
@@ -216,28 +216,28 @@ CREATE OR REPLACE FUNCTION query_facilities_by_uic_ref(
     RETURN QUERY
       -- We do not sort the result, although we use DISTINCT ON because osm_ids is sufficient to sort out duplicates.
       SELECT
-        DISTINCT ON (osm_ids)
-        r.osm_ids,
-        r.name,
-        r.feature,
-        r.state,
-        r.railway_ref,
-        r.station,
-        r.uic_ref,
-        r.operator,
-        r.network,
-        r.wikidata,
-        r.wikimedia_commons,
-        r.wikimedia_commons_file,
-        r.image,
-        r.mapillary,
-        r.wikipedia,
-        r.note,
-        r.description,
-        ST_X(ST_Transform(r.geom, 4326)) AS latitude,
-        ST_Y(ST_Transform(r.geom, 4326)) AS longitude
-      FROM openrailwaymap_ref r
-      WHERE r.uic_ref = input_uic_ref
+        DISTINCT ON (osm_id)
+        ARRAY[osm_id] as osm_ids,
+        name,
+        feature,
+        state,
+        railway_ref,
+        station,
+        uic_ref,
+        ARRAY[operator] AS operator,
+        ARRAY[network] AS network,
+        ARRAY[wikidata] AS wikidata,
+        ARRAY[wikimedia_commons] AS wikimedia_commons,
+        ARRAY[wikimedia_commons_file] AS wikimedia_commons_file,
+        ARRAY[image] AS image,
+        ARRAY[mapillary] AS mapillary,
+        ARRAY[wikipedia] AS wikipedia,
+        ARRAY[note] AS note,
+        ARRAY[description] AS description,
+        ST_X(ST_Transform(way, 4326)) AS latitude,
+        ST_Y(ST_Transform(way, 4326)) AS longitude
+      FROM stations
+      WHERE uic_ref = input_uic_ref
       LIMIT input_limit;
   END
 $$ LANGUAGE plpgsql

--- a/import/sql/api_facility_views.sql
+++ b/import/sql/api_facility_views.sql
@@ -1,40 +1,5 @@
 -- SPDX-License-Identifier: GPL-2.0-or-later
 
-CREATE MATERIALIZED VIEW openrailwaymap_ref AS
-  SELECT
-    ARRAY[osm_id] AS osm_ids,
-    name,
-    feature,
-    state,
-    station,
-    ref,
-    railway_ref,
-    uic_ref,
-    ARRAY[operator] AS operator,
-    ARRAY[network] AS network,
-    ARRAY[wikidata] AS wikidata,
-    ARRAY[wikimedia_commons] AS wikimedia_commons,
-    ARRAY[wikimedia_commons_file] AS wikimedia_commons_file,
-    ARRAY[image] AS image,
-    ARRAY[mapillary] AS mapillary,
-    ARRAY[wikipedia] AS wikipedia,
-    ARRAY[note] AS note,
-    ARRAY[description] AS description,
-    way AS geom
-  FROM stations
-  WHERE
-    (railway_ref IS NOT NULL OR uic_ref IS NOT NULL);
-
-CREATE INDEX openrailwaymap_ref_railway_ref_idx
-  ON openrailwaymap_ref
-    USING BTREE(railway_ref)
-  WHERE railway_ref IS NOT NULL;
-
-CREATE INDEX openrailwaymap_ref_uic_ref_idx
-  ON openrailwaymap_ref
-    USING BTREE(uic_ref)
-  WHERE uic_ref IS NOT NULL;
-
 CREATE MATERIALIZED VIEW openrailwaymap_facilities_for_search AS
   SELECT
     id,

--- a/import/sql/api_milestone_views.sql
+++ b/import/sql/api_milestone_views.sql
@@ -81,7 +81,7 @@ CREATE MATERIALIZED VIEW openrailwaymap_milestones AS
       WHERE railway_position_exact IS NOT NULL
     ) AS features_with_position
     WHERE position IS NOT NULL
-    ORDER BY osm_id ASC, precision DESC
+    ORDER BY osm_id, precision DESC
   ) AS duplicates_merged;
 
 CREATE INDEX openrailwaymap_milestones_geom_idx

--- a/import/sql/api_milestone_views.sql
+++ b/import/sql/api_milestone_views.sql
@@ -91,25 +91,3 @@ CREATE INDEX openrailwaymap_milestones_geom_idx
 CREATE INDEX openrailwaymap_milestones_position_idx
   ON openrailwaymap_milestones
     USING gist(geom);
-
-CREATE MATERIALIZED VIEW openrailwaymap_tracks_with_ref AS
-  SELECT
-    osm_id,
-    feature,
-    name,
-    ref,
-    way AS geom
-  FROM railway_line
-  WHERE
-    feature IN ('rail', 'narrow_gauge', 'subway', 'light_rail', 'tram')
-    AND (service IS NULL OR usage IN ('industrial', 'military', 'test'))
-    AND ref IS NOT NULL
-    AND osm_id > 0;
-
-CREATE INDEX planet_osm_line_ref_geom_idx
-  ON openrailwaymap_tracks_with_ref
-    USING gist(geom);
-
-CREATE INDEX planet_osm_line_ref_idx
-  ON openrailwaymap_tracks_with_ref
-    USING btree(ref);

--- a/import/sql/update_api_views.sql
+++ b/import/sql/update_api_views.sql
@@ -1,7 +1,5 @@
 -- Refresh facilities API views
 REFRESH MATERIALIZED VIEW openrailwaymap_facilities_for_search;
-REFRESH MATERIALIZED VIEW openrailwaymap_ref;
 
 -- Refresh milestone API views
 REFRESH MATERIALIZED VIEW openrailwaymap_milestones;
-REFRESH MATERIALIZED VIEW openrailwaymap_tracks_with_ref;


### PR DESCRIPTION
Followup on https://github.com/hiddewie/OpenRailwayMap-vector/pull/459

Simplify the database views because the API directly queries the database in the server deployment.