### PR TITLE
Fix platforms with multiple references

### DIFF
--- a/import/sql/tile_views.sql
+++ b/import/sql/tile_views.sql
@@ -558,7 +558,7 @@ SELECT
   way,
   'platform' as feature,
   name,
-  ref,
+  nullif(array_to_string(ref, U&'\001E'), '') as ref,
   height,
   surface,
   elevator,


### PR DESCRIPTION
Platforms often have multiple references, one for each platform edge. The data was stored correctly, but output incorrectly: as SQL array, instead of a `\001e` (record separated) delimited value.

Now the popup shows references `1, 2, 3`:
(http://localhost:8000/#view=17.83/54.100187/11.905644)
<img width="789" height="639" alt="image" src="https://github.com/user-attachments/assets/eb576b84-d024-4d66-a9e6-9c8493287070" />
