### PR TITLE
Fix map not showing colored rotation icon on page reload

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -1560,4 +1560,4 @@ fetch(`${location.origin}/features.json`)
   .catch(error => console.error('Error during fetching of features', error))
 
 onStyleChange();
-onMapRotate();
+onMapRotate(map.getBearing());


### PR DESCRIPTION
When the map has a bearing on page load, the colored bearing map control did not show a color, even though it was rotated.

<img width="703" height="567" alt="image" src="https://github.com/user-attachments/assets/ef74a5ff-e69c-4b75-889e-32b22eeb731c" />
