### PR TITLE
Add colours for some German operators

### DIFF
--- a/features/operators.yaml
+++ b/features/operators.yaml
@@ -87,3 +87,59 @@ operators:
   - names:
       - 'New York & Atlantic Railway'
     color: '#38553E'
+
+  # GERMANY
+  - names:
+      - 'DB InfraGO AG'
+      - 'DB InfraGO'
+      - 'DB Netz AG'
+      - 'DB Netz'
+      - 'DB Station&Service AG'
+      - 'DB Station&Service'
+    color: '#f01414'
+
+  - names:
+      - 'Albtal-Verkehrs-Gesellschaft mbH'
+    color: '#008833'
+
+  - names:
+      - 'Berliner Verkehrsbetriebe'
+    color: '#f0d020'
+
+  - names:
+      - 'DB RegioNetz Infrastruktur GmbH'
+    color: '#dd4488'
+
+  - names:
+      - 'Regio Infra Nord-Ost GmbH & Co. KG'
+    color: '#007733'
+
+  - names:
+      - 'Rhein-Neckar-Verkehr'
+    color: '#ee7700'
+
+  - names:
+      - 'Rostocker Straßenbahn AG'
+    color: '#005090'
+
+  - names:
+      - 'SSB AG' # Stuttgarter Straßenbahnen AG
+    color: '#ffcc00'
+
+  - names:
+      - 'SWEG Schienenwege GmbH'
+    color: '#114499'
+
+  - names:
+      - 'Usedomer Bäderbahn GmbH'
+      - 'UBB Polska sp. z o.o.'
+    color: '#114488'
+
+  - names:
+      - 'Verkehrsbetriebe Karlsruhe GmbH'
+    color: '#ffaa33'
+
+  - names:
+      - 'VGF' # Verkehrsgesellschaft Frankfurt am Main
+    color: '#008080'
+


### PR DESCRIPTION
This adds colours for some German operators.

The important part is DB InfraGO, the main operator of the German rail network. Since this company is only two years old in its current form, there are several different values in use for the operator tag which currently are rendered in different colours. This should be fixed.

I used this opportunity to also assign colours to some other companies where the current colours don't fit or clash with similar colours of different operators in the same area. I mainly used the colours from the companies' logos. Where this conflicts with other colours of operators active in the same region (in particular DB's red), I used other colours associated with the company (e.g. based on the vehicle livery in Karlsruhe instead of the red logo).

**List of colours:**

_Railway:_
- DB InfraGO `#f01414`
- DB RegioNetz `#dd4488`
- AVG `#008833`
- Regio Infra Nord-Ost `#007733`
- SWEG `#114499`
- UBB `#114488`

_Tram/subway:_
- Berlin `#f0d020`
- Frankfurt `#008080`
- Karlsruhe `#ffaa33`
- Rhein-Neckar `#ee7700`
- Rostock `#005090`
- Stuttgart `#ffcc00`