### PR TITLE
Do not import bus-only platforms

### DIFF
--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -920,7 +920,9 @@ function osm2pgsql.process_node(object)
     })
   end
 
-  if tags.public_transport == 'platform' or tags.railway == 'platform' then
+  -- Platforms: gnore bus-only platforms
+  if (tags.public_transport == 'platform' or tags.railway == 'platform')
+    and (tags.train == 'yes' or tags.tram == 'yes' or tags.subway == 'yes' or tags.light_rail == 'yes' or tags.bus ~= 'yes') then
     platforms:insert({
       way = object:as_point(),
       name = tags.name,
@@ -1156,7 +1158,9 @@ function osm2pgsql.process_way(object)
     end
   end
 
-  if tags.public_transport == 'platform' or tags.railway == 'platform' then
+  -- Platforms: gnore bus-only platforms
+  if (tags.public_transport == 'platform' or tags.railway == 'platform')
+    and (tags.train == 'yes' or tags.tram == 'yes' or tags.subway == 'yes' or tags.light_rail == 'yes' or tags.bus ~= 'yes') then
     platforms:insert({
       way = object:as_polygon(),
       name = tags.name,
@@ -1259,7 +1263,9 @@ local route_platform_relation_roles = osm2pgsql.make_check_values_func({'platfor
 function osm2pgsql.process_relation(object)
   local tags = object.tags
 
-  if tags.public_transport == 'platform' or tags.railway == 'platform' then
+  -- Platforms: gnore bus-only platforms
+  if (tags.public_transport == 'platform' or tags.railway == 'platform')
+    and (tags.train == 'yes' or tags.tram == 'yes' or tags.subway == 'yes' or tags.light_rail == 'yes' or tags.bus ~= 'yes') then
     platforms:insert({
       way = object:as_multipolygon(),
       name = tags.name,


### PR DESCRIPTION
Fixes #575

For `public_transport = platform`:
- Always import if `train = yes`
- Always import if `tram = yes`
- Always import if `subway = yes`
- Always import if `light_rail = yes`
- Else, do not import if `bus = yes`

Always import `railway = platform`