### PR TITLE
German signals major rework

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -1590,665 +1590,43 @@ features:
 
   # --- DE --- #
 
-  - description: Shunting stop sign (Ra 10)
-    country: DE
-    icon: { default: 'de/ra10' }
-    tags:
-      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra10' }
-      - { tag: 'railway:signal:shunting:form', value: 'sign' }
+  # --- DE-ESO (regular railway) --- #
 
-  - description: Main signal invalid for shunting trains sign (Zs 103)
-    country: DE
-    icon: { default: 'de/zs103' }
-    tags:
-      - { tag: 'railway:signal:shunting', value: 'DE-ESO:zs103' }
-      - { tag: 'railway:signal:shunting:form', value: 'sign' }
-
-  - description: Wait sign (Ra 11)
-    country: DE
-    icon: { default: 'de/ra11-sign' }
-    tags:
-      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra11' }
-      - { tag: 'railway:signal:shunting:form', value: 'sign' }
-
-  - description: Wait sign with Sh 1 (Ra 11)
-    country: DE
-    icon: { default: 'de/ra11-sh1' }
-    tags:
-      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra11' }
-      - { tag: 'railway:signal:shunting:form', value: 'light' }
-
-  - description: Wait sign (Ra 11b)
-    country: DE
-    icon: { default: 'de/ra11b' }
-    tags:
-      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra11b' }
-      - { tag: 'railway:signal:shunting:form', value: 'sign' }
-
-  - description: Mandatory stop (Sh 1, Tram)
-    country: DE
-    icon: { default: 'de/bostrab/sh1' }
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-BOStrab:sh1' }
-      - { tag: 'railway:signal:minor:form', value: 'sign' }
-
-  - description: Shunting light signals (Sh)
+  - description: Main semaphore signals type Hp
     country: DE
     icon:
-      match: 'railway:signal:minor:height'
+      match: 'railway:signal:main:states'
       cases:
-        - { exact: 'normal', value: 'de/sh1-light-normal', description: 'normal height' }
-      default: 'de/sh0-light-dwarf'
+        - { exact: 'DE-ESO:hp2', value: 'de/hp2-semaphore' }
+        - { exact: 'DE-ESO:hp1', value: 'de/hp1-semaphore' }
+      default: 'de/hp0-semaphore'
     tags:
-      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh' }
-      - { tag: 'railway:signal:minor:form', value: 'light' }
+      - { tag: 'railway:signal:main', value: 'DE-ESO:hp' }
+      - { tag: 'railway:signal:main:form', value: 'semaphore' }
 
-  - description: Shunting light signals attached to main signals (Sh)
+  - description: Distant semaphore signals type Vr
     country: DE
     icon:
-      default: 'de/sh1-light-dwarf'
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh1' }
-      - { tag: 'railway:signal:minor:form', value: 'light' }
-
-  - description: Derailer state signal (Wn 7)
-    country: DE
-    icon: { default: 'de/wn7-semaphore-normal' }
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh' }
-      - { tag: 'railway:signal:minor:form', value: 'semaphore' }
-      - { tag: 'railway:signal:minor:states', all: ['DE-ESO:sh0', 'DE-ESO:wn7'] }
-
-  - description: Shunting semaphore signals (Sh)
-    country: DE
-    icon:
-      match: 'railway:signal:minor:height'
+      match: 'railway:signal:distant:states'
       cases:
-        - { exact: 'normal', value: 'de/sh1-semaphore-normal' }
-      default: 'de/sh0-semaphore-dwarf'
+        - { exact: 'DE-ESO:vr2', value: 'de/vr2-semaphore' }
+        - { exact: 'DE-ESO:vr1', value: 'de/vr1-semaphore' }
+      default: 'de/vr0-semaphore'
     tags:
-      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh' }
-      - { tag: 'railway:signal:minor:form', value: 'semaphore' }
+      - { tag: 'railway:signal:distant', value: 'DE-ESO:vr' }
+      - { tag: 'railway:signal:distant:form', value: 'semaphore' }
 
-  - description: Proceeding prohibition (at buffer stop) (Sh 0)
-    country: DE
-    icon: { default: 'de/sh0-sign' }
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh0' }
-      - { tag: 'railway:signal:minor:form', value: 'sign' }
-
-  - description: Protective stop (Sh 2)
-    country: DE
-    icon: { default: 'de/sh2' }
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh2' }
-      - { tag: 'railway:signal:minor:form', value: 'sign' }
-
-  - description: Protective stop (Sh 2, tram)
-    country: DE
-    icon: { default: 'de/bostrab/sh2' }
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-BOStrab:sh2' }
-      - { tag: 'railway:signal:minor:form', value: 'sign' }
-
-  - description: Emergency stop (Sh 3, Hamburger Hochbahn)
-    country: DE
-    icon: { default: 'de/hha/sh3' }
-    tags:
-      - { tag: 'railway:signal:minor', value: 'DE-HHA:sh3' }
-      - { tag: 'railway:signal:minor:form', value: 'light' }
-
-  - description: Start of train protection (So 1, tram)
-    country: DE
-    icon: { default: 'de/bostrab/so1' }
-    tags:
-      - { tag: 'railway:signal:train_protection', any: ['DE-BOStrab:so1', 'DE-AVG:so1'] }
-      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
-      - { tag: 'railway:signal:train_protection:type', value: 'start' }
-
-  - description: End of train protection (So 2, tram)
-    country: DE
-    icon: { default: 'de/bostrab/so2' }
-    tags:
-      - { tag: 'railway:signal:train_protection', any: ['DE-BOStrab:so2', 'DE-AVG:so2'] }
-      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
-      - { tag: 'railway:signal:train_protection:type', value: 'end' }
-
-  - description: ETCS stop marker (Ne 14)
+  - description: Main light signals type Hp
     country: DE
     icon:
-      match: 'railway:signal:position'
+      match: 'railway:signal:main:states'
       cases:
-        - { exact: 'left', value: 'de/ne14-right' }
-        - { exact: 'overhead', value: 'de/ne14-down' }
-      default: 'de/ne14-left'
+        - { exact: 'DE-ESO:hp2', value: 'de/hp2-light' }
+        - { exact: 'DE-ESO:hp1', value: 'de/hp1-light' }
+      default: 'de/hp0-light'
     tags:
-      - { tag: 'railway:signal:train_protection', value: 'DE-ESO:ne14' }
-      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
-      - { tag: 'railway:signal:train_protection:type', value: 'block_marker' }
-
-  - description: LZB section start (LZB-Bereichskennzeichen)
-    country: DE
-    icon: { default: 'de/lzb-section-start' }
-    tags:
-      - { tag: 'railway:signal:train_protection', value: 'DE-ESO:lzb-bereichskennzeichen' }
-      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
-
-  - description: ETCS/LZB block marker
-    country: DE
-    icon:
-      match: 'ref_multiline'
-      cases:
-        - { regex: '^([^\n]{4}\n[^\n]{1,4})|([^\n]{1,4}\n[^\n]{4})$', value: 'de/blockkennzeichen-4x2' }
-        - { regex: '^[^\n]{4}$', value: 'de/blockkennzeichen-4x1' }
-        - { regex: '^([^\n]{3}\n[^\n]{1,3})|([^\n]{1,3}\n[^\n]{3})$', value: 'de/blockkennzeichen-3x2' }
-        - { regex: '^[^\n]{3}$', value: 'de/blockkennzeichen-3x1' }
-        - { regex: '^([^\n]{2}\n[^\n]{1,2})|([^\n]{1,2}\n[^\n]{2})$', value: 'de/blockkennzeichen-2x2' }
-        - { regex: '^[^\n]{2}$', value: 'de/blockkennzeichen-2x1' }
-        - { regex: '^[^\n]\n[^\n]$', value: 'de/blockkennzeichen-1x2' }
-        - { regex: '^[^\n]$', value: 'de/blockkennzeichen-1x1' }
-      default: 'de/blockkennzeichen'
-    tags:
-      - { tag: 'railway:signal:train_protection', value: 'DE-ESO:blockkennzeichen' }
-
-  - description: Entry signal halt indicator (Signalhaltmelder)
-    country: DE
-    icon: { default: 'de/zlb-haltmelder-light' }
-    tags:
-      - { tag: 'railway:signal:main_repeated', value: 'DE-DB:signalhaltmelder' }
-      - { tag: 'railway:signal:main_repeated:form', value: 'light' }
-
-  - description: Driving permission indicator (Fahrtanzeiger)
-    country: DE
-    icon: { default: 'de/fahrtanzeiger' }
-    tags:
-      - { tag: 'railway:signal:main_repeated', value: 'DE-ESO:fahrtanzeiger' }
-      - { tag: 'railway:signal:main_repeated:form', value: 'light' }
-
-  - description: Passing-by prohibited sign (So 5, tram)
-    country: DE
-    icon: { default: 'de/bostrab/so5' }
-    tags:
-      - { tag: 'railway:signal:passing', value: 'DE-BOStrab:so5' }
-      - { tag: 'railway:signal:passing:form', value: 'sign' }
-      - { tag: 'railway:signal:passing:type', value: 'no_passing' }
-
-  - description: Passing-by prohibited end sign (So 6, tram)
-    country: DE
-    icon: { default: 'de/bostrab/so6' }
-    tags:
-      - { tag: 'railway:signal:passing', value: 'DE-BOStrab:so6' }
-      - { tag: 'railway:signal:passing:form', value: 'sign' }
-      - { tag: 'railway:signal:passing:type', value: 'passing_allowed' }
-
-  - description: Stop demand board (Ne 5)
-    country: DE
-    icon: { default: 'de/ne5-light' }
-    tags:
-      - { tag: 'railway:signal:stop_demand', value: 'DE-ESO:ne5' }
-      - { tag: 'railway:signal:stop_demand:form', value: 'light' }
-
-  - description: Stop board (Ne 5)
-    country: DE
-    icon: { default: 'de/ne5-sign' }
-    tags:
-      - { tag: 'railway:signal:stop', value: 'DE-ESO:ne5' }
-      - { tag: 'railway:signal:stop:form', value: 'sign' }
-
-  - description: Stop board (Sh 7, tram)
-    country: DE
-    icon: { default: 'de/bostrab/sh7' }
-    tags:
-      - { tag: 'railway:signal:stop', value: 'DE-BOStrab:sh7' }
-      - { tag: 'railway:signal:stop:form', value: 'sign' }
-
-  - description: Halt/station anouncment sign (Ne 6)
-    country: DE
-    icon: { default: 'de/ne6' }
-    tags:
-      - { tag: 'railway:signal:station_distant', value: 'DE-ESO:ne6' }
-      - { tag: 'railway:signal:station_distant:form', value: 'sign' }
-
-  # TODO support variants of same feature
-  - description: Crossing (always) unsecured (Bü 0, sign, repeater)
-    country: DE
-    icon: { default: 'de/bue0-ds-repeated' }
-    tags:
-      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
-      - { tag: 'railway:signal:crossing:form', value: 'sign' }
-      - { tag: 'railway:signal:crossing:repeated' }
-
-  - description: Crossing (always) unsecured (Bü 0, sign)
-    country: DE
-    icon:
-      match: 'railway:signal:crossing:shortened'
-      cases:
-        - { value: 'de/bue0-ds-shortened', description: 'shortened' }
-      default: 'de/bue0-ds'
-    tags:
-      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
-      - { tag: 'railway:signal:crossing:form', value: 'sign' }
-
-  - description: Crossing unsecured/secured (repeater) (Bü 0/1)
-    country: DE
-    icon: { default: 'de/bue1-ds-repeated' }
-    tags:
-      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
-      - { tag: 'railway:signal:crossing:repeated' }
-
-  - description: Crossing unsecured/secured signal (Bü 0/1)
-    country: DE
-    icon:
-      match: 'railway:signal:crossing:shortened'
-      cases:
-        - { value: 'de/bue1-ds-shortened', description: 'shortened' }
-      default: 'de/bue1-ds'
-    tags:
-      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
-
-  - description: Crossing unsecured/secured signal (repeater) (So 16b/a)
-    country: DE
-    icon: { default: 'de/bue1-dv-repeated' }
-    tags:
-      - { tag: 'railway:signal:crossing', value: 'DE-ESO:so16' }
-      - { tag: 'railway:signal:crossing:form', value: 'light' }
-      - { tag: 'railway:signal:crossing:repeated' }
-
-  - description: Crossing unsecured/secured signal (So 16b/a)
-    country: DE
-    icon:
-      match: 'railway:signal:crossing:shortened'
-      cases:
-        - { value: 'de/bue1-dv-shortened', description: 'shortened' }
-      default: 'de/bue1-dv'
-    tags:
-      - { tag: 'railway:signal:crossing', value: 'DE-ESO:so16' }
-      - { tag: 'railway:signal:crossing:form', value: 'light' }
-
-  - description: Expect So16 crossing signal sign (So 15, DV 301)
-    country: DE
-    icon: { default: 'de/so15' }
-    tags:
-      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:so15' }
-      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
-
-  - description: Crossing switch-on location pole (So 14, DV 301)
-    country: DE
-    icon: { default: 'de/so14' }
-    tags:
-      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:so14' }
-      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
-
-  - description: Expect Bü 0/1 crossing signal (Bü 2)
-    country: DE
-    icon:
-      match: 'railway:signal:crossing_distant:shortened'
-      cases:
-        - { value: 'de/bue2-ds-reduced-distance', description: 'shortened' }
-      default: 'de/bue2-ds'
-    tags:
-      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:bü2' }
-      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
-
-  - description: Crossing switch-on location board (Bü 3)
-    country: DE
-    icon: { default: 'de/bue3' }
-    tags:
-      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:bü3' }
-      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
-
-  - description: Crossing unsecured/secured signal (Bü 0/1, tram)
-    country: DE
-    icon: { default: 'de/bostrab/bü' }
-    tags:
-      - { tag: 'railway:signal:crossing', value: 'DE-BOStrab:bü' }
-      - { tag: 'railway:signal:crossing:form', value: 'light' }
-
-  - description: Expect Bü 0/1 crossing signal (Bü 2, tram)
-    country: DE
-    icon: { default: 'de/bostrab/bü2' }
-    tags:
-      - { tag: 'railway:signal:crossing_distant', value: 'DE-BOStrab:bü2' }
-      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
-
-  - description: Whistle sign (Bü 4)
-    country: DE
-    icon:
-      match: 'railway:signal:whistle:only_transit'
-      cases:
-        - { value: 'de/bue4-ds-only-transit', description: 'only transit' }
-      default: 'de/bue4-ds'
-    tags:
-      - { tag: 'railway:signal:whistle', value: 'DE-ESO:db:bü4' }
-      - { tag: 'railway:signal:whistle:form', value: 'sign' }
-
-  - description: Whistle sign (Pf 1, DV 301)
-    country: DE
-    icon:
-      match: 'railway:signal:whistle:only_transit'
-      cases:
-        - { value: 'de/pf1-dv-only-transit', description: 'only transit' }
-      default: 'de/pf1-dv'
-    tags:
-      - { tag: 'railway:signal:whistle', value: 'DE-ESO:dr:pf1' }
-      - { tag: 'railway:signal:whistle:form', value: 'sign' }
-
-  - description: Whistle twice sign (Pf 2) (DV 301)
-    country: DE
-    icon:
-      default: 'de/pf2-dv'
-    tags:
-      - { tag: 'railway:signal:whistle', value: 'DE-ESO:dr:pf2' }
-      - { tag: 'railway:signal:whistle:form', value: 'sign' }
-
-  - description: Ring bell sign (Bü 5)
-    country: DE
-    icon:
-      match: 'railway:signal:ring:only_transit'
-      cases:
-        - { value: 'de/bue5-only-transit', description: 'only transit' }
-      default: 'de/bue5'
-    tags:
-      - { tag: 'railway:signal:ring', value: 'DE-ESO:bü5' }
-      - { tag: 'railway:signal:ring:form', value: 'sign' }
-
-  - description: Lift / Fold snowplow sign (Ne 7)
-    country: DE
-    icon:
-      match: 'railway:signal:snowplow:type'
-      cases:
-        - { exact: 'down', value: 'de/ne7-yellow-down' }
-      default: 'de/ne7-yellow-up'
-    tags:
-      - { tag: 'railway:signal:snowplow', value: 'DE-ESO:ne7' }
-      - { tag: 'railway:signal:snowplow:form', value: 'sign' }
-
-  - description: Resetting switch signal (Ne 13)
-    country: DE
-    icon: { default: 'de/ne13a' }
-    tags:
-      - { tag: 'railway:signal:resetting_switch', value: 'DE-ESO:ne13' }
-      - { tag: 'railway:signal:resetting_switch:form', value: 'light' }
-
-  - description: Expect and mind resetting switch signal (Ne 12)
-    country: DE
-    icon: { default: 'de/ne12' }
-    tags:
-      - { tag: 'railway:signal:resetting_switch_distant', value: 'DE-ESO:ne12' }
-      - { tag: 'railway:signal:resetting_switch_distant:form', value: 'sign' }
-
-  - description: Humping signal (Ra 6-9)
-    country: DE
-    icon: { default: 'de/ra7' }
-    tags:
-      - { tag: 'railway:signal:humping', value: 'DE-ESO:ra' }
-      - { tag: 'railway:signal:humping:form', value: 'light' }
-
-  - description: Ring bell sign (Sh 4, tram)
-    country: DE
-    icon: { default: 'de/bostrab/sh4' }
-    tags:
-      - { tag: 'railway:signal:ring', value: 'DE-BOStrab:sh4' }
-      - { tag: 'railway:signal:ring:form', value: 'sign' }
-
-  - description: Helper engine sign (Ts)
-    country: DE
-    icon: { default: 'de/ts1' }
-    tags:
-      - { tag: 'railway:signal:helper_engine', value: 'DE-ESO:ts' }
-      - { tag: 'railway:signal:helper_engine:form', value: 'sign' }
-
-  - description: Brake test signal (Zp 6-8)
-    country: DE
-    icon: { default: 'de/zp8' }
-    tags:
-      - { tag: 'railway:signal:brake_test', value: 'DE-ESO:zp' }
-      - { tag: 'railway:signal:brake_test:form', value: 'light' }
-
-  - description: Departure order / Close doors (Zp 9 / Zp 10)
-    country: DE
-    icon:
-      match: 'railway:signal:departure:states'
-      cases:
-        - { exact: 'DE-ESO:zp10', value: 'de/zp10-db' }
-      default: 'de/zp9-db'
-    tags:
-      - { tag: 'railway:signal:departure', value: 'DE-ESO:zp' }
-      - { tag: 'railway:signal:departure:form', value: 'light' }
-
-  - description: Close doors / Departure order (A1 / A2, tram)
-    country: DE
-    icon:
-      match: 'railway:signal:departure:states'
-      cases:
-        - { exact: 'DE-BOStrab:a2', value: 'de/bostrab/a2' }
-      default: 'de/bostrab/a1'
-    tags:
-      - { tag: 'railway:signal:departure', any: ['DE-BOStrab:a', 'DE-BOStrab:a1', 'DE-BOStrab:a2' ] }
-      - { tag: 'railway:signal:departure:form', value: 'light' }
-
-  - description: Crossing marking sign (Bü-Kennzeichentafel)
-    country: DE
-    icon: { default: 'de/bue-crossing-info' }
-    tags:
-      - { tag: 'railway:signal:crossing_info', value: 'DE-ESO:bü-kennzeichentafel' }
-      - { tag: 'railway:signal:crossing_info:form', value: 'sign' }
-
-  - description: Crossing anouncement sign (Bü-Ankündetafel)
-    country: DE
-    icon: { default: 'de/bue-crossing-hint' }
-    tags:
-      - { tag: 'railway:signal:crossing_hint', value: 'DE-ESO:bü-ankündetafel' }
-      - { tag: 'railway:signal:crossing_hint:form', value: 'sign' }
-
-  - description: Crossing signals (Bü 201, tram Karlsruhe / AVG)
-    country: DE
-    icon:
-      match: 'railway:signal:crossing_distant:states'
-      cases:
-        - { exact: 'DE-AVG:bü201v', value: 'de/avg/bue201v' }
-      default: 'de/avg/bue201'
-    tags:
-      - { tag: 'railway:signal:crossing_distant', value: 'DE-AVG:bü201' }
-      - { tag: 'railway:signal:crossing_distant:form', value: 'light' }
-
-  - description: AVG stop demand (Hw 1, tram Karlsruhe / AVG)
-    country: DE
-    icon: { default: 'de/avg/hw1' }
-    tags:
-      - { tag: 'railway:signal:stop_demand', value: 'DE-AVG:hw1' }
-      - { tag: 'railway:signal:stop_demand:form', value: 'light' }
-
-  - description: Opposite track sign (Zs 6)
-    country: DE
-    icon: { default: 'de/zs6-sign' }
-    tags:
-      - { tag: 'railway:signal:wrong_road', value: 'DE-ESO:db:zs6' }
-      - { tag: 'railway:signal:wrong_road:form', value: 'sign' }
-
-  - description: Opposite track signal (Zs 6)
-    country: DE
-    icon: { default: 'de/zs6-db-light' }
-    tags:
-      - { tag: 'railway:signal:wrong_road', value: 'DE-ESO:db:zs6' }
-      - { tag: 'railway:signal:wrong_road:form', value: 'light' }
-
-  - description: Opposite track signal (Zs 7, DV 301)
-    country: DE
-    icon: { default: 'de/zs7-dr-light' }
-    tags:
-      - { tag: 'railway:signal:wrong_road', value: 'DE-ESO:dr:zs7' }
-      - { tag: 'railway:signal:wrong_road:form', value: 'light' }
-
-  - description: Entry into dead-end sign (Zs 13 / Zs 6 DV 301)
-    country: DE
-    icon: { default: 'de/zs13-sign' }
-    tags:
-      - { tag: 'railway:signal:short_route', any: ['DE-ESO:zs13', 'DE-ESO:dr:zs6'] }
-      - { tag: 'railway:signal:short_route:form', value: 'sign' }
-
-  - description: Entry into dead-end signal (Zs 13 / Zs 6 DV 301)
-    country: DE
-    icon: { default: 'de/zs13-light' }
-    tags:
-      - { tag: 'railway:signal:short_route', any: ['DE-ESO:zs13', 'DE-ESO:dr:zs6'] }
-      - { tag: 'railway:signal:short_route:form', value: 'light' }
-
-  - description: Route pre-indicator (Zs 2v)
-    country: DE
-    icon:
-      match: 'railway:signal:route_distant:states'
-      cases:
-        - { regex: '^([A-ZÄÖÜẞ])$', value: 'de/zs2v-{}', example: 'de/zs2v-{ẞ}' }
-      default: 'de/zs2v-unknown'
-    tags:
-      - { tag: 'railway:signal:route_distant', value: 'DE-ESO:zs2v' }
-      - { tag: 'railway:signal:route_distant:form', value: 'light' }
-
-  - description: Speed limit through switches sign (distant) (Zs 3v)
-    country: DE
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^(1[0-6]|[1-9])0$', value: 'de/zs3v-sign-down-{}', example: 'de/zs3v-sign-down-{60}' }
-      default: 'de/zs3v-empty-sign-down'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:zs3v' }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
-
-  - description: Speed limit through switches signal (distant) (Zs 3v)
-    country: DE
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^([1-9]|1[0-6]|20)0$', value: 'de/zs3v-light-{}', example: 'de/zs3v-light-{20}' }
-      default: 'de/zs3v-light-unknown'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:zs3v' }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'light' }
-
-  - description: Expect speed restriction (on branch lines) (Lf 4, DS 301)
-    country: DE
-    type: line
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^([2-8]0|1?[05])$', value: 'de/lf4-ds301-sign-down-{}', example: 'de/lf4-ds301-sign-down-{80}' }
-      default: 'de/lf4-ds301-empty-sign-down'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:db:lf4' }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
-
-  - description: Speed sign (Lf 4, DV 301)
-    country: DE
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^(100|[2-8]0|1?[05])$', value: 'de/lf4-dr-sign-down-{}', example: 'de/lf4-dr-sign-down-{70}' }
-      default: 'de/lf4-dr-sign-down-empty'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:dr:lf4' }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
-
-  - description: Expect new line speed sign (Lf 6)
-    country: DE
-    type: line
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^((1[0-9]|[1-9])0|5|15)$', value: 'de/lf6-sign-down-{}', example: 'de/lf6-sign-down-{30}' }
-      default: 'de/lf6-empty-sign-down'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:lf6' }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
-
-  - description: Expect temporary speed restriction sign (Lf 1)
-    country: DE
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^(5|15|[1-9]0|1[0-9]0|200)$', value: 'de/lf1-sign-down-{}', example: 'de/lf1-sign-down-{200}' }
-      default: 'de/lf1-empty-sign-down'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:lf1' }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
-
-  - description: Hamburger Hochbahn L1
-    country: DE
-    type: line
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^([3-7]0)$', value: 'de/hha/l1-sign-{}', example: 'de/hha/l1-sign-{70}' }
-      default: 'de/hha/l1-empty-sign'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-HHA:l1' }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
-
-  - description: Tram distance speed limit (G 1a) (sign)
-    country: DE
-    type: tram
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^(5|[1-7][0-5])$', value: 'de/bostrab/g1a-{}', example: 'de/bostrab/g1a-{40}' }
-      default: 'de/bostrab/g1a-empty'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', any: ['DE-BOStrab:g1', 'DE-BOStrab:g1a', 'DE-BSVG:g1a'] }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
-
-  - description: Tram distance speed limit (G 1b) (light)
-    country: DE
-    type: tram
-    icon:
-      match: 'railway:signal:speed_limit_distant:speed'
-      cases:
-        - { regex: '^[1-7]0$', value: 'de/bostrab/g1b-{}', example: 'de/bostrab/g1b-{40}' }
-      default: 'de/bostrab/g1b-empty'
-    tags:
-      - { tag: 'railway:signal:speed_limit_distant', any: ['DE-BOStrab:g1', 'DE-BOStrab:g1b'] }
-      - { tag: 'railway:signal:speed_limit_distant:form', value: 'light' }
-
-  - description: Distant signal announcement signs (Ne 3, normal)
-    country: DE
-    icon:
-      match: 'railway:signal:distant:type'
-      cases:
-        - { exact: 'II', value: 'de/ne3-normal-II' }
-        - { exact: 'III', value: 'de/ne3-normal-III' }
-        - { exact: 'IV', value: 'de/ne3-normal-IV' }
-      default: 'de/ne3-normal-I'
-    tags:
-      - { tag: 'railway:signal:distant', value: 'DE-ESO:ne3' }
-      - { tag: 'railway:signal:distant:form', value: 'sign' }
-
-  - description: Distant signal announcement signs (Ne 3, dwarf)
-    country: DE
-    icon:
-      match: 'railway:signal:distant:type'
-      cases:
-        - { exact: 'II', value: 'de/ne3-dwarf-II' }
-        - { exact: 'III', value: 'de/ne3-dwarf-III' }
-        - { exact: 'IV', value: 'de/ne3-dwarf-IV' }
-      default: 'de/ne3-dwarf-I'
-    tags:
-      - { tag: 'railway:signal:distant', value: 'DE-ESO:ne3' }
-      - { tag: 'railway:signal:distant:form', value: 'sign' }
-      - { tag: 'railway:signal:distant:height', value: 'dwarf' }
-
-  - description: Hamburger Hochbahn distant signal
-    country: DE
-    icon: { default: 'de/hha/v1' }
-    tags:
-      - { tag: 'railway:signal:distant', value: 'DE-HHA:v' }
-      - { tag: 'railway:signal:distant:form', value: 'light' }
-
-  - description: Distant signal stand-in sign (So 106, DV 301)
-    country: DE
-    icon: { default: 'de/so106' }
-    tags:
-      - { tag: 'railway:signal:distant', value: 'DE-ESO:so106' }
-      - { tag: 'railway:signal:distant:form', value: 'sign' }
+      - { tag: 'railway:signal:main', value: 'DE-ESO:hp' }
+      - { tag: 'railway:signal:main:form', value: 'light' }
 
   - description: Distant light signals type Vr (repeated)
     country: DE
@@ -2288,89 +1666,30 @@ features:
       - { tag: 'railway:signal:distant', value: 'DE-ESO:vr' }
       - { tag: 'railway:signal:distant:form', value: 'light' }
 
-  - description: Distant semaphore signals type Vr
+  - description: Main signals type Ks
+    country: DE
+    icon: { default: 'de/ks-main' }
+    tags:
+      - { tag: 'railway:signal:main', value: 'DE-ESO:ks' }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+
+  - description: Combined signals type Ks
     country: DE
     icon:
-      match: 'railway:signal:distant:states'
+      match: 'railway:signal:combined:shortened'
       cases:
-        - { exact: 'DE-ESO:vr2', value: 'de/vr2-semaphore' }
-        - { exact: 'DE-ESO:vr1', value: 'de/vr1-semaphore' }
-      default: 'de/vr0-semaphore'
+        - { value: 'de/ks-combined-shortened' }
+      default: 'de/ks-combined'
     tags:
-      - { tag: 'railway:signal:distant', value: 'DE-ESO:vr' }
-      - { tag: 'railway:signal:distant:form', value: 'semaphore' }
+      - { tag: 'railway:signal:combined', value: 'DE-ESO:ks' }
+      - { tag: 'railway:signal:combined:form', value: 'light' }
 
-  - description: Distant signal stand-in sign (Ne 2)
+  - description: Distant signals type Ks
     country: DE
-    icon:
-      match: 'railway:signal:distant:shortened'
-      cases:
-        - { value: 'de/ne2-reduced-distance' }
-      default: 'de/ne2'
-    tags:
-      - { tag: 'railway:signal:distant', value: 'DE-ESO:db:ne2' }
-      - { tag: 'railway:signal:distant:form', value: 'sign' }
-
-  - description: Distant signal stand-in sign shortened (So 3, DV 301)
-    country: DE
-    icon: { default: 'de/ne2-dv301-reduced-distance' }
-    tags:
-      - { tag: 'railway:signal:distant', value: 'DE-ESO:dr:so3' }
-      - { tag: 'railway:signal:distant:form', value: 'sign' }
-      - { tag: 'railway:signal:distant:shortened' }
-
-  - description: Distant light signals type Hl
-    country: DE
-    icon:
-      match: 'railway:signal:distant:repeated'
-      cases:
-        - { value: 'de/hl1-distant-repeated' }
-      default: 'de/hl1-distant'
-    tags:
-      - { tag: 'railway:signal:distant', value: 'DE-ESO:hl' }
-      - { tag: 'railway:signal:distant:form', value: 'light' }
-
-  - description: Karlsruhe VBK Vorsignale (light)
-    country: DE
-    icon:
-      match: 'railway:signal:distant:states'
-      cases:
-        - { exact: 'DE-VBK:fv2', value: 'de/vbk/fv2' }
-        - { exact: 'DE-VBK:fv3', value: 'de/vbk/fv3' }
-      default: 'de/vbk/fv1'
-    tags:
-      - { tag: 'railway:signal:distant', value: 'DE-VBK:fv' }
-      - { tag: 'railway:signal:distant:form', value: 'light' }
-
-  - description: Karlsruhe VBK Vorsignale (sign)
-    country: DE
-    icon: { default: 'de/vbk/fv0' }
-    tags:
-      - { tag: 'railway:signal:distant', any: ['DE-VBK:fv', 'DE-VBK:fv0'] }
-      - { tag: 'railway:signal:distant:form', value: 'sign' }
-
-  - description: BOStrab distant signal (V)
-    country: DE
-    icon:
-      match: 'railway:signal:distant:states'
-      cases:
-        - { exact: 'DE-BOStrab:v2', value: 'de/bostrab/v2'}
-        - { exact: 'DE-BOStrab:v1', value: 'de/bostrab/v1'}
-        - { exact: 'DE-VAGN:vr2', value: 'de/vag-nuremberg/vr2'}
-        - { exact: 'DE-VAGN:vr1', value: 'de/vag-nuremberg/vr1'}
-        - { exact: 'DE-VAGN:vr0', value: 'de/vag-nuremberg/vr0'}
-      default: 'de/bostrab/v0'
-    tags:
-      - { tag: 'railway:signal:distant', value: 'DE-BOStrab:v' }
-      - { tag: 'railway:signal:distant:form', value: 'light' }
-
-  - description: Distant signals type Ks (repeated)
-    country: DE
-    icon: { default: 'de/ks-distant-repeated' }
+    icon: { default: 'de/ks-distant' }
     tags:
       - { tag: 'railway:signal:distant', value: 'DE-ESO:ks' }
       - { tag: 'railway:signal:distant:form', value: 'light' }
-      - { tag: 'railway:signal:distant:repeated' }
 
   - description: Distant signals type Ks (shortened)
     country: DE
@@ -2380,43 +1699,13 @@ features:
       - { tag: 'railway:signal:distant:form', value: 'light' }
       - { tag: 'railway:signal:distant:shortened' }
 
-  - description: Distant signals type Ks
+  - description: Distant signals type Ks (repeated)
     country: DE
-    icon: { default: 'de/ks-distant' }
+    icon: { default: 'de/ks-distant-repeated' }
     tags:
       - { tag: 'railway:signal:distant', value: 'DE-ESO:ks' }
       - { tag: 'railway:signal:distant:form', value: 'light' }
-
-  - description: Main signal stand-in sign (Ne 1)
-    country: DE
-    icon: { default: 'de/ne1' }
-    tags:
-      - { tag: 'railway:signal:main', value: 'DE-ESO:ne1' }
-      - { tag: 'railway:signal:main:form', value: 'sign' }
-
-  - description: Main semaphore signals type Hp
-    country: DE
-    icon:
-      match: 'railway:signal:main:states'
-      cases:
-        - { exact: 'DE-ESO:hp2', value: 'de/hp2-semaphore' }
-        - { exact: 'DE-ESO:hp1', value: 'de/hp1-semaphore' }
-      default: 'de/hp0-semaphore'
-    tags:
-      - { tag: 'railway:signal:main', value: 'DE-ESO:hp' }
-      - { tag: 'railway:signal:main:form', value: 'semaphore' }
-
-  - description: Main light signals type Hp
-    country: DE
-    icon:
-      match: 'railway:signal:main:states'
-      cases:
-        - { exact: 'DE-ESO:hp2', value: 'de/hp2-light' }
-        - { exact: 'DE-ESO:hp1', value: 'de/hp1-light' }
-      default: 'de/hp0-light'
-    tags:
-      - { tag: 'railway:signal:main', value: 'DE-ESO:hp' }
-      - { tag: 'railway:signal:main:form', value: 'light' }
+      - { tag: 'railway:signal:distant:repeated' }
 
   - description: Main light signals type Hl
     country: DE
@@ -2430,70 +1719,6 @@ features:
       default: 'de/hl0-main'
     tags:
       - { tag: 'railway:signal:main', value: 'DE-ESO:hl' }
-      - { tag: 'railway:signal:main:form', value: 'light' }
-
-  - description: Proceed signal with registration (F1-5 + A, tram)
-    country: DE
-    icon:
-      match: 'railway:signal:main:states'
-      cases:
-        - { any: ['DE-AVG:f5', 'DE-BOStrab:f5'], value: 'de/bostrab/f5-st9' }
-        - { any: ['DE-AVG:f3', 'DE-BOStrab:f3'], value: 'de/bostrab/f3-st9' }
-        - { any: ['DE-AVG:f2', 'DE-BOStrab:f2'], value: 'de/bostrab/f2-st9' }
-        - { any: ['DE-AVG:f1', 'DE-BOStrab:f1'], value: 'de/bostrab/f1-st9' }
-      default: 'de/bostrab/f0-st9'
-    tags:
-      - { tag: 'railway:signal:main', any: ['DE-AVG:f', 'DE-BOStrab:f'] }
-      - { tag: 'railway:signal:main:form', value: 'light' }
-      - { tag: 'railway:signal:main:PT_priority', value: 'requested;off' }
-
-  - description: Proceed signal (F1-5, tram)
-    country: DE
-    icon:
-      match: 'railway:signal:main:states'
-      cases:
-        - { any: ['DE-AVG:f5', 'DE-BOStrab:f5'], value: 'de/bostrab/f5' }
-        - { any: ['DE-AVG:f3', 'DE-BOStrab:f3'], value: 'de/bostrab/f3' }
-        - { any: ['DE-AVG:f2', 'DE-BOStrab:f2'], value: 'de/bostrab/f2' }
-        - { any: ['DE-AVG:f1', 'DE-BOStrab:f1'], value: 'de/bostrab/f1' }
-      default: 'de/bostrab/f0'
-    tags:
-      - { tag: 'railway:signal:main', any: ['DE-AVG:f', 'DE-BOStrab:f'] }
-      - { tag: 'railway:signal:main:form', value: 'light' }
-
-  - description: BOStrab main signal
-    country: DE
-    icon:
-      match: 'railway:signal:main:states'
-      cases:
-        - { exact: 'DE-BOStrab:h2', value: 'de/bostrab/h2' }
-        - { exact: 'DE-BOStrab:h1', value: 'de/bostrab/h1' }
-        - { exact: 'DE-VAGN:hp2', value: 'de/vag-nuremberg/hp2' }
-        - { exact: 'DE-VAGN:hp1', value: 'de/vag-nuremberg/hp1' }
-        - { all: ['DE-VAGN:hp0', 'off'], value: 'de/vag-nuremberg/off' }
-        - { exact: 'DE-VAGN:hp3', value: 'de/vag-nuremberg/hp3' }
-        - { exact: 'DE-VAGN:hp0', value: 'de/vag-nuremberg/hp0' }
-      default: 'de/bostrab/h0'
-    tags:
-      - { tag: 'railway:signal:main', value: 'DE-BOStrab:h' }
-      - { tag: 'railway:signal:main:form', value: 'light' }
-
-  - description: Hamburger Hochbahn main signal
-    country: DE
-    icon:
-      match: 'railway:signal:main:states'
-      cases:
-        - { exact: 'DE-HHA:h1', value: 'de/hha/h1' }
-      default: 'de/hha/h0'
-    tags:
-      - { tag: 'railway:signal:main', value: 'DE-HHA:h' }
-      - { tag: 'railway:signal:main:form', value: 'light' }
-
-  - description: Main signals type Ks
-    country: DE
-    icon: { default: 'de/ks-main' }
-    tags:
-      - { tag: 'railway:signal:main', value: 'DE-ESO:ks' }
       - { tag: 'railway:signal:main:form', value: 'light' }
 
   - description: Combined light signals type Hl
@@ -2510,6 +1735,17 @@ features:
       - { tag: 'railway:signal:combined', value: 'DE-ESO:hl' }
       - { tag: 'railway:signal:combined:form', value: 'light' }
 
+  - description: Distant light signals type Hl
+    country: DE
+    icon:
+      match: 'railway:signal:distant:repeated'
+      cases:
+        - { value: 'de/hl1-distant-repeated' }
+      default: 'de/hl1-distant'
+    tags:
+      - { tag: 'railway:signal:distant', value: 'DE-ESO:hl' }
+      - { tag: 'railway:signal:distant:form', value: 'light' }
+
   - description: Combined light signals type Sv
     country: DE
     icon:
@@ -2522,23 +1758,27 @@ features:
       - { tag: 'railway:signal:combined', value: 'DE-ESO:sv' }
       - { tag: 'railway:signal:combined:form', value: 'light' }
 
-  - description: BOStrab combined signals
-    country: DE
-    icon: { default: 'de/bostrab/h' }
-    tags:
-      - { tag: 'railway:signal:combined', value: 'DE-BOStrab:h' }
-      - { tag: 'railway:signal:combined:form', value: 'light' }
-
-  - description: Combined signals type Ks
+  - description: Route indicator (Zs 2)
     country: DE
     icon:
-      match: 'railway:signal:combined:shortened'
+      match: 'railway:signal:route:states'
       cases:
-        - { value: 'de/ks-combined-shortened' }
-      default: 'de/ks-combined'
+        - { regex: '^([A-ZÄÖÜẞ])$', value: 'de/zs2-{}', example: 'de/zs2-{ẞ}' }
+      default: 'de/zs2-unknown'
     tags:
-      - { tag: 'railway:signal:combined', value: 'DE-ESO:ks' }
-      - { tag: 'railway:signal:combined:form', value: 'light' }
+      - { tag: 'railway:signal:route', value: 'DE-ESO:zs2' }
+      - { tag: 'railway:signal:route:form', value: 'light' }
+
+  - description: Route pre-indicator (Zs 2v)
+    country: DE
+    icon:
+      match: 'railway:signal:route_distant:states'
+      cases:
+        - { regex: '^([A-ZÄÖÜẞ])$', value: 'de/zs2v-{}', example: 'de/zs2v-{ẞ}' }
+      default: 'de/zs2v-unknown'
+    tags:
+      - { tag: 'railway:signal:route_distant', value: 'DE-ESO:zs2v' }
+      - { tag: 'railway:signal:route_distant:form', value: 'light' }
 
   - description: Speed limit through switches sign (Zs 3)
     country: DE
@@ -2562,97 +1802,101 @@ features:
       - { tag: 'railway:signal:speed_limit', value: 'DE-ESO:zs3' }
       - { tag: 'railway:signal:speed_limit:form', value: 'light' }
 
-  - description: Speed limit sign (G2a, tram)
+  - description: Speed limit through switches sign (distant) (Zs 3v)
     country: DE
-    type: tram
     icon:
-      match: 'railway:signal:speed_limit:speed'
+      match: 'railway:signal:speed_limit_distant:speed'
       cases:
-        - { regex: '^(5|[1-7][05])$', value: 'de/bostrab/g2a-{}', example: 'de/bostrab/g2a-{40}' }
-      default: 'de/bostrab/g2a-empty'
+        - { regex: '^(1[0-6]|[1-9])0$', value: 'de/zs3v-sign-down-{}', example: 'de/zs3v-sign-down-{60}' }
+      default: 'de/zs3v-empty-sign-down'
     tags:
-      - { tag: 'railway:signal:speed_limit', any: ['DE-BOStrab:g2', 'DE-BOStrab:g2a', 'DE-BSVG:g2a'] }
+      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:zs3v' }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
+
+  - description: Speed limit through switches signal (distant) (Zs 3v)
+    country: DE
+    icon:
+      match: 'railway:signal:speed_limit_distant:speed'
+      cases:
+        - { regex: '^([1-9]|1[0-6]|20)0$', value: 'de/zs3v-light-{}', example: 'de/zs3v-light-{20}' }
+      default: 'de/zs3v-light-unknown'
+    tags:
+      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:zs3v' }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'light' }
+
+  - description: Opposite track sign (Zs 6)
+    country: DE
+    icon: { default: 'de/zs6-sign' }
+    tags:
+      - { tag: 'railway:signal:wrong_road', value: 'DE-ESO:db:zs6' }
+      - { tag: 'railway:signal:wrong_road:form', value: 'sign' }
+
+  - description: Opposite track signal (Zs 6)
+    country: DE
+    icon: { default: 'de/zs6-db-light' }
+    tags:
+      - { tag: 'railway:signal:wrong_road', value: 'DE-ESO:db:zs6' }
+      - { tag: 'railway:signal:wrong_road:form', value: 'light' }
+
+  - description: Opposite track signal (Zs 7, DV 301)
+    country: DE
+    icon: { default: 'de/zs7-dr-light' }
+    tags:
+      - { tag: 'railway:signal:wrong_road', value: 'DE-ESO:dr:zs7' }
+      - { tag: 'railway:signal:wrong_road:form', value: 'light' }
+
+  - description: End of speed limit through switches sign (Zs 10)
+    country: DE
+    icon: { default: 'de/zs10-sign' }
+    tags:
+      - { tag: 'railway:signal:speed_limit', value: 'DE-ESO:db:zs10' }
       - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
 
-  - description: Speed limit signal (G2b, tram)
+  - description: End of speed limit through switches signal (Zs 10)
     country: DE
-    type: tram
-    icon:
-      match: 'railway:signal:speed_limit:speed'
-      cases:
-        - { regex: '^[1-7]0$', value: 'de/bostrab/g2b-{}', example: 'de/bostrab/g2b-{40}' }
-      default: 'de/bostrab/g2b-empty'
+    icon: { default: 'de/zs10-light' }
     tags:
-      - { tag: 'railway:signal:speed_limit', any: ['DE-BOStrab:g2', 'DE-BOStrab:g2b'] }
+      - { tag: 'railway:signal:speed_limit', value: 'DE-ESO:db:zs10' }
       - { tag: 'railway:signal:speed_limit:form', value: 'light' }
 
-  - description: End of speed limit sign (G3, tram)
+  - description: Entry into dead-end sign (Zs 13 / Zs 6 DV 301)
     country: DE
-    type: tram
-    icon: { default: 'de/bostrab/g3' }
+    icon: { default: 'de/zs13-sign' }
     tags:
-      - { tag: 'railway:signal:speed_limit', value: 'DE-BOStrab:g3' }
-      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
+      - { tag: 'railway:signal:short_route', any: ['DE-ESO:zs13', 'DE-ESO:dr:zs6'] }
+      - { tag: 'railway:signal:short_route:form', value: 'sign' }
 
-  - description: Speed limit increase sign (G4, tram)
+  - description: Entry into dead-end signal (Zs 13 / Zs 6 DV 301)
     country: DE
-    type: tram
+    icon: { default: 'de/zs13-light' }
+    tags:
+      - { tag: 'railway:signal:short_route', any: ['DE-ESO:zs13', 'DE-ESO:dr:zs6'] }
+      - { tag: 'railway:signal:short_route:form', value: 'light' }
+
+  - description: Main signal invalid for shunting trains sign (Zs 103)
+    country: DE
+    icon: { default: 'de/zs103' }
+    tags:
+      - { tag: 'railway:signal:shunting', value: 'DE-ESO:zs103' }
+      - { tag: 'railway:signal:shunting:form', value: 'sign' }
+
+  - description: Helper engine sign (Ts)
+    country: DE
+    icon: { default: 'de/ts1' }
+    tags:
+      - { tag: 'railway:signal:helper_engine', value: 'DE-ESO:ts' }
+      - { tag: 'railway:signal:helper_engine:form', value: 'sign' }
+
+  - description: Expect temporary speed restriction sign (Lf 1)
+    country: DE
     icon:
-      match: 'railway:signal:speed_limit:speed'
+      match: 'railway:signal:speed_limit_distant:speed'
       cases:
-        - { regex: '^(100|[2-9]0|[235]5)$', value: 'de/bostrab/g4-{}', example: 'de/bostrab/g4-{40}' }
-      default: 'de/bostrab/g4-empty'
+        - { regex: '^(5|15|[1-9]0|1[0-9]0|200)$', value: 'de/lf1-sign-down-{}', example: 'de/lf1-sign-down-{200}' }
+      default: 'de/lf1-empty-sign-down'
     tags:
-      - { tag: 'railway:signal:speed_limit', value: 'DE-BOStrab:g4' }
-      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
-
-  - description: Hannover tram speed limit G5
-    country: DE
-    type: tram
-    icon:
-      match: 'railway:signal:speed_limit:speed'
-      cases:
-        - { regex: '^(5|[1-6][05])$', value: 'de/bostrab/g5-{}', example: 'de/bostrab/g5-{40}' }
-      default: 'de/bostrab/g5-empty'
-    tags:
-      - { tag: 'railway:signal:speed_limit', value: 'DE-UESTRA:g5' }
-      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
-
-  - description: Start of speed restriction (Lf 5, DV 301)
-    country: DE
-    type: line
-    icon: { default: 'de/lf5-dv301-sign' }
-    tags:
-      - { tag: 'railway:signal:speed_limit', value: 'DE-ESO:dr:lf5' }
-      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
-
-  - description:  Start of speed restriction (Lf 5, DS 301)
-    country: DE
-    type: line
-    icon: { default: 'de/lf5-ds301-sign' }
-    tags:
-      - { tag: 'railway:signal:speed_limit', value: 'DE-ESO:db:lf5' }
-      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
-
-  - description: Line speed sign (Lf 7)
-    country: DE
-    type: line
-    icon:
-      match: 'railway:signal:speed_limit:speed'
-      cases:
-        - { regex: '^(5|15|[1-9]0|1[0-9]0|200)$', value: 'de/lf7-sign-{}', example: 'de/lf7-sign-{180}' }
-      default: 'de/lf7-empty-sign'
-    tags:
-      - { tag: 'railway:signal:speed_limit', value: 'DE-ESO:lf7' }
-      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
-
-  - description: Hamburger Hochbahn L4
-    country: DE
-    type: line
-    icon: { default: 'de/hha/l4' }
-    tags:
-      - { tag: 'railway:signal:speed_limit', value: 'DE-HHA:l4' }
-      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
+      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:lf1' }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
 
   - description: Start of temporary speed restriction (Lf 2)
     country: DE
@@ -2679,30 +1923,173 @@ features:
       - { tag: 'railway:signal:speed_limit', value: 'DE-ESO:lf3' }
       - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
 
-  - description: End of speed limit through switches sign (Zs 10)
+  - description: Expect speed restriction (on branch lines) (Lf 4, DS 301)
     country: DE
-    icon: { default: 'de/zs10-sign' }
+    type: line
+    icon:
+      match: 'railway:signal:speed_limit_distant:speed'
+      cases:
+        - { regex: '^([2-8]0|1?[05])$', value: 'de/lf4-ds301-sign-down-{}', example: 'de/lf4-ds301-sign-down-{80}' }
+      default: 'de/lf4-ds301-empty-sign-down'
     tags:
-      - { tag: 'railway:signal:speed_limit', value: 'DE-ESO:db:zs10' }
-      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
+      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:db:lf4' }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
 
-  - description: End of speed limit through switches signal (Zs 10)
-    country: DE
-    icon: { default: 'de/zs10-light' }
-    tags:
-      - { tag: 'railway:signal:speed_limit', value: 'DE-ESO:db:zs10' }
-      - { tag: 'railway:signal:speed_limit:form', value: 'light' }
-
-  - description: Route indicator (Zs 2)
+  - description: Speed sign (Lf 4, DV 301)
     country: DE
     icon:
-      match: 'railway:signal:route:states'
+      match: 'railway:signal:speed_limit_distant:speed'
       cases:
-        - { regex: '^([A-ZÄÖÜẞ])$', value: 'de/zs2-{}', example: 'de/zs2-{ẞ}' }
-      default: 'de/zs2-unknown'
+        - { regex: '^(100|[2-8]0|1?[05])$', value: 'de/lf4-dr-sign-down-{}', example: 'de/lf4-dr-sign-down-{70}' }
+      default: 'de/lf4-dr-sign-down-empty'
     tags:
-      - { tag: 'railway:signal:route', value: 'DE-ESO:zs2' }
-      - { tag: 'railway:signal:route:form', value: 'light' }
+      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:dr:lf4' }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
+
+  - description: Start of speed restriction (Lf 5, DV 301)
+    country: DE
+    type: line
+    icon: { default: 'de/lf5-dv301-sign' }
+    tags:
+      - { tag: 'railway:signal:speed_limit', value: 'DE-ESO:dr:lf5' }
+      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
+
+  - description:  Start of speed restriction (Lf 5, DS 301)
+    country: DE
+    type: line
+    icon: { default: 'de/lf5-ds301-sign' }
+    tags:
+      - { tag: 'railway:signal:speed_limit', value: 'DE-ESO:db:lf5' }
+      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
+
+  - description: Expect new line speed sign (Lf 6)
+    country: DE
+    type: line
+    icon:
+      match: 'railway:signal:speed_limit_distant:speed'
+      cases:
+        - { regex: '^((1[0-9]|[1-9])0|5|15)$', value: 'de/lf6-sign-down-{}', example: 'de/lf6-sign-down-{30}' }
+      default: 'de/lf6-empty-sign-down'
+    tags:
+      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-ESO:lf6' }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
+
+  - description: Line speed sign (Lf 7)
+    country: DE
+    type: line
+    icon:
+      match: 'railway:signal:speed_limit:speed'
+      cases:
+        - { regex: '^(5|15|[1-9]0|1[0-9]0|200)$', value: 'de/lf7-sign-{}', example: 'de/lf7-sign-{180}' }
+      default: 'de/lf7-empty-sign'
+    tags:
+      - { tag: 'railway:signal:speed_limit', value: 'DE-ESO:lf7' }
+      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
+
+  - description: Shunting light signals (dwarf) (Sh)
+    country: DE
+    icon:
+      match: 'railway:signal:minor:height'
+      cases:
+        - { exact: 'normal', value: 'de/sh1-light-normal', description: 'normal height' }
+      default: 'de/sh0-light-dwarf'
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh' }
+      - { tag: 'railway:signal:minor:form', value: 'light' }
+
+  - description: Shunting light signals attached to main signals (Sh)
+    country: DE
+    icon:
+      default: 'de/sh1-light-dwarf'
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh1' }
+      - { tag: 'railway:signal:minor:form', value: 'light' }
+
+  - description: Shunting semaphore signals (Sh)
+    country: DE
+    icon:
+      match: 'railway:signal:minor:height'
+      cases:
+        - { exact: 'normal', value: 'de/sh1-semaphore-normal' }
+      default: 'de/sh0-semaphore-dwarf'
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh' }
+      - { tag: 'railway:signal:minor:form', value: 'semaphore' }
+
+  - description: Proceeding prohibition (at buffer stop) (Sh 0)
+    country: DE
+    icon: { default: 'de/sh0-sign' }
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh0' }
+      - { tag: 'railway:signal:minor:form', value: 'sign' }
+
+  - description: Protective stop (Sh 2)
+    country: DE
+    icon: { default: 'de/sh2' }
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh2' }
+      - { tag: 'railway:signal:minor:form', value: 'sign' }
+
+  - description: Humping signal (Ra 6-9)
+    country: DE
+    icon: { default: 'de/ra7' }
+    tags:
+      - { tag: 'railway:signal:humping', value: 'DE-ESO:ra' }
+      - { tag: 'railway:signal:humping:form', value: 'light' }
+
+  - description: Shunting stop sign (Ra 10)
+    country: DE
+    icon: { default: 'de/ra10' }
+    tags:
+      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra10' }
+      - { tag: 'railway:signal:shunting:form', value: 'sign' }
+
+  - description: Wait sign (Ra 11)
+    country: DE
+    icon: { default: 'de/ra11-sign' }
+    tags:
+      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra11' }
+      - { tag: 'railway:signal:shunting:form', value: 'sign' }
+
+  - description: Wait sign with Sh 1 (Ra 11)
+    country: DE
+    icon: { default: 'de/ra11-sh1' }
+    tags:
+      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra11' }
+      - { tag: 'railway:signal:shunting:form', value: 'light' }
+
+  - description: Wait sign (Ra 11b)
+    country: DE
+    icon: { default: 'de/ra11b' }
+    tags:
+      - { tag: 'railway:signal:shunting', value: 'DE-ESO:ra11b' }
+      - { tag: 'railway:signal:shunting:form', value: 'sign' }
+
+  - description: Derailer state signal (Wn 7)
+    country: DE
+    icon: { default: 'de/wn7-semaphore-normal' }
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-ESO:sh' }
+      - { tag: 'railway:signal:minor:form', value: 'semaphore' }
+      - { tag: 'railway:signal:minor:states', all: ['DE-ESO:sh0', 'DE-ESO:wn7'] }
+
+  - description: Brake test signal (Zp 6-8)
+    country: DE
+    icon: { default: 'de/zp8' }
+    tags:
+      - { tag: 'railway:signal:brake_test', value: 'DE-ESO:zp' }
+      - { tag: 'railway:signal:brake_test:form', value: 'light' }
+
+  - description: Departure order / Close doors (Zp 9 / Zp 10)
+    country: DE
+    icon:
+      match: 'railway:signal:departure:states'
+      cases:
+        - { exact: 'DE-ESO:zp10', value: 'de/zp10-db' }
+      default: 'de/zp9-db'
+    tags:
+      - { tag: 'railway:signal:departure', value: 'DE-ESO:zp' }
+      - { tag: 'railway:signal:departure:form', value: 'light' }
 
   - description: Power off anouncement sign (El 1v)
     country: DE
@@ -2727,6 +2114,14 @@ features:
       - { tag: 'railway:signal:electricity:type', value: 'power_on' }
       - { tag: 'railway:signal:electricity:form', value: 'sign' }
       - { tag: 'railway:signal:electricity', any: ['DE-ESO:el2', 'DE-BOStrab:st4', 'DE-HHA:s2'] }
+
+  - description: Power off shortly (El 1-2)
+    country: DE
+    icon: { default: 'de/el1-el2' }
+    tags:
+      - { tag: 'railway:signal:electricity:type', value: 'power_off_shortly' }
+      - { tag: 'railway:signal:electricity:form', value: 'sign' }
+      - { tag: 'railway:signal:electricity', any: ['DE-ESO:el1;DE-ESO:el2', 'DE-ESO:el2:DE-ESO:el1'] }
 
   - description: Pantograph down anouncement sign (El 3)
     country: DE
@@ -2774,29 +2169,306 @@ features:
       - { tag: 'railway:signal:electricity:form', value: 'sign' }
       - { tag: 'railway:signal:electricity', value: 'DE-ESO:el7' }
 
-  - description: Power off shortly signal (St 7, tram)
+  - description: Main signal stand-in sign (Ne 1)
     country: DE
-    icon: { default: 'de/bostrab/st7' }
+    icon: { default: 'de/ne1' }
     tags:
-      - { tag: 'railway:signal:electricity:type', value: 'power_off_shortly' }
-      - { tag: 'railway:signal:electricity:form', value: 'sign' }
-      - { tag: 'railway:signal:electricity', any: ['DE-BOStrab:st7', 'DE-AVG:st7'] }
+      - { tag: 'railway:signal:main', value: 'DE-ESO:ne1' }
+      - { tag: 'railway:signal:main:form', value: 'sign' }
 
-  - description: Power off shortly (El 1-2)
+  - description: Distant signal stand-in sign (Ne 2)
     country: DE
-    icon: { default: 'de/el1-el2' }
+    icon:
+      match: 'railway:signal:distant:shortened'
+      cases:
+        - { value: 'de/ne2-reduced-distance' }
+      default: 'de/ne2'
     tags:
-      - { tag: 'railway:signal:electricity:type', value: 'power_off_shortly' }
-      - { tag: 'railway:signal:electricity:form', value: 'sign' }
-      - { tag: 'railway:signal:electricity', any: ['DE-ESO:el1;DE-ESO:el2', 'DE-ESO:el2:DE-ESO:el1'] }
+      - { tag: 'railway:signal:distant', value: 'DE-ESO:db:ne2' }
+      - { tag: 'railway:signal:distant:form', value: 'sign' }
 
-  - description: Sign power off shortly (El 1, tram)
+  - description: Distant signal announcement signs (Ne 3, normal)
     country: DE
-    icon: { default: 'de/avg/el1' }
+    icon:
+      match: 'railway:signal:distant:type'
+      cases:
+        - { exact: 'II', value: 'de/ne3-normal-II' }
+        - { exact: 'III', value: 'de/ne3-normal-III' }
+        - { exact: 'IV', value: 'de/ne3-normal-IV' }
+      default: 'de/ne3-normal-I'
     tags:
-      - { tag: 'railway:signal:electricity:type', value: 'power_off_shortly' }
+      - { tag: 'railway:signal:distant', value: 'DE-ESO:ne3' }
+      - { tag: 'railway:signal:distant:form', value: 'sign' }
+
+  - description: Distant signal announcement signs (Ne 3, dwarf)
+    country: DE
+    icon:
+      match: 'railway:signal:distant:type'
+      cases:
+        - { exact: 'II', value: 'de/ne3-dwarf-II' }
+        - { exact: 'III', value: 'de/ne3-dwarf-III' }
+        - { exact: 'IV', value: 'de/ne3-dwarf-IV' }
+      default: 'de/ne3-dwarf-I'
+    tags:
+      - { tag: 'railway:signal:distant', value: 'DE-ESO:ne3' }
+      - { tag: 'railway:signal:distant:form', value: 'sign' }
+      - { tag: 'railway:signal:distant:height', value: 'dwarf' }
+
+  - description: Stop demand board (Ne 5)
+    country: DE
+    icon: { default: 'de/ne5-light' }
+    tags:
+      - { tag: 'railway:signal:stop_demand', value: 'DE-ESO:ne5' }
+      - { tag: 'railway:signal:stop_demand:form', value: 'light' }
+
+  - description: Stop location board (Ne 5)
+    country: DE
+    icon: { default: 'de/ne5-sign' }
+    tags:
+      - { tag: 'railway:signal:stop', value: 'DE-ESO:ne5' }
+      - { tag: 'railway:signal:stop:form', value: 'sign' }
+
+  - description: Halt/station anouncment sign (Ne 6)
+    country: DE
+    icon: { default: 'de/ne6' }
+    tags:
+      - { tag: 'railway:signal:station_distant', value: 'DE-ESO:ne6' }
+      - { tag: 'railway:signal:station_distant:form', value: 'sign' }
+
+  - description: Lift / Fold snowplow sign (Ne 7)
+    country: DE
+    icon:
+      match: 'railway:signal:snowplow:type'
+      cases:
+        - { exact: 'down', value: 'de/ne7-yellow-down' }
+      default: 'de/ne7-yellow-up'
+    tags:
+      - { tag: 'railway:signal:snowplow', value: 'DE-ESO:ne7' }
+      - { tag: 'railway:signal:snowplow:form', value: 'sign' }
+
+  - description: Expect and mind resetting switch signal (Ne 12)
+    country: DE
+    icon: { default: 'de/ne12' }
+    tags:
+      - { tag: 'railway:signal:resetting_switch_distant', value: 'DE-ESO:ne12' }
+      - { tag: 'railway:signal:resetting_switch_distant:form', value: 'sign' }
+
+  - description: Resetting switch signal (Ne 13)
+    country: DE
+    icon: { default: 'de/ne13a' }
+    tags:
+      - { tag: 'railway:signal:resetting_switch', value: 'DE-ESO:ne13' }
+      - { tag: 'railway:signal:resetting_switch:form', value: 'light' }
+
+  - description: ETCS stop marker (Ne 14)
+    country: DE
+    icon:
+      match: 'railway:signal:position'
+      cases:
+        - { exact: 'left', value: 'de/ne14-right' }
+        - { exact: 'overhead', value: 'de/ne14-down' }
+      default: 'de/ne14-left'
+    tags:
+      - { tag: 'railway:signal:train_protection', value: 'DE-ESO:ne14' }
+      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
+      - { tag: 'railway:signal:train_protection:type', value: 'block_marker' }
+
+  - description: Distant signal stand-in sign shortened (So 3, DV 301)
+    country: DE
+    icon: { default: 'de/ne2-dv301-reduced-distance' }
+    tags:
+      - { tag: 'railway:signal:distant', value: 'DE-ESO:dr:so3' }
+      - { tag: 'railway:signal:distant:form', value: 'sign' }
+      - { tag: 'railway:signal:distant:shortened' }
+
+  - description: Distant signal stand-in sign (So 106, DV 301)
+    country: DE
+    icon: { default: 'de/so106' }
+    tags:
+      - { tag: 'railway:signal:distant', value: 'DE-ESO:so106' }
+      - { tag: 'railway:signal:distant:form', value: 'sign' }
+
+  # TODO support variants of same feature
+  - description: Crossing (always) unsecured (Bü 0, sign, repeater)
+    country: DE
+    icon: { default: 'de/bue0-ds-repeated' }
+    tags:
+      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
+      - { tag: 'railway:signal:crossing:form', value: 'sign' }
+      - { tag: 'railway:signal:crossing:repeated' }
+
+  - description: Crossing (always) unsecured (Bü 0, sign)
+    country: DE
+    icon:
+      match: 'railway:signal:crossing:shortened'
+      cases:
+        - { value: 'de/bue0-ds-shortened', description: 'shortened' }
+      default: 'de/bue0-ds'
+    tags:
+      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
+      - { tag: 'railway:signal:crossing:form', value: 'sign' }
+
+  - description: Crossing unsecured/secured signal (repeater) (Bü 0/1)
+    country: DE
+    icon: { default: 'de/bue1-ds-repeated' }
+    tags:
+      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
+      - { tag: 'railway:signal:crossing:repeated' }
+
+  - description: Crossing unsecured/secured signal (Bü 0/1)
+    country: DE
+    icon:
+      match: 'railway:signal:crossing:shortened'
+      cases:
+        - { value: 'de/bue1-ds-shortened', description: 'shortened' }
+      default: 'de/bue1-ds'
+    tags:
+      - { tag: 'railway:signal:crossing', value: 'DE-ESO:bü' }
+
+  - description: Crossing unsecured/secured signal (repeater) (So 16b/a)
+    country: DE
+    icon: { default: 'de/bue1-dv-repeated' }
+    tags:
+      - { tag: 'railway:signal:crossing', value: 'DE-ESO:so16' }
+      - { tag: 'railway:signal:crossing:form', value: 'light' }
+      - { tag: 'railway:signal:crossing:repeated' }
+
+  - description: Crossing unsecured/secured signal (So 16b/a)
+    country: DE
+    icon:
+      match: 'railway:signal:crossing:shortened'
+      cases:
+        - { value: 'de/bue1-dv-shortened', description: 'shortened' }
+      default: 'de/bue1-dv'
+    tags:
+      - { tag: 'railway:signal:crossing', value: 'DE-ESO:so16' }
+      - { tag: 'railway:signal:crossing:form', value: 'light' }
+
+  - description: Expect Bü 0/1 crossing signal (Bü 2)
+    country: DE
+    icon:
+      match: 'railway:signal:crossing_distant:shortened'
+      cases:
+        - { value: 'de/bue2-ds-reduced-distance', description: 'shortened' }
+      default: 'de/bue2-ds'
+    tags:
+      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:bü2' }
+      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
+
+  - description: Expect So16 crossing signal sign (So 15, DV 301)
+    country: DE
+    icon: { default: 'de/so15' }
+    tags:
+      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:so15' }
+      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
+
+  - description: Crossing switch-on location board (Bü 3)
+    country: DE
+    icon: { default: 'de/bue3' }
+    tags:
+      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:bü3' }
+      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
+
+  - description: Crossing switch-on location pole (So 14, DV 301)
+    country: DE
+    icon: { default: 'de/so14' }
+    tags:
+      - { tag: 'railway:signal:crossing_distant', value: 'DE-ESO:so14' }
+      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
+
+  - description: Whistle sign (Bü 4)
+    country: DE
+    icon:
+      match: 'railway:signal:whistle:only_transit'
+      cases:
+        - { value: 'de/bue4-ds-only-transit', description: 'only transit' }
+      default: 'de/bue4-ds'
+    tags:
+      - { tag: 'railway:signal:whistle', value: 'DE-ESO:db:bü4' }
+      - { tag: 'railway:signal:whistle:form', value: 'sign' }
+
+  - description: Whistle sign (Pf 1, DV 301)
+    country: DE
+    icon:
+      match: 'railway:signal:whistle:only_transit'
+      cases:
+        - { value: 'de/pf1-dv-only-transit', description: 'only transit' }
+      default: 'de/pf1-dv'
+    tags:
+      - { tag: 'railway:signal:whistle', value: 'DE-ESO:dr:pf1' }
+      - { tag: 'railway:signal:whistle:form', value: 'sign' }
+
+  - description: Whistle twice sign (Pf 2) (DV 301)
+    country: DE
+    icon:
+      default: 'de/pf2-dv'
+    tags:
+      - { tag: 'railway:signal:whistle', value: 'DE-ESO:dr:pf2' }
+      - { tag: 'railway:signal:whistle:form', value: 'sign' }
+
+  - description: Ring bell sign (Bü 5)
+    country: DE
+    icon:
+      match: 'railway:signal:ring:only_transit'
+      cases:
+        - { value: 'de/bue5-only-transit', description: 'only transit' }
+      default: 'de/bue5'
+    tags:
+      - { tag: 'railway:signal:ring', value: 'DE-ESO:bü5' }
+      - { tag: 'railway:signal:ring:form', value: 'sign' }
+
+  - description: Crossing marking sign (Bü-Kennzeichentafel)
+    country: DE
+    icon: { default: 'de/bue-crossing-info' }
+    tags:
+      - { tag: 'railway:signal:crossing_info', value: 'DE-ESO:bü-kennzeichentafel' }
+      - { tag: 'railway:signal:crossing_info:form', value: 'sign' }
+
+  - description: Crossing anouncement sign (Bü-Ankündetafel)
+    country: DE
+    icon: { default: 'de/bue-crossing-hint' }
+    tags:
+      - { tag: 'railway:signal:crossing_hint', value: 'DE-ESO:bü-ankündetafel' }
+      - { tag: 'railway:signal:crossing_hint:form', value: 'sign' }
+
+  - description: ICE-Schaltmerkhilfe
+    country: DE
+    icon: { default: 'de/ice-schaltmerkhilfe' }
+    tags:
+      - { tag: 'railway:signal:electricity', value: 'DE-ESO:ice-schaltmerkhilfe' }
+      - { tag: 'railway:signal:electricity:type', value: 'power_on_for_long_trains' }
       - { tag: 'railway:signal:electricity:form', value: 'sign' }
-      - { tag: 'railway:signal:electricity', value: 'DE-AVG:el1' }
+
+  - description: Driving permission indicator (Fahrtanzeiger)
+    country: DE
+    icon: { default: 'de/fahrtanzeiger' }
+    tags:
+      - { tag: 'railway:signal:main_repeated', value: 'DE-ESO:fahrtanzeiger' }
+      - { tag: 'railway:signal:main_repeated:form', value: 'light' }
+
+  - description: LZB section start (LZB-Bereichskennzeichen)
+    country: DE
+    icon: { default: 'de/lzb-section-start' }
+    tags:
+      - { tag: 'railway:signal:train_protection', value: 'DE-ESO:lzb-bereichskennzeichen' }
+      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
+
+  - description: ETCS/LZB block marker
+    country: DE
+    icon:
+      match: 'ref_multiline'
+      cases:
+        - { regex: '^([^\n]{4}\n[^\n]{1,4})|([^\n]{1,4}\n[^\n]{4})$', value: 'de/blockkennzeichen-4x2' }
+        - { regex: '^[^\n]{4}$', value: 'de/blockkennzeichen-4x1' }
+        - { regex: '^([^\n]{3}\n[^\n]{1,3})|([^\n]{1,3}\n[^\n]{3})$', value: 'de/blockkennzeichen-3x2' }
+        - { regex: '^[^\n]{3}$', value: 'de/blockkennzeichen-3x1' }
+        - { regex: '^([^\n]{2}\n[^\n]{1,2})|([^\n]{1,2}\n[^\n]{2})$', value: 'de/blockkennzeichen-2x2' }
+        - { regex: '^[^\n]{2}$', value: 'de/blockkennzeichen-2x1' }
+        - { regex: '^[^\n]\n[^\n]$', value: 'de/blockkennzeichen-1x2' }
+        - { regex: '^[^\n]$', value: 'de/blockkennzeichen-1x1' }
+      default: 'de/blockkennzeichen'
+    tags:
+      - { tag: 'railway:signal:train_protection', value: 'DE-ESO:blockkennzeichen' }
 
   - description: Begin of isolated overlap
     country: DE
@@ -2814,13 +2486,247 @@ features:
       - { tag: 'railway:signal:electricity:type', value: 'end_of_isolated_overlap' }
       - { tag: 'railway:signal:electricity:form', value: 'sign' }
 
-  - description: ICE-Schaltmerkhilfe
+  - description: Entry signal halt indicator (Signalhaltmelder)
     country: DE
-    icon: { default: 'de/ice-schaltmerkhilfe' }
+    icon: { default: 'de/zlb-haltmelder-light' }
     tags:
-      - { tag: 'railway:signal:electricity', value: 'DE-ESO:ice-schaltmerkhilfe' }
-      - { tag: 'railway:signal:electricity:type', value: 'power_on_for_long_trains' }
+      - { tag: 'railway:signal:main_repeated', value: 'DE-DB:signalhaltmelder' }
+      - { tag: 'railway:signal:main_repeated:form', value: 'light' }
+
+  # --- DE-BOStrab (Tram + Subways) --- #
+
+  - description: BOStrab main signal
+    country: DE
+    icon:
+      match: 'railway:signal:main:states'
+      cases:
+        - { exact: 'DE-BOStrab:h2', value: 'de/bostrab/h2' }
+        - { exact: 'DE-BOStrab:h1', value: 'de/bostrab/h1' }
+        - { exact: 'DE-VAGN:hp2', value: 'de/vag-nuremberg/hp2' }
+        - { exact: 'DE-VAGN:hp1', value: 'de/vag-nuremberg/hp1' }
+        - { all: ['DE-VAGN:hp0', 'off'], value: 'de/vag-nuremberg/off' }
+        - { exact: 'DE-VAGN:hp3', value: 'de/vag-nuremberg/hp3' }
+        - { exact: 'DE-VAGN:hp0', value: 'de/vag-nuremberg/hp0' }
+      default: 'de/bostrab/h0'
+    tags:
+      - { tag: 'railway:signal:main', value: 'DE-BOStrab:h' }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+
+  - description: BOStrab combined signals
+    country: DE
+    icon: { default: 'de/bostrab/h' }
+    tags:
+      - { tag: 'railway:signal:combined', value: 'DE-BOStrab:h' }
+      - { tag: 'railway:signal:combined:form', value: 'light' }
+
+  - description: BOStrab distant signal (V)
+    country: DE
+    icon:
+      match: 'railway:signal:distant:states'
+      cases:
+        - { exact: 'DE-BOStrab:v2', value: 'de/bostrab/v2'}
+        - { exact: 'DE-BOStrab:v1', value: 'de/bostrab/v1'}
+        - { exact: 'DE-VAGN:vr2', value: 'de/vag-nuremberg/vr2'}
+        - { exact: 'DE-VAGN:vr1', value: 'de/vag-nuremberg/vr1'}
+        - { exact: 'DE-VAGN:vr0', value: 'de/vag-nuremberg/vr0'}
+      default: 'de/bostrab/v0'
+    tags:
+      - { tag: 'railway:signal:distant', value: 'DE-BOStrab:v' }
+      - { tag: 'railway:signal:distant:form', value: 'light' }
+
+  - description: Proceed signal with registration (F1-5 + A, tram)
+    country: DE
+    icon:
+      match: 'railway:signal:main:states'
+      cases:
+        - { any: ['DE-AVG:f5', 'DE-BOStrab:f5'], value: 'de/bostrab/f5-st9' }
+        - { any: ['DE-AVG:f3', 'DE-BOStrab:f3'], value: 'de/bostrab/f3-st9' }
+        - { any: ['DE-AVG:f2', 'DE-BOStrab:f2'], value: 'de/bostrab/f2-st9' }
+        - { any: ['DE-AVG:f1', 'DE-BOStrab:f1'], value: 'de/bostrab/f1-st9' }
+      default: 'de/bostrab/f0-st9'
+    tags:
+      - { tag: 'railway:signal:main', any: ['DE-AVG:f', 'DE-BOStrab:f'] }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+      - { tag: 'railway:signal:main:PT_priority', value: 'requested;off' }
+
+  - description: Proceed signal (F1-5, tram)
+    country: DE
+    icon:
+      match: 'railway:signal:main:states'
+      cases:
+        - { any: ['DE-AVG:f5', 'DE-BOStrab:f5'], value: 'de/bostrab/f5' }
+        - { any: ['DE-AVG:f3', 'DE-BOStrab:f3'], value: 'de/bostrab/f3' }
+        - { any: ['DE-AVG:f2', 'DE-BOStrab:f2'], value: 'de/bostrab/f2' }
+        - { any: ['DE-AVG:f1', 'DE-BOStrab:f1'], value: 'de/bostrab/f1' }
+      default: 'de/bostrab/f0'
+    tags:
+      - { tag: 'railway:signal:main', any: ['DE-AVG:f', 'DE-BOStrab:f'] }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+
+  - description: Close doors / Departure order (A1 / A2, tram)
+    country: DE
+    icon:
+      match: 'railway:signal:departure:states'
+      cases:
+        - { exact: 'DE-BOStrab:a2', value: 'de/bostrab/a2' }
+      default: 'de/bostrab/a1'
+    tags:
+      - { tag: 'railway:signal:departure', any: ['DE-BOStrab:a', 'DE-BOStrab:a1', 'DE-BOStrab:a2' ] }
+      - { tag: 'railway:signal:departure:form', value: 'light' }
+
+  - description: Mandatory stop (Sh 1, Tram)
+    country: DE
+    icon: { default: 'de/bostrab/sh1' }
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-BOStrab:sh1' }
+      - { tag: 'railway:signal:minor:form', value: 'sign' }
+
+  - description: Protective stop (Sh 2, tram)
+    country: DE
+    icon: { default: 'de/bostrab/sh2' }
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-BOStrab:sh2' }
+      - { tag: 'railway:signal:minor:form', value: 'sign' }
+
+  - description: Ring bell sign (Sh 4, tram)
+    country: DE
+    icon: { default: 'de/bostrab/sh4' }
+    tags:
+      - { tag: 'railway:signal:ring', value: 'DE-BOStrab:sh4' }
+      - { tag: 'railway:signal:ring:form', value: 'sign' }
+
+  - description: Stop board (Sh 7, tram)
+    country: DE
+    icon: { default: 'de/bostrab/sh7' }
+    tags:
+      - { tag: 'railway:signal:stop', value: 'DE-BOStrab:sh7' }
+      - { tag: 'railway:signal:stop:form', value: 'sign' }
+
+  - description: Power off shortly signal (St 7, tram)
+    country: DE
+    icon: { default: 'de/bostrab/st7' }
+    tags:
+      - { tag: 'railway:signal:electricity:type', value: 'power_off_shortly' }
       - { tag: 'railway:signal:electricity:form', value: 'sign' }
+      - { tag: 'railway:signal:electricity', any: ['DE-BOStrab:st7', 'DE-AVG:st7'] }
+
+  - description: Crossing unsecured/secured signal (Bü 0/1, tram)
+    country: DE
+    icon: { default: 'de/bostrab/bü' }
+    tags:
+      - { tag: 'railway:signal:crossing', value: 'DE-BOStrab:bü' }
+      - { tag: 'railway:signal:crossing:form', value: 'light' }
+
+  - description: Expect Bü 0/1 crossing signal (Bü 2, tram)
+    country: DE
+    icon: { default: 'de/bostrab/bü2' }
+    tags:
+      - { tag: 'railway:signal:crossing_distant', value: 'DE-BOStrab:bü2' }
+      - { tag: 'railway:signal:crossing_distant:form', value: 'sign' }
+
+  - description: Start of train protection (So 1, tram)
+    country: DE
+    icon: { default: 'de/bostrab/so1' }
+    tags:
+      - { tag: 'railway:signal:train_protection', any: ['DE-BOStrab:so1', 'DE-AVG:so1'] }
+      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
+      - { tag: 'railway:signal:train_protection:type', value: 'start' }
+
+  - description: End of train protection (So 2, tram)
+    country: DE
+    icon: { default: 'de/bostrab/so2' }
+    tags:
+      - { tag: 'railway:signal:train_protection', any: ['DE-BOStrab:so2', 'DE-AVG:so2'] }
+      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
+      - { tag: 'railway:signal:train_protection:type', value: 'end' }
+
+  - description: Passing-by prohibited sign (So 5, tram)
+    country: DE
+    icon: { default: 'de/bostrab/so5' }
+    tags:
+      - { tag: 'railway:signal:passing', value: 'DE-BOStrab:so5' }
+      - { tag: 'railway:signal:passing:form', value: 'sign' }
+      - { tag: 'railway:signal:passing:type', value: 'no_passing' }
+
+  - description: Passing-by prohibited end sign (So 6, tram)
+    country: DE
+    icon: { default: 'de/bostrab/so6' }
+    tags:
+      - { tag: 'railway:signal:passing', value: 'DE-BOStrab:so6' }
+      - { tag: 'railway:signal:passing:form', value: 'sign' }
+      - { tag: 'railway:signal:passing:type', value: 'passing_allowed' }
+
+  - description: Tram distance speed limit (G1a) (sign)
+    country: DE
+    type: tram
+    icon:
+      match: 'railway:signal:speed_limit_distant:speed'
+      cases:
+        - { regex: '^(5|[1-7][0-5])$', value: 'de/bostrab/g1a-{}', example: 'de/bostrab/g1a-{40}' }
+      default: 'de/bostrab/g1a-empty'
+    tags:
+      - { tag: 'railway:signal:speed_limit_distant', any: ['DE-BOStrab:g1', 'DE-BOStrab:g1a', 'DE-BSVG:g1a'] }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
+
+  - description: Tram distance speed limit (G1b) (light)
+    country: DE
+    type: tram
+    icon:
+      match: 'railway:signal:speed_limit_distant:speed'
+      cases:
+        - { regex: '^[1-7]0$', value: 'de/bostrab/g1b-{}', example: 'de/bostrab/g1b-{40}' }
+      default: 'de/bostrab/g1b-empty'
+    tags:
+      - { tag: 'railway:signal:speed_limit_distant', any: ['DE-BOStrab:g1', 'DE-BOStrab:g1b'] }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'light' }
+
+  - description: Speed limit sign (G2a, tram)
+    country: DE
+    type: tram
+    icon:
+      match: 'railway:signal:speed_limit:speed'
+      cases:
+        - { regex: '^(5|[1-7][05])$', value: 'de/bostrab/g2a-{}', example: 'de/bostrab/g2a-{40}' }
+      default: 'de/bostrab/g2a-empty'
+    tags:
+      - { tag: 'railway:signal:speed_limit', any: ['DE-BOStrab:g2', 'DE-BOStrab:g2a', 'DE-BSVG:g2a'] }
+      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
+
+  - description: Speed limit signal (G2b, tram)
+    country: DE
+    type: tram
+    icon:
+      match: 'railway:signal:speed_limit:speed'
+      cases:
+        - { regex: '^[1-7]0$', value: 'de/bostrab/g2b-{}', example: 'de/bostrab/g2b-{40}' }
+      default: 'de/bostrab/g2b-empty'
+    tags:
+      - { tag: 'railway:signal:speed_limit', any: ['DE-BOStrab:g2', 'DE-BOStrab:g2b'] }
+      - { tag: 'railway:signal:speed_limit:form', value: 'light' }
+
+  - description: End of speed limit sign (G3, tram)
+    country: DE
+    type: tram
+    icon: { default: 'de/bostrab/g3' }
+    tags:
+      - { tag: 'railway:signal:speed_limit', value: 'DE-BOStrab:g3' }
+      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
+
+  - description: Speed limit increase sign (G4, tram)
+    country: DE
+    type: tram
+    icon:
+      match: 'railway:signal:speed_limit:speed'
+      cases:
+        - { regex: '^(100|[2-9]0|[235]5)$', value: 'de/bostrab/g4-{}', example: 'de/bostrab/g4-{40}' }
+      default: 'de/bostrab/g4-empty'
+    tags:
+      - { tag: 'railway:signal:speed_limit', value: 'DE-BOStrab:g4' }
+      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
+
+  # --- DE local specialities --- #
+
+  # --- DE-BOStrab Frankfurt --- #
 
   - description: VGF st9
     country: DE
@@ -2842,6 +2748,116 @@ features:
     tags:
       - { tag: 'railway:signal:electricity:form', value: 'sign' }
       - { tag: 'railway:signal:electricity', value: 'DE-VGF:st9;DE-VGF:st10' }
+
+  # --- DE-BOStrab Hamburg --- #
+
+  - description: Hamburger Hochbahn main signal
+    country: DE
+    icon:
+      match: 'railway:signal:main:states'
+      cases:
+        - { exact: 'DE-HHA:h1', value: 'de/hha/h1' }
+      default: 'de/hha/h0'
+    tags:
+      - { tag: 'railway:signal:main', value: 'DE-HHA:h' }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+
+  - description: Hamburger Hochbahn distant signal
+    country: DE
+    icon: { default: 'de/hha/v1' }
+    tags:
+      - { tag: 'railway:signal:distant', value: 'DE-HHA:v' }
+      - { tag: 'railway:signal:distant:form', value: 'light' }
+
+  - description: Emergency stop (Sh 3, Hamburger Hochbahn)
+    country: DE
+    icon: { default: 'de/hha/sh3' }
+    tags:
+      - { tag: 'railway:signal:minor', value: 'DE-HHA:sh3' }
+      - { tag: 'railway:signal:minor:form', value: 'light' }
+
+  - description: Hamburger Hochbahn L1
+    country: DE
+    type: line
+    icon:
+      match: 'railway:signal:speed_limit_distant:speed'
+      cases:
+        - { regex: '^([3-7]0)$', value: 'de/hha/l1-sign-{}', example: 'de/hha/l1-sign-{70}' }
+      default: 'de/hha/l1-empty-sign'
+    tags:
+      - { tag: 'railway:signal:speed_limit_distant', value: 'DE-HHA:l1' }
+      - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
+
+  - description: Hamburger Hochbahn L4
+    country: DE
+    type: line
+    icon: { default: 'de/hha/l4' }
+    tags:
+      - { tag: 'railway:signal:speed_limit', value: 'DE-HHA:l4' }
+      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
+
+  # --- DE-BOStrab Karlsruhe --- #
+
+  - description: Karlsruhe VBK Vorsignale (light)
+    country: DE
+    icon:
+      match: 'railway:signal:distant:states'
+      cases:
+        - { exact: 'DE-VBK:fv2', value: 'de/vbk/fv2' }
+        - { exact: 'DE-VBK:fv3', value: 'de/vbk/fv3' }
+      default: 'de/vbk/fv1'
+    tags:
+      - { tag: 'railway:signal:distant', value: 'DE-VBK:fv' }
+      - { tag: 'railway:signal:distant:form', value: 'light' }
+
+  - description: Karlsruhe VBK Vorsignale (sign)
+    country: DE
+    icon: { default: 'de/vbk/fv0' }
+    tags:
+      - { tag: 'railway:signal:distant', any: ['DE-VBK:fv', 'DE-VBK:fv0'] }
+      - { tag: 'railway:signal:distant:form', value: 'sign' }
+
+  - description: Crossing signals (Bü 201, tram Karlsruhe / AVG)
+    country: DE
+    icon:
+      match: 'railway:signal:crossing_distant:states'
+      cases:
+        - { exact: 'DE-AVG:bü201v', value: 'de/avg/bue201v' }
+      default: 'de/avg/bue201'
+    tags:
+      - { tag: 'railway:signal:crossing_distant', value: 'DE-AVG:bü201' }
+      - { tag: 'railway:signal:crossing_distant:form', value: 'light' }
+
+  - description: AVG stop demand (Hw 1, tram Karlsruhe / AVG)
+    country: DE
+    icon: { default: 'de/avg/hw1' }
+    tags:
+      - { tag: 'railway:signal:stop_demand', value: 'DE-AVG:hw1' }
+      - { tag: 'railway:signal:stop_demand:form', value: 'light' }
+
+  - description: Sign power off shortly (El 1, tram Karlsruhe / AVG)
+    country: DE
+    icon: { default: 'de/avg/el1' }
+    tags:
+      - { tag: 'railway:signal:electricity:type', value: 'power_off_shortly' }
+      - { tag: 'railway:signal:electricity:form', value: 'sign' }
+      - { tag: 'railway:signal:electricity', value: 'DE-AVG:el1' }
+
+  # --- DE-BOStrab Hannover --- #
+
+  - description: Hannover tram speed limit G5
+    country: DE
+    type: tram
+    icon:
+      match: 'railway:signal:speed_limit:speed'
+      cases:
+        - { regex: '^(5|[1-6][05])$', value: 'de/bostrab/g5-{}', example: 'de/bostrab/g5-{40}' }
+      default: 'de/bostrab/g5-empty'
+    tags:
+      - { tag: 'railway:signal:speed_limit', value: 'DE-UESTRA:g5' }
+      - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
+
+  # --- DE-BOStrab Rostock --- #
 
   - description: Give way (So 11, tram, RSAG)
     country: DE


### PR DESCRIPTION
1. Rework most descriptions to be clearer to map users
2. Prevent legend texts from overlapping
3. Reorder German signals in more logical way: First ESO (mostly using the order from German signalling book DB Ril 301), second BOStrab, third local signalling

<img width="332" height="414" alt="image" src="https://github.com/user-attachments/assets/0963e84e-fae2-47a5-bc1c-d28b9dc3c35e" />
<img width="332" height="414" alt="image" src="https://github.com/user-attachments/assets/aa33229a-a3aa-41ee-bca3-4433578e31ba" />
<img width="332" height="414" alt="image" src="https://github.com/user-attachments/assets/0195ffee-b2c0-4a4a-ac9e-5871b79662fa" />
<img width="332" height="414" alt="image" src="https://github.com/user-attachments/assets/43266669-beab-4933-a6cd-96d6059dacb7" />
<img width="332" height="414" alt="image" src="https://github.com/user-attachments/assets/e19a45d0-c99e-4b43-ac9b-e0749a76a8fc" />
<img width="332" height="414" alt="image" src="https://github.com/user-attachments/assets/9d621c29-3057-4b91-81d2-79864383b5b3" />
<img width="332" height="414" alt="image" src="https://github.com/user-attachments/assets/d62343cd-0414-432b-95a4-eb7fed006b41" />
<img width="332" height="414" alt="image" src="https://github.com/user-attachments/assets/994d1e6d-662e-41a4-be35-e5874c646f12" />
<img width="332" height="414" alt="image" src="https://github.com/user-attachments/assets/5f7392cb-966c-491e-80c3-1cf881e0fb49" />
<img width="332" height="414" alt="image" src="https://github.com/user-attachments/assets/811e0182-488a-489f-9313-3bb714d0c491" />
<img width="332" height="414" alt="image" src="https://github.com/user-attachments/assets/4a230f48-3c8d-4fca-a465-1188f58b6ebd" />

