### PR TITLE
Fix UI control for enabling references as station label

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -264,7 +264,7 @@ function showConfiguration() {
 
   const stationLowZoomLabel = configuration.stationLowZoomLabel ?? defaultConfiguration.stationLowZoomLabel
   if (stationLowZoomLabel === 'label') {
-    stationLowZoomLabel.checked = true
+    stationLabelReferenceControl.checked = true
   } else if (stationLowZoomLabel === 'name') {
     stationLabelNameControl.checked = true
   }


### PR DESCRIPTION
Selecting the correct radio button from user configuration for the station labels in the settings UI was using the incorrect variable.