### PR TITLE
Nightly update: simplify and build containers

### DIFF
--- a/.github/workflows/nightly-update.yml
+++ b/.github/workflows/nightly-update.yml
@@ -71,9 +71,3 @@ jobs:
           DB_CONTAINER_ID="$(docker compose ps --all --format json | jq -r 'select(.Service == "db") | .ID')"
           docker commit "$DB_CONTAINER_ID" ghcr.io/${{ github.repository_owner }}/openrailwaymap-import-db:latest
           docker compose push db
-
-      - name: Trigger deployment
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh workflow run --ref '${{ github.ref_name }}' deploy.yml


### PR DESCRIPTION
The last nightly update failed because it tried to trigger the deployment trigger (https://github.com/hiddewie/OpenRailwayMap-vector/actions/runs/16092774316/job/45411619735).

Changes:
- [x] Do not trigger a deployment.
- [ ] Build the proxy, API and tile images, such that the server does not have to build them.