### PR TITLE
Render switches without references

### DIFF
--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -981,7 +981,7 @@ function osm2pgsql.process_node(object)
     end
   end
 
-  if railway_switch_values(tags.railway) and tags.ref then
+  if railway_switch_values(tags.railway) then
     railway_switches:insert({
       way = object:as_point(),
       railway = tags.railway,


### PR DESCRIPTION
Fixes #503

Import all switches, including those without a `ref`.

http://localhost:8000/#view=17.71/50.956407/7.012742

Before:
<img width="1434" height="1114" alt="image" src="https://github.com/user-attachments/assets/ef650870-d709-408d-a552-08ce602ff7cb" />

After:
<img width="1434" height="1114" alt="image" src="https://github.com/user-attachments/assets/ba5b471a-4f84-4896-9c0b-1ef937332d14" />
