### PR TITLE
Add User-Agent header to Wikidata API requests

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -18,7 +18,6 @@ from openrailwaymap_api.wikidata_api import WikidataAPI
 DEFAULT_HTTP_HEADERS = {
   'User-Agent': f'OpenRailwayMap API (https://openrailwaymap.app), httpx {httpx.__version__}, Python {sys.version}'
 }
-print('user agent', DEFAULT_HTTP_HEADERS)
 
 @contextlib.asynccontextmanager
 async def lifespan(app):


### PR DESCRIPTION
Fixes https://github.com/hiddewie/OpenRailwayMap-vector/issues/692

This will send a user agent header of the form
```
OpenRailwayMap API (https://openrailwaymap.app), httpx 0.28.1, Python 3.13.9 (main, Oct 15 2025, 16:47:14) [GCC 14.2.0]
```

Now it works
```shell
http http://localhost:8000/api/wikidata/Q567336

HTTP/1.1 307 Temporary Redirect
Cache-Control: public, max-age=0, stale-if-error=0
Connection: keep-alive
Content-Length: 0
Date: Sun, 30 Nov 2025 14:46:38 GMT
Server: nginx/1.29.3
location: https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/Bahnhof_Berlin-Wannsee_Empfangsgebaeude_04-2015.jpg/330px-Bahnhof_Berlin-Wannsee_Empfangsgebaeude_04-2015.jpg
```

Popup also shows images again
<img width="657" height="543" alt="image" src="https://github.com/user-attachments/assets/79ccb99d-8de1-4591-9aba-27bda2cfa23a" />
