### PR TITLE
Do not render a large Blockkennzeichen when on top of other signals

### DIFF
--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -3013,7 +3013,12 @@ const layers = Object.fromEntries(knownThemes.map(theme => [theme, {
       imageLayerWithOutline(
         theme,
         `railway_signals_high_${featureIndex}`,
-        ['get', `feature${featureIndex}`],
+        featureIndex == 0
+          ? ['get', `feature${featureIndex}`]
+          : ['case',
+              ['==', ['slice', ['get', `feature${featureIndex}`], 0, 20], 'de/blockkennzeichen-'], 'de/blockkennzeichen',
+              ['get', `feature${featureIndex}`],
+            ],
         {
           type: 'symbol',
           minzoom: 16,


### PR DESCRIPTION
Part of #514

More custom handling of the Blockkennzeichen. 

We should consider removing this functionality entirely to simplify the style. Especially because the multiline-refs are parsed and stored and output specifically for the Blockkennzeichen, impacting general performance.

(http://localhost:8000/#view=18.79/50.0042855/8.5830457&style=signals)

Before:
<img width="768" height="750" alt="image" src="https://github.com/user-attachments/assets/96646d19-aa2c-4f84-9b87-cc366b6396ae" />

After:
<img width="842" height="479" alt="image" src="https://github.com/user-attachments/assets/46f1082a-a1f3-43dc-84b2-96f1e45c0d54" />
