### PR TITLE
Split signal direction and signal features materialized views from signal query

### DIFF
--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -372,8 +372,6 @@ local signals = osm2pgsql.define_table({
   name = 'signals',
   ids = { type = 'node', id_column = 'osm_id' },
   columns = signal_columns,
-  -- The queried table is signal_features
-  cluster = 'no',
 })
 
 local boxes = osm2pgsql.define_table({


### PR DESCRIPTION

Split off from https://github.com/hiddewie/OpenRailwayMap-vector/pull/657 to make that PR a bit smaller.

Part of #484, this improves performance importing signals.

This pull request splits off the *direction* and *features* (*icons*) into separate views. 

During tile rendering, the `signals` table is joined with the direction and feature views to determine the signal direction and features for map display.