### PR TITLE
Position signal features on left/right side of rail

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -126,7 +126,7 @@ tags:
   - { tag: 'railway:signal:wrong_road', description: 'Wrong road' }
   - { tag: 'railway:signal:wrong_road:form', description: 'Wrong road form' }
   - { tag: 'railway:vacancy_detection', description: 'Vacancy detection' }
-  - { tag: 'railway:signal:position', description: 'Position' }
+  - { tag: 'railway:signal:position', description: 'Signal position' }
 
 # A mapping of every type of signal that is imported
 # Every type that is known in the tag array above should also be present here

--- a/import/sql/signal_features.sql.js
+++ b/import/sql/signal_features.sql.js
@@ -180,11 +180,12 @@ CREATE OR REPLACE VIEW signal_features_view AS
     SELECT
       id,
       azimuth,
-      ST_translate(
-        way, 
-        1 * cos(azimuth + (CASE "railway:signal:position" WHEN 'right' THEN 1.0 WHEN 'left' THEN -1.0 ELSE 0.0 END) * pi() / 2.0),
-        1 * sin(azimuth + (CASE "railway:signal:position" WHEN 'right' THEN 1.0 WHEN 'left' THEN -1.0 ELSE 0.0 END) * pi() / 2.0)
-      ) as way
+      way
+      -- ST_translate(
+      --   way, 
+      --   1.0 * (CASE "railway:signal:position" WHEN 'right' THEN azimuth - pi() / 2.0 WHEN 'left' THEN azimuth + pi() / 2.0 ELSE 0.0 END),
+      --   1.0 * (CASE "railway:signal:position" WHEN 'right' THEN azimuth - pi() / 2.0 WHEN 'left' THEN azimuth + pi() / 2.0 ELSE 0.0 END)
+      -- ) as way
     FROM signals_with_azimuth
   )
   -- Aggregate calculated properties and features for final view
@@ -212,7 +213,7 @@ CREATE OR REPLACE VIEW signal_features_view AS
     sf.features,
     sf.rank,
     (signal_direction = 'both') as direction_both,
-    degrees(sa.azimuth) as azimuth
+    degrees(fmod(sa.azimuth, 2.0 * pi())) as azimuth
   FROM signals_with_features sf
   JOIN signals s
     ON s.id = sf.signal_id

--- a/import/sql/signal_features.sql.js
+++ b/import/sql/signal_features.sql.js
@@ -155,29 +155,69 @@ CREATE OR REPLACE VIEW signal_features_view AS
       MAX(rank) as rank
     FROM signals_with_features_1 sf
     GROUP BY signal_id, layer
+  ),
+  -- Find signal azimuth
+  signals_with_azimuth AS (
+    SELECT
+      id,
+      s.way,
+      "railway:signal:position",
+      ST_Azimuth(
+        st_lineinterpolatepoint(sl.way, greatest(0, st_linelocatepoint(sl.way, ST_ClosestPoint(sl.way, s.way)) - 0.01)),
+        st_lineinterpolatepoint(sl.way, least(1, st_linelocatepoint(sl.way, ST_ClosestPoint(sl.way, s.way)) + 0.01))
+      ) + (CASE WHEN signal_direction = 'backward' THEN pi() ELSE 0.0 END) as azimuth
+    FROM signals s
+    LEFT JOIN LATERAL (
+      SELECT line.way as way
+      FROM railway_line line
+      WHERE st_dwithin(s.way, line.way, 10) AND line.feature IN ('rail', 'tram', 'light_rail', 'subway', 'narrow_gauge', 'monorail', 'miniature', 'funicular')
+      ORDER BY s.way <-> line.way
+      LIMIT 1
+    ) as sl ON true
+  ),
+  -- Translate signal with azimuth
+  translated_signals_with_azimuth AS (
+    SELECT
+      id,
+      azimuth,
+      ST_translate(
+        way, 
+        1 * cos(azimuth + (CASE "railway:signal:position" WHEN 'right' THEN 1.0 WHEN 'left' THEN -1.0 ELSE 0.0 END) * pi() / 2.0),
+        1 * sin(azimuth + (CASE "railway:signal:position" WHEN 'right' THEN 1.0 WHEN 'left' THEN -1.0 ELSE 0.0 END) * pi() / 2.0)
+      ) as way
+    FROM signals_with_azimuth
   )
-  -- Calculate signal-specific details like fields, azimuth and features
+  -- Aggregate calculated properties and features for final view
   SELECT
-    s.*,
+    s.id,
+    s.osm_id,
+    sa.way,
+    s.railway,
+    s.ref,
+    s.ref_multiline,
+    s.caption,
+    s.deactivated,
+    s.position,
+    s.wikidata,
+    s.wikimedia_commons,
+    s.wikimedia_commons_file,
+    s.image,
+    s.mapillary,
+    s.wikipedia,
+    s.note,
+    s.description,${signals_railway_signals.tags.map(tag => `
+    s."${tag.tag}",`).join('')}
     sf.type,
     sf.layer,
     sf.features,
     sf.rank,
     (signal_direction = 'both') as direction_both,
-    degrees(ST_Azimuth(
-      st_lineinterpolatepoint(sl.way, greatest(0, st_linelocatepoint(sl.way, ST_ClosestPoint(sl.way, s.way)) - 0.01)),
-      st_lineinterpolatepoint(sl.way, least(1, st_linelocatepoint(sl.way, ST_ClosestPoint(sl.way, s.way)) + 0.01))
-    )) + (CASE WHEN signal_direction = 'backward' THEN 180.0 ELSE 0.0 END) as azimuth
+    degrees(sa.azimuth) as azimuth
   FROM signals_with_features sf
   JOIN signals s
     ON s.id = sf.signal_id
-  LEFT JOIN LATERAL (
-    SELECT line.way as way
-    FROM railway_line line
-    WHERE st_dwithin(s.way, line.way, 10) AND line.feature IN ('rail', 'tram', 'light_rail', 'subway', 'narrow_gauge', 'monorail', 'miniature', 'funicular')
-    ORDER BY s.way <-> line.way
-    LIMIT 1
-  ) as sl ON true
+  JOIN translated_signals_with_azimuth sa
+    ON sa.id = sf.signal_id
   WHERE
     (railway IN ('signal', 'buffer_stop') AND signal_direction IS NOT NULL)
       OR railway IN ('derail', 'vacancy_detection');

--- a/import/sql/tile_functions.sql
+++ b/import/sql/tile_functions.sql
@@ -1,3 +1,10 @@
+CREATE OR REPLACE FUNCTION fmod(
+  dividend double precision,
+  divisor double precision
+) RETURNS double precision
+  LANGUAGE sql IMMUTABLE AS
+    'SELECT dividend - floor(dividend / divisor) * divisor';
+
 CREATE OR REPLACE FUNCTION railway_to_int(value TEXT) RETURNS INTEGER AS $$
 BEGIN
   IF value ~ '^-?[0-9]+$' THEN

--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -1428,6 +1428,7 @@ const imageLayerWithOutline = (theme, id, spriteExpression, layer) => [
     id: `${id}_outline`,
     ...layer,
     paint: {
+      ...(layer.paint || {}),
       'icon-halo-color': ['case',
         ['boolean', ['feature-state', 'hover'], false], colors[theme].hover.textHalo,
         colors[theme].halo,
@@ -2647,16 +2648,10 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
     {
       id: 'speed_railway_signal_direction',
       type: 'symbol',
-      minzoom: 13,
+      minzoom: 14,
       source: 'openrailwaymap_speed',
       'source-layer': 'speed_railway_signals',
       filter: ['step', ['zoom'],
-        ['all',
-          ['!=', ['get', 'feature0'], null],
-          ['!=', ['get', 'azimuth'], null],
-          ['==', ['get', 'type'], 'line'],
-        ],
-        14,
         ['all',
           ['!=', ['get', 'feature0'], null],
           ['!=', ['get', 'azimuth'], null],
@@ -2940,7 +2935,7 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
     {
       id: 'railway_signals_direction',
       type: 'symbol',
-      minzoom: 13,
+      minzoom: 14,
       source: 'openrailwaymap_signals',
       'source-layer': 'signals_railway_signals',
       filter: ['all',
@@ -2948,19 +2943,36 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
         ['!=', ['get', 'feature0'], ''],
       ],
       paint: {
-        'icon-color': colors[theme].signals.direction,
-        'icon-halo-color': ['case',
-          ['boolean', ['feature-state', 'hover'], false], colors[theme].hover.textHalo,
-          colors[theme].halo,
+        // 'icon-color': colors[theme].signals.direction,
+        // 'icon-halo-color': ['case',
+        //   ['boolean', ['feature-state', 'hover'], false], colors[theme].hover.textHalo,
+        //   colors[theme].halo,
+        // ],
+        // 'icon-halo-width': 2.0,
+        // 'icon-halo-blur': 2.0,
+        // 'icon-opacity': ['/', ['+', ['sin', ['*', ['get', 'azimuth'], Math.PI / 180.0]], 1], 2.0],
+
+        'icon-opacity': ['let',
+          'bearing', ['global-state', 'bearing'],
+          'azimuth', 0,// ['get', 'azimuth'],
+          ['case',
+            // ['/', ['+', ['sin', ['*', ['get', 'azimuth'], Math.PI / 180.0]], 1], 2.0]
+            ['all',
+              // ['!=', ['var', 'azimuth'], null],
+              ['any',
+                ['<=', ['%', ['+', ['var', 'azimuth'], ['var', 'bearing'], 360.0], 360.0], 0 + 60],
+                ['>=', ['%', ['+', ['var', 'azimuth'], ['var', 'bearing'], 360.0], 360.0], 360 - 60],
+              ],
+            ], 1.0,
+            0.3,
+          ],
         ],
-        'icon-halo-width': 2.0,
-        'icon-halo-blur': 2.0,
       },
       layout: {
         'icon-overlap': 'always',
         'icon-image': ['case',
-          ['coalesce', ['get', 'direction_both'], false], 'sdf:general/signal-direction-both',
-          'sdf:general/signal-direction',
+          ['coalesce', ['get', 'direction_both'], false], 'general/signal-direction-both',
+          'general/signal-direction',
         ],
         'icon-anchor': ['case',
           ['coalesce', ['get', 'direction_both'], false], 'center',
@@ -2987,6 +2999,24 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
           source: 'openrailwaymap_signals',
           'source-layer': 'signals_railway_signals',
           filter: ['!=', ['get', `feature${featureIndex}`], null],
+          paint: {
+
+            'icon-opacity': ['let',
+              'bearing', ['global-state', 'bearing'],
+              'azimuth', 0,// ['get', 'azimuth'],
+              ['case',
+                // ['/', ['+', ['sin', ['*', ['get', 'azimuth'], Math.PI / 180.0]], 1], 2.0]
+                ['all',
+                  // ['!=', ['var', 'azimuth'], null],
+                  ['any',
+                    ['<=', ['%', ['+', ['var', 'azimuth'], ['var', 'bearing'], 360.0], 360.0], 0 + 60],
+                    ['>=', ['%', ['+', ['var', 'azimuth'], ['var', 'bearing'], 360.0], 360.0], 360 - 60],
+                  ],
+                ], 1.0,
+                0.3,
+              ],
+            ],
+          },
           layout: {
             'symbol-z-order': 'source',
             'icon-overlap': 'always',
@@ -3006,6 +3036,23 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
           source: 'openrailwaymap_signals',
           'source-layer': 'signals_railway_signals',
           filter: ['!=', ['get', `feature${featureIndex}`], null],
+          paint: {
+            'icon-opacity': ['let',
+              'bearing', ['global-state', 'bearing'],
+              'azimuth', 0,// ['get', 'azimuth'],
+              ['case',
+                // ['/', ['+', ['sin', ['*', ['get', 'azimuth'], Math.PI / 180.0]], 1], 2.0]
+                ['all',
+                  // ['!=', ['var', 'azimuth'], null],
+                  ['any',
+                    ['<=', ['%', ['+', ['var', 'azimuth'], ['var', 'bearing'], 360.0], 360.0], 0 + 60],
+                    ['>=', ['%', ['+', ['var', 'azimuth'], ['var', 'bearing'], 360.0], 360.0], 360 - 60],
+                  ],
+                ], 1.0,
+                0.3,
+              ],
+            ],
+          },
           layout: {
             'symbol-z-order': 'source',
             'icon-overlap': 'always',
@@ -3302,7 +3349,7 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
     {
       id: 'electrification_signals_direction',
       type: 'symbol',
-      minzoom: 13,
+      minzoom: 14,
       source: 'openrailwaymap_electrification',
       'source-layer': 'electrification_signals',
       filter: ['all',
@@ -3971,6 +4018,14 @@ const makeStyle = (selectedStyle, theme) => ({
   ],
   version: 8,
   layers: layers[theme][selectedStyle],
+  state: {
+    date: {
+      default: (new Date()).getFullYear(),
+    },
+    bearing: {
+      default: 0.0,
+    },
+  },
 });
 
 const legendData = {
@@ -6368,11 +6423,6 @@ function makeLegendStyle(style, theme) {
     name: `${sourceStyle.name} legend`,
     layers: legendLayers,
     sources: legendSources,
-    state: {
-      date: {
-        default: (new Date()).getFullYear(),
-      }
-    },
     metadata: {
       name: style,
     }

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -749,7 +749,10 @@ const onStyleChange = () => {
 }
 
 const onDateChange = () => {
-  map.setGlobalStateProperty('date', selectedDate);
+  if (map.isStyleLoaded()) {
+    map.setGlobalStateProperty('date', selectedDate);
+  }
+
   onPageParametersChange();
 }
 
@@ -1138,6 +1141,10 @@ const onMapZoom = zoom => {
   legendMapContainer.style.height = `${numberOfLegendEntries * 27.5}px`;
 }
 const onMapRotate = bearing => {
+  if (map.isStyleLoaded()) {
+    map.setGlobalStateProperty('bearing', bearing);
+  }
+
   const rotated = Math.abs(bearing) >= 1;
   const rotatedShownOnIcon = navigationControl._compassIcon.classList.contains('rotated');
   if (rotated && !rotatedShownOnIcon) {


### PR DESCRIPTION
Part of #270

Render signals on the correct position in relation to the railway track. Currently at a distance of 1 meter (might be tweaked).

(http://localhost:8000/#view=16.82/52.4777/13.314954/113.5&style=signals)
Normal zooms:
<img width="893" height="607" alt="image" src="https://github.com/user-attachments/assets/198c61fb-8c0a-494f-b5df-378c4db0a921" />
Zoomed in:
<img width="893" height="607" alt="image" src="https://github.com/user-attachments/assets/dd046eab-7c0a-4efb-96e8-b1dd70185e09" />

