### PR TITLE
Use `railway:signal:regime` tag for BE signal regime

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -55,7 +55,6 @@ tags:
   - { tag: 'railway:signal:main:states', description: 'Main states', type: array }
   - { tag: 'railway:signal:main:substitute_signal', description: 'Main substitute signal' }
   - { tag: 'railway:signal:main:PT_priority', description: 'Main PT priority' }
-  - { tag: 'railway:signal:main:regime', description: 'Main regime' }
   - { tag: 'railway:signal:main_repeated', description: 'Main repeated' }
   - { tag: 'railway:signal:main_repeated:form', description: 'Main repeated form' }
   - { tag: 'railway:signal:main_repeated:magnet', description: 'Main repeated magnet', type: boolean }
@@ -130,6 +129,7 @@ tags:
   - { tag: 'railway:signal:wrong_road', description: 'Wrong road' }
   - { tag: 'railway:signal:wrong_road:form', description: 'Wrong road form' }
   - { tag: 'railway:vacancy_detection', description: 'Vacancy detection' }
+  - { tag: 'railway:signal:regime', description: 'Signal regime' }
   - { tag: 'railway:signal:position', description: 'Position' }
 
 # A mapping of every type of signal that is imported
@@ -856,7 +856,7 @@ features:
       default: 'be/GSA-opposite-R'
     tags:
       - { tag: 'railway:signal:main', value: 'BE:GSA' }
-      - { tag: 'railway:signal:main:regime', value: 'opposite' }
+      - { tag: 'railway:signal:regime', value: 'opposite' }
 
   - description: Grand Signal d'Arrêt (normal regime)
     country: BE

--- a/taginfo.json
+++ b/taginfo.json
@@ -248,6 +248,7 @@
     { "key": "railway:signal:wrong_road:form" },
     { "key": "railway:vacancy_detection" },
     { "key": "railway:signal:position" },
+    { "key": "railway:signal:regime" },
     { "key": "ref:crs" },
     { "key": "tourism", "value": "museum" },
     { "key": "museum", "value": "railway" }


### PR DESCRIPTION
Fixes #520

See wiki about regime tagging on https://wiki.openstreetmap.org/wiki/OpenRailwayMap/Tagging_in_Belgium#Regime

Tested in Brussel (http://localhost:8000/#view=18.43/50.8245989/4.3233201&style=signals): icon is now inverted in opposite regime:
<img width="1015" height="824" alt="image" src="https://github.com/user-attachments/assets/7e3bf5d6-5759-4585-9e46-c97679ec2189" />
