### PR TITLE
Fix DE-AVG crossing signals

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -2106,13 +2106,16 @@ features:
 
   - description: Karlsruhe AVG crossing signals
     country: DE
-    icon:
-      match: 'railway:signal:crossing_distant:states'
-      cases:
-        - { exact: 'DE-AVG:bü201v', value: 'de/avg/bue201v' }
-      default: 'de/avg/bue201'
+    icon: { default: 'de/avg/bue201' }
     tags:
-      - { tag: 'railway:signal:crossing_distant', value: 'DE-AVG:bü201' }
+      - { tag: 'railway:signal:crossing', value: 'DE-AVG:bü200' }
+      - { tag: 'railway:signal:crossing:form', value: 'light' }
+
+  - description: Karlsruhe AVG distant crossing signals
+    country: DE
+    icon: { default: 'de/avg/bue201v' }
+    tags:
+      - { tag: 'railway:signal:crossing_distant', value: 'DE-AVG:bü200v' }
       - { tag: 'railway:signal:crossing_distant:form', value: 'light' }
 
   - description: Karlsruhe AVG Stop Demand


### PR DESCRIPTION
There are two kinds of crossing signals of German infra manager AVG:
- crossing signal [`railway:signal:crossing=DE-AVG:bü200`](https://overpass-turbo.eu/?w=%22railway%3Asignal%3Acrossing%22%3D%22DE-AVG%3Ab%C3%BC200%22+global&R) ([example](https://www.openstreetmap.org/node/1636970608))
- distant crossing signal [`railway:signal:crossing_distant=DE-AVG:bü200v`](https://overpass-turbo.eu/?w=%22railway%3Asignal%3Acrossing_distant%22%3D%22DE-AVG%3Ab%C3%BC200v%22+global&R) ([example](https://www.openstreetmap.org/node/2574283718))

Both were conflated before so that none of them were rendered on the map.