### PR TITLE
Improve signal halo in dark mode

### DIFF
--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -48,12 +48,14 @@ const colors = {
     halo: themeSwitch('white', 'black'),
   },
   halo: themeSwitch('white', '#333'),
+  iconHalo: themeSwitch('white', '#ccc'),
   casing: themeSwitch('white', '#666'),
   hover: {
     main: themeSwitch('#ff0000', '#ff0000'),
     // High speed lines and 25kV are the hover color by default
     alternative: themeSwitch('#ffc107', '#ffc107'),
     textHalo: themeSwitch('yellow', '#28281e'),
+    iconHalo: themeSwitch('yellow', '#E7E700'),
   },
   railwayLine: {
     text: themeSwitch('#585858', '#ccc'),
@@ -1345,8 +1347,8 @@ const imageLayerWithOutline = (id, spriteExpression, layer) => [
     ...layer,
     paint: {
       'icon-halo-color': ['case',
-        ['boolean', ['feature-state', 'hover'], false], colors.hover.textHalo,
-        colors.halo,
+        ['boolean', ['feature-state', 'hover'], false], colors.hover.iconHalo,
+        colors.iconHalo,
       ],
       'icon-halo-blur': ['case',
         ['boolean', ['feature-state', 'hover'], false], 1.0,


### PR DESCRIPTION

For some reason the halo and hover of the signals became almost black. For the railway lines and text labels this is fine, but for the signals a more clear halo is nicer.

(http://localhost:8000/#view=17.22/48.629921/9.343935/-76.9&style=signals):

Before:
<img width="1586" height="381" alt="image" src="https://github.com/user-attachments/assets/5f68fe35-42d6-4f52-92e3-1c453d3afaf1" />


After:
<img width="1586" height="381" alt="image" src="https://github.com/user-attachments/assets/0f866d28-391c-42a0-b4f9-eff723be59c7" />
