### PR TITLE
add TMACS to train_protection.yaml

### DIFF
--- a/features/train_protection.yaml
+++ b/features/train_protection.yaml
@@ -37,6 +37,7 @@ train_protections:
   - { train_protection: 'ssc', legend: 'Sistema di Supporto alla Condotta (SSC)', color: 'hsl(155, 100%, 40%)' }
   - { train_protection: 'tasc', legend: '定位置停止装置 (TASC)', color: 'hsl(155, 100%, 40%)' }
   - { train_protection: 'tbl', legend: 'Transmissie Baken-Lokomotief (TBL)', color: 'hsl(305, 100%, 40%)' }
+  - { train_protection: 'tmacs', legend: 'Train Management and Control System (TMACS)', color: '#ffcc00' }
   - { train_protection: 'tpws', legend: 'Train Protection & Warning System (TPWS)', color: 'pink' }
   - { train_protection: 'zbs', legend: 'Zugbeeinflussung S-Bahn Berlin (ZBS)', color: 'hsl(155, 100%, 40%)' }
   - { train_protection: 'zsl90', legend: 'Zugsicherung mit Linienleiter 1990 (ZSL 90)', color: 'pink' }
@@ -258,6 +259,10 @@ features:
   - train_protection: tbl
     tags:
       - { tag: 'railway:tbl', values: ['yes', '1', '1+', '2'] }
+
+  - train_protection: tmacs
+    tags:
+      - { tag: 'railway:tmacs', value: 'yes' }
 
   - train_protection: tpws
     tags:


### PR DESCRIPTION
TMACS is another australian system ([enwiki](https://en.wikipedia.org/wiki/Train_Management_and_Control_System) | [osmwiki](https://osm.wiki/Key:railway:tmacs)). Just like ATMS (#546), it uses GPS instead of Balises.


To avoid a colour clash, i've used `#ffcc00`. This is a list of every colour used in Australia:

* `#006eff` ETCS
* `#cc0052` CBTC
* `#43b54d` ATMS
* `#884400` TWC
* `#ffc0cb` TPWS
* `#ffcc00` TMACS 🆕

<img width="1165" height="687" alt="image" src="https://github.com/user-attachments/assets/0e135eda-fa9d-42fd-9028-f60d9d48b6e7" />
<img width="1290" height="516" alt="image" src="https://github.com/user-attachments/assets/4595c1f8-1125-4451-9b0d-0827bdf23a27" />

