### PR TITLE
Fix import tests for shunting_route tags

### DIFF
--- a/import/test/test_import_poi.lua
+++ b/import/test/test_import_poi.lua
@@ -631,7 +631,8 @@ assert.eq(osm2pgsql.get_and_clear_imported_data(), {
       ["railway:signal:distant:repeated"] = false,
       ["railway:signal:speed_limit:deactivated"] = false,
       ["railway:signal:main_repeated:magnet"] = false,
-      ["railway:signal:main:deactivated"] = false
+      ["railway:signal:main:deactivated"] = false,
+      ["railway:signal:shunting_route:deactivated"] = false,
     },
   },
 })
@@ -694,7 +695,8 @@ assert.eq(osm2pgsql.get_and_clear_imported_data(), {
       ["railway:signal:distant:repeated"] = false,
       ["railway:signal:speed_limit:deactivated"] = false,
       ["railway:signal:main_repeated:magnet"] = false,
-      ["railway:signal:main:deactivated"] = false
+      ["railway:signal:main:deactivated"] = false,
+      ["railway:signal:shunting_route:deactivated"] = false,
     },
   },
 })


### PR DESCRIPTION
After https://github.com/hiddewie/OpenRailwayMap-vector/pull/642 CI failed in https://github.com/hiddewie/OpenRailwayMap-vector/pull/642 because of missing merge checks for import tests.