### PR TITLE
Fix milestones wrong property during import

### DIFF
--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -704,12 +704,12 @@ function parse_railway_position(position)
 
   if position:find('^mi:') then
     return {
-      position = position:gsub('^mi:', ''),
+      text = position:gsub('^mi:', ''),
       type = 'mi',
     }
   elseif position:find('^pkm:') then
     return {
-      position = position:gsub('^pkm:', ''),
+      text = position:gsub('^pkm:', ''),
       type = 'pkm',
     }
   else


### PR DESCRIPTION
Followup on #481. A property was wrong, failing to import `mi:` and `pkm:` milestones.