### PR TITLE
Revert usage of port 8443

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -84,7 +84,9 @@ SSL is supported by generating a trusted certificate, and installing it in the p
   docker compose up --build --watch martin-proxy
   ```
 
-The OpenRailwayMap is available on https://localhost:8443, with SSL enabled and without browser warnings.
+The OpenRailwayMap is available on https://localhost, with SSL enabled and without browser warnings. 
+
+You can modify the TLS port 443 to port 8443 in the Docker Compose configuration, if you want the container to start without priviledges, for example using Podman.
 
 ## Tests
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -86,7 +86,7 @@ SSL is supported by generating a trusted certificate, and installing it in the p
 
 The OpenRailwayMap is available on https://localhost, with SSL enabled and without browser warnings. 
 
-You can modify the TLS port 443 to port 8443 in the Docker Compose configuration, if you want the container to start without priviledges, for example using Podman.
+You can modify the TLS port 443 to port 8443 [in the Compose configuration](./compose.yaml), if you want the container to start without privileges, for example using Podman.
 
 ## Tests
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -76,7 +76,7 @@ services:
       dockerfile: proxy.Dockerfile
     ports:
       - '8000:8000'
-      - '8443:8443'
+      - '443:443'
     environment:
       TILES_UPSTREAM: martin:3000
       API_UPSTREAM: api:5000

--- a/proxy/proxy.conf.template
+++ b/proxy/proxy.conf.template
@@ -9,8 +9,8 @@ proxy_cache_path /var/cache/nginx/
 server {
   listen 8000 default_server;
   listen [::]:8000 ipv6only=on;
-  listen 8443 ssl;
-  listen [::]:8443 ipv6only=on ssl;
+  listen 443 ssl;
+  listen [::]:443 ipv6only=on ssl;
 
   server_name localhost;
 


### PR DESCRIPTION
Followup on #574.

Ref https://github.com/hiddewie/OpenRailwayMap-vector/issues/549#issuecomment-3351985508

Currently OpenRailwayMap is unreachable on https://openrailwaymap.app/ because Cloudflare proxies to port 443 and not to 8443.