### PR TITLE
Clean up source URLs

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -90,7 +90,6 @@ services:
       CLIENT_CACHE_TTL_API_STALE: '0'
       CLIENT_CACHE_TTL_TILES_FRESH: '0'
       CLIENT_CACHE_TTL_TILES_STALE: '0'
-      REWRITE_TILE_URLS: 'true'
     develop:
       watch:
         - action: rebuild

--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -755,32 +755,32 @@ const sources = {
   },
   high: {
     type: 'vector',
-    url: '/high',
+    url: '/railway_line_high,railway_text_km',
     promoteId: 'id',
   },
   openrailwaymap_standard: {
     type: 'vector',
-    url: '/standard',
+    url: '/standard_railway_turntables,standard_railway_text_stations,standard_railway_grouped_stations,standard_railway_symbols,standard_railway_switch_ref,standard_station_entrances',
     promoteId: 'id',
   },
   openrailwaymap_speed: {
     type: 'vector',
-    url: '/speed',
+    url: '/speed_railway_signals',
     promoteId: 'id',
   },
   openrailwaymap_signals: {
     type: 'vector',
-    url: '/signals',
+    url: '/signals_railway_signals,signals_signal_boxes',
     promoteId: 'id',
   },
   openrailwaymap_electrification: {
     type: 'vector',
-    url: '/electrification',
+    url: '/electrification_signals,catenary,electrification_railway_symbols',
     promoteId: 'id',
   },
   openrailwaymap_operator: {
     type: 'vector',
-    url: '/operator',
+    url: '/operator_railway_symbols',
     promoteId: 'id',
   },
   openhistoricalmap: {

--- a/proxy/proxy.conf.template
+++ b/proxy/proxy.conf.template
@@ -17,8 +17,6 @@ server {
   ssl_certificate /etc/nginx/ssl/certificate.pem;
   ssl_certificate_key /etc/nginx/ssl/key.pem;
 
-  set $rewrite_tile_urls ${REWRITE_TILE_URLS};
-
   gzip on;
   gzip_disable "msie6";
 
@@ -128,15 +126,6 @@ server {
   }
 
   location / {
-    if ($rewrite_tile_urls = true) {
-      rewrite ^/high$ /railway_line_high,railway_text_km last;
-      rewrite ^/standard$ /standard_railway_turntables,standard_railway_text_stations,standard_railway_grouped_stations,standard_railway_symbols,standard_railway_switch_ref,standard_station_entrances last;
-      rewrite ^/speed$ /speed_railway_signals last;
-      rewrite ^/signals$ /signals_railway_signals,signals_signal_boxes last;
-      rewrite ^/electrification$ /electrification_signals,catenary,electrification_railway_symbols last;
-      rewrite ^/operator$ /operator_railway_symbols last;
-    }
-
     set $upstream http://${TILES_UPSTREAM};
     proxy_pass $upstream;
     proxy_http_version 1.1;

--- a/proxy/test/proxy.hurl
+++ b/proxy/test/proxy.hurl
@@ -19,38 +19,53 @@ HTTP 200
 Content-Type: application/json
 
 # Proxy to tiles
-GET {{base_url}}/speed
+GET {{base_url}}/railway_line_high
 Referer: http://localhost:8000
 HTTP 200
 Content-Type: application/json
 
-GET {{base_url}}/standard
+GET {{base_url}}/standard_railway_text_stations_low
 Referer: http://localhost:8000
 HTTP 200
 Content-Type: application/json
 
-GET {{base_url}}/speed
+GET {{base_url}}/standard_railway_text_stations_med
 Referer: http://localhost:8000
 HTTP 200
 Content-Type: application/json
 
-GET {{base_url}}/signals
+GET {{base_url}}/standard_railway_turntables,standard_railway_text_stations,standard_railway_grouped_stations,standard_railway_symbols,standard_railway_switch_ref,standard_station_entrances
 Referer: http://localhost:8000
 HTTP 200
 Content-Type: application/json
 
-GET {{base_url}}/electrification
+GET {{base_url}}/speed_railway_signals
+Referer: http://localhost:8000
+HTTP 200
+Content-Type: application/json
+
+GET {{base_url}}/signals_railway_signals,signals_signal_boxes
+Referer: http://localhost:8000
+HTTP 200
+Content-Type: application/json
+
+GET {{base_url}}/electrification_signals,catenary,electrification_railway_symbols
+Referer: http://localhost:8000
+HTTP 200
+Content-Type: application/json
+
+GET {{base_url}}/operator_railway_symbols
 Referer: http://localhost:8000
 HTTP 200
 Content-Type: application/json
 
 # (local URLs)
-GET {{base_url}}/signals_railway_signals/14/8803/5371
+GET {{base_url}}/signals_railway_signals,signals_signal_boxes/14/8803/5371
 Referer: http://localhost:8000
 HTTP 200
 Content-Type: application/x-protobuf
 
-GET {{base_url}}/signals_railway_signals/18/140807/85974
+GET {{base_url}}/signals_railway_signals,signals_signal_boxes/18/140807/85974
 Referer: http://localhost:8000
 HTTP 204
 


### PR DESCRIPTION
Path rewriting for source URLs is no longer needed because everything runs in Docker with the same proxying rules. No tiles with different URLs.