### PR TITLE
Emoji flag translations for cases where country does not match language

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -41,6 +41,7 @@ const flagEmojiTranslations = {
   UK: 'UA',
   KA: 'GE',
   HY: 'AM',
+  HE: 'IS',
 }
 function getFlagEmoji(countryCode) {
   const codePoints = (flagEmojiTranslations[countryCode.toUpperCase()] || countryCode.toUpperCase())


### PR DESCRIPTION
Japan (http://localhost:8000/#view=12.31/35.36436/139.54215):
<img width="506" height="427" alt="image" src="https://github.com/user-attachments/assets/faa3effb-eafd-4fa4-9cfe-124fb778a8e9" />

Using flags for is not entirely correct (country != language), but works well enough.

Adds emoji flag translations for:
- Japanese
- Chinese
- Farsi 
- Ukranian
- Georgian
- Armenian
- Hebrew