### PR TITLE
Adjust speed colour scale

### DIFF
--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -344,7 +344,7 @@ const present_dasharray = [1];
 const train_protection_construction_dasharray = [2, 8];
 
 const minSpeed = 10
-const maxSpeed = 40
+const maxSpeed = 380
 const startHue = 250
 const endHue = 275;
 

--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -257,30 +257,19 @@ const speedLegends = [
   80,
   90,
   100,
-  110,
   120,
-  130,
   140,
-  150,
   160,
-  170,
   180,
-  190,
   200,
-  210,
   220,
-  230,
   240,
-  250,
   260,
-  270,
   280,
-  290,
   300,
   320,
   340,
-  360,
-  380
+  360
 ];
 
 const gaugeLegends = [
@@ -355,17 +344,17 @@ const present_dasharray = [1];
 const train_protection_construction_dasharray = [2, 8];
 
 const minSpeed = 10
-const maxSpeed = 380
-const startHue = 248
-const endHue = 284;
+const maxSpeed = 40
+const startHue = 250
+const endHue = 275;
 
 const speedColor = ['case',
   ['==', ['get', 'maxspeed'], null], 'gray',
   // Reverse hue order
-  ['concat', 'hsl(', ['%', ['+', ['-', startHue, ['*', startHue + (360 - endHue), ['/', ['-', ['max', minSpeed, ['min', ['get', 'maxspeed'], maxSpeed]], minSpeed], maxSpeed - minSpeed]]], 360], 360], ', 100%, 40%)'],
+  ['concat', 'hsl(', ['%', ['+', ['-', startHue, ['*', startHue + (360 - endHue), ['^', ['/', ['-', ['max', minSpeed, ['min', ['get', 'maxspeed'], maxSpeed]], minSpeed], maxSpeed - minSpeed], 0.63]]], 360], 360], ', 100%, 42%)'],
 ]
 const speedHoverColor = ['case',
-  ['all', ['!=', ['get', 'maxspeed'], null], ['>=', ['get', 'maxspeed'], 260], ['<=', ['get', 'maxspeed'], 300]], colors.hover.alternative,
+  ['all', ['!=', ['get', 'maxspeed'], null], ['>=', ['get', 'maxspeed'], 200], ['<=', ['get', 'maxspeed'], 340]], colors.hover.alternative,
   colors.hover.main,
 ]
 


### PR DESCRIPTION
This adjusts the colour scale of the speed layer with the goal of using a wider range of colours for low speed values. See #668 for more details.
<img width="1567" height="619" alt="image" src="https://github.com/user-attachments/assets/6750670a-becb-4378-a071-120cec1bfdcf" />
