### PR TITLE
Add watching to API container

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -19,7 +19,7 @@ docker compose up --build --watch martin
 
 Prepare and start the API:
 ```shell
-docker compose up --build api
+docker compose up --build --watch api
 ```
 
 Start the web server:
@@ -42,7 +42,7 @@ docker compose run --build import refresh
 
 The OSM data file can be updated with:
 ```shell
-docker compose run --build import refresh
+docker compose run --build import update
 ```
 This command will request all updates in the region and process them into the OSM data file.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -110,3 +110,7 @@ services:
       - POSTGRES_DB=gis
     ports:
       - '5000:5000'
+    develop:
+      watch:
+        - action: rebuild
+          path: api


### PR DESCRIPTION
For local development.
```
docker compose up --build --watch api
```
watches the API directory to make the container automatically rebuild and restart after making changes.