### PR TITLE
Change defaults of background map

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -585,8 +585,8 @@ function updateBackgroundMapContainer() {
 }
 
 const defaultConfiguration = {
-  backgroundSaturation: 0.0,
-  backgroundOpacity: 1.0,
+  backgroundSaturation: 0.2,
+  backgroundOpacity: 0.5,
   backgroundType: 'raster',
   backgroundUrl: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
   theme: 'system',


### PR DESCRIPTION
Users that have saved their configuration have no different behaviour.

For new users, the default background map will have a saturation of 0.2 (from 0.0) and opacity of 0.5 (from 1.0).

Before:
<img width="1920" height="1034" alt="image" src="https://github.com/user-attachments/assets/4e21d256-9563-4b32-ba66-9934dd3f7f08" />

After:
<img width="1920" height="1034" alt="image" src="https://github.com/user-attachments/assets/729fe963-c86d-479b-865c-221dc8a0a037" />
