### PR TITLE
Station areas with platforms as ways

### DIFF
--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -1093,16 +1093,14 @@ function osm2pgsql.process_relation(object)
     local platform_members = {}
     local node_members = {}
     for _, member in ipairs(object.members) do
-      if member.type == 'n' then
-        if member.role == 'stop' then
-          table.insert(stop_members, member.ref)
-        elseif member.role == 'platform' then
-          table.insert(platform_members, member.ref)
-        else
-          -- Station has no role defined
-          table.insert(node_members, member.ref)
-          has_node_members = true
-        end
+      if member.role == 'stop' and member.type == 'n' then
+        table.insert(stop_members, member.ref)
+      elseif member.role == 'platform' then
+        table.insert(platform_members, member.ref)
+      elseif member.type == 'n' then
+        -- Station has no role defined
+        table.insert(node_members, member.ref)
+        has_node_members = true
       end
     end
 

--- a/import/sql/get_station_importance.sql
+++ b/import/sql/get_station_importance.sql
@@ -189,7 +189,7 @@ CREATE INDEX IF NOT EXISTS stations_with_route_count_idx
 CREATE MATERIALIZED VIEW IF NOT EXISTS grouped_stations_with_route_count AS
   SELECT
     -- Aggregated station columns
-    array_agg(station_id ORDER BY station_id) as station_ids,
+    array_agg(DISTINCT station_id ORDER BY station_id) as station_ids,
     hstore(string_agg(nullif(name_tags::text, ''), ',')) as name_tags,
     array_agg(osm_id ORDER BY osm_id) as osm_ids,
     array_agg(osm_type ORDER BY osm_id) as osm_types,


### PR DESCRIPTION
Only platform nodes are used now for station area station <-> platform and station <-> stop position references. Platform ways should also work.