### PR TITLE
Ignore signal feature type for popup

### DIFF
--- a/proxy/js/features.mjs
+++ b/proxy/js/features.mjs
@@ -51,7 +51,6 @@ const generateSignalFeatures = (features, types) =>
         {
           country: feature.country,
           name: feature.description,
-          type: feature.type,
         }
       ],
       ...(


### PR DESCRIPTION
Fixes #533

The feature type (none, tram or line) for signals was used in the popup. This is not correct for signals, as the code expects `point` or `line` as feature type. All signals are points (the default).

Only features without icon matching were impacted. Signals matching on possible signal state, or speed signals matching on speeds, were not impacted.

(https://openrailwaymap.app/#view=20/48.9858191/8.4562737&style=speed)

Before:
<img width="714" height="566" alt="image" src="https://github.com/user-attachments/assets/42d50e50-569b-4a43-91c8-a85f605d6ba6" />

After:
<img width="714" height="566" alt="image" src="https://github.com/user-attachments/assets/aa482be9-5d3e-423f-afab-4b3e42261e41" />
