### PR TITLE
Fix paragraph properties not displaying

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -1605,7 +1605,6 @@ function popupContent(feature) {
       .join(', ');
 
   const propertyValues = Object.entries(featureCatalog.properties || {})
-    .filter(([_, {paragraph}]) => !paragraph)
     .filter(([property, {name, format, link}]) => (properties[property] !== undefined && properties[property] !== null && properties[property] !== '' && properties[property] !== false))
     .map(([property, {name, format, link, paragraph, description}]) => ({
       title: name,


### PR DESCRIPTION
Fixes #681

For some reason all paragraph properties (those with a large amount of text) were excluded from showing in the popup.

<img width="519" height="483" alt="image" src="https://github.com/user-attachments/assets/cee9b30e-648c-4848-a806-3bd6e1241e66" />
<img width="995" height="572" alt="image" src="https://github.com/user-attachments/assets/af7def20-7bcc-4446-8f2b-65933b38628d" />
