### PR TITLE
Feature icon height for non-centered positioned icons

### DIFF
--- a/import/sql/signal_features.sql.js
+++ b/import/sql/signal_features.sql.js
@@ -229,7 +229,7 @@ CREATE OR REPLACE VIEW signal_features_view AS
             `).join('')}
             -- Unknown signal (${type.type})
             ELSE
-              ARRAY['general/signal-unknown-${type.type}', NULL, '17.1', NULL, 'false', '${type.layer}', NULL]
+              ARRAY['general/signal-unknown-${type.type}', NULL, '17.1', '0', '0', NULL, 'false', '${type.layer}', NULL]
         END
       END as feature_${type.type}`).join(',')}
     FROM signals s


### PR DESCRIPTION
Followup on https://github.com/hiddewie/OpenRailwayMap-vector/pull/657

Features with multiple icons did not output their icon height correctly for non-center-positioned icons.

Now the feature icon height is calculated as
```
max(max(centered) + sum(top_bottom), left_right)
```
with centered the height of centered icons, `top_bottom` the height of the top/bottom positioned icons, and `left_right` the left/right positioned icons.


Tested on http://localhost:8000/#view=18.5/45.5409841/11.5417528&style=signals:
Before:
<img width="1275" height="574" alt="image" src="https://github.com/user-attachments/assets/d99aa4fb-2f50-4ddd-86ae-00037074cc28" />


After:
<img width="1196" height="586" alt="image" src="https://github.com/user-attachments/assets/5e6f79b9-99bc-4ced-8e20-7cda5f8e06ad" />
