### PR TITLE
Specify tagging for NL shunting / train protection signal addons

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -4242,7 +4242,9 @@ features:
     icon: { default: 'nl/main_light_dwarf_shunting' }
     tags:
       - { tag: 'railway:signal:main', value: 'NL' }
+      - { tag: 'railway:signal:main:form', value: 'light' }
       - { tag: 'railway:signal:main:height', value: 'dwarf' }
+      - { tag: 'railway:signal:shunting', value: 'NL' }
       - { tag: 'railway:signal:shunting:form', value: 'light' }
 
   - description: train protection block marker light
@@ -4250,6 +4252,8 @@ features:
     icon: { default: 'nl/main_light_white_bar' }
     tags:
       - { tag: 'railway:signal:main', value: 'NL' }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+      - { tag: 'railway:signal:train_protection', value: 'NL:228' }
       - { tag: 'railway:signal:train_protection:form', value: 'light' }
       - { tag: 'railway:signal:train_protection:type', value: 'block_marker' }
 
@@ -4265,6 +4269,8 @@ features:
     icon: { default: 'nl/main_light_shunting' }
     tags:
       - { tag: 'railway:signal:main', value: 'NL' }
+      - { tag: 'railway:signal:main:form', value: 'light' }
+      - { tag: 'railway:signal:shunting', value: 'NL' }
       - { tag: 'railway:signal:shunting:form', value: 'light' }
 
   - description: main repeated light


### PR DESCRIPTION
Main/dwarf signals with shunting light add-on, and main signals with block marker add-on were not configured correctly.

(https://openrailwaymap.app/#view=15.6/51.859503/5.270863&style=signals)
Before:
<img width="1430" height="1112" alt="image" src="https://github.com/user-attachments/assets/bd1a4de0-5c5d-4838-a03a-323849ac7d47" />
After:
<img width="1430" height="1112" alt="image" src="https://github.com/user-attachments/assets/552d3789-08b2-4e0d-a32b-b8adcae57bb6" />

(https://openrailwaymap.app/#view=16/52.305968/6.932672&style=signals)
Before:
<img width="1371" height="530" alt="image" src="https://github.com/user-attachments/assets/62b2d917-3da6-46de-a7f0-aa26b33c6796" />
After:
<img width="1371" height="530" alt="image" src="https://github.com/user-attachments/assets/8f810579-6342-4ac2-9b57-1a0eae584bc9" />
