### PR TITLE
Add German signals Pl 3, Pl 4

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -1941,6 +1941,20 @@ features:
       - { tag: 'railway:signal:ring', value: 'DE-ESO:bü5' }
       - { tag: 'railway:signal:ring:form', value: 'sign' }
 
+  - description: start ringing Pl 3
+    country: DE
+    icon: { default: 'de/pl3' }
+    tags:
+      - { tag: 'railway:signal:ring', value: 'DE-ESO:dr:pl3' }
+      - { tag: 'railway:signal:ring:form', value: 'sign' }
+
+  - description: stop ringing Pl 4
+    country: DE
+    icon: { default: 'de/pl4' }
+    tags:
+      - { tag: 'railway:signal:ring', value: 'DE-ESO:dr:pl4' }
+      - { tag: 'railway:signal:ring:form', value: 'sign' }
+
   - description: Lift / Fold snowplow Ne 7 (sign)
     country: DE
     icon:

--- a/symbols/de/pl3.svg
+++ b/symbols/de/pl3.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="21.85" height="31.85" viewBox="0 0 21.85 31.85">
+<path fill="rgb(100%, 100%, 100%)" stroke-width="0.15" stroke="rgb(0%, 0%, 0%)" d="M 0.075,0.075 H 10.925 V 15.925 H 0.075 Z" />
+<path fill="rgb(0%, 0%, 0%)" d="M 2.0,2.6 V 13.8 H 3.7 V 9.0 H 6.2 V 9.0 C 10.2,9.0 10.4,2.6 6.2,2.6 Z M 6.2,4.3 C 7.9,4.4 7.9,7.2 6.2,7.2 6.2,7.2 6.2,7.2 6.2,7.2 H 3.7 V 4.3 Z"/>
+<path fill="rgb(100%, 100%, 100%)" stroke-width="0.15" stroke="rgb(0%, 0%, 0%)" d="M 10.925,0.075 H 21.775 V 15.925 H 10.925 Z"/>
+<path fill="rgb(0%, 0%, 0%)" d="M 12.8,2.0 V 13.8 H 19.7 V 12.0 H 14.6 V 2.0 Z"/>
+<path fill="rgb(100%, 100%, 100%)" stroke-width="0.15" stroke="rgb(0%, 0%, 0%)" d="M 10.925,15.925 H 21.775 V 31.775 H 10.925 Z"/>
+<path fill="rgb(0%, 0%, 0%)" d="M 12.8,17.85 V 29.65 H 19.7 V 27.85 H 14.6 V 17.85 Z"/>
+</svg>

--- a/symbols/de/pl4.svg
+++ b/symbols/de/pl4.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="21.85" height="16" viewBox="0 0 21.85 16">
+<path fill="rgb(100%, 100%, 100%)" stroke-width="0.15" stroke="rgb(0%, 0%, 0%)" d="M 0.075,0.075 H 10.925 V 15.925 H 0.075 Z" />
+<path fill="rgb(0%, 0%, 0%)" d="M 1.95,2.0 V 13.8 H 8.85 V 12.0 H 3.75 V 8.8 H 7.95 V 7.0 H 3.75 V 3.8 H 8.85 V 2.0 Z"/>
+<path fill="rgb(100%, 100%, 100%)" stroke-width="0.15" stroke="rgb(0%, 0%, 0%)" d="M 10.925,0.075 H 21.775 V 15.925 H 10.925 Z"/>
+<path fill="rgb(0%, 0%, 0%)" d="M 12.8,2.0 V 13.8 H 19.7 V 12.0 H 14.6 V 8.8 H 18.8 V 7.0 H 14.6 V 3.8 H 19.7 V 2.0 Z"/>
+</svg>


### PR DESCRIPTION
Added German railway signals Pl 3 and Pl 4 which are used on several narrow-gauge railways in eastern Germany. Their documentation on the wiki can be found [here](https://wiki.openstreetmap.org/wiki/DE:OpenRailwayMap/Tagging_in_Germany/B%C3%BC,_Ne,_Pf_and_So_Signals#Pl-Signale), images on Commons at [Pl 3](https://commons.wikimedia.org/wiki/Category:Pl_3_(German_railway_signal))/[Pl 4](https://commons.wikimedia.org/wiki/Category:Pl_4_(German_railway_signal)).

Examples for the signals on OSM are nodes [13153203728](https://www.openstreetmap.org/node/13153203728) and [9516827595](https://www.openstreetmap.org/node/9516827595), respectively.

I built the SVGs from the existing symbols [de/bue4-ds.svg](https://github.com/hiddewie/OpenRailwayMap-vector/blob/master/symbols/de/bue4-ds.svg) and [de/bue5.svg](https://github.com/hiddewie/OpenRailwayMap-vector/blob/master/symbols/de/bue5.svg) with each part in their original size. Maybe this makes the combined signal a bit too large?

This is my first pull request and I am not quite sure how it works; I hope everything is okay.