### PR TITLE
Give NEXTEO priority over KVB train protection

### DIFF
--- a/features/train_protection.yaml
+++ b/features/train_protection.yaml
@@ -112,13 +112,13 @@ features:
     tags:
       - { tag: 'railway:tvm', values: ['300', '430'] }
 
-  - train_protection: kvb
-    tags:
-      - { tag: 'railway:kvb', value: 'yes' }
-
   - train_protection: nexteo
     tags:
       - { tag: 'railway:nexteo', value: 'yes' }
+
+  - train_protection: kvb
+    tags:
+      - { tag: 'railway:kvb', value: 'yes' }
 
   - train_protection: atb
     tags:


### PR DESCRIPTION
Part of discussion in https://github.com/hiddewie/OpenRailwayMap-vector/discussions/496

(Paris: https://openrailwaymap.app/#view=12.27/48.86185/2.33082&style=signals)

Before: 
<img width="1433" height="1115" alt="image" src="https://github.com/user-attachments/assets/1a2c66b0-76b1-4f1c-9f8a-59c79d7a7e44" />

After:
<img width="1433" height="1115" alt="image" src="https://github.com/user-attachments/assets/322bb8a6-aa50-4861-b903-170ebcd4d9ff" />
