### PR TITLE
Hillshade: use global state to toggle layer visibility

### DIFF
--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -1439,6 +1439,12 @@ const hillshade = {
       15, 0.8,
     ],
   },
+  layout: {
+    visibility: ['case',
+      ['global-state', 'hillshade'], 'visible',
+      'none',
+    ],
+  }
 }
 
 /**
@@ -4610,6 +4616,9 @@ const makeStyle = selectedStyle => ({
     stationLowZoomLabel: {
       default: 'label',
     },
+    hillshade: {
+      default: false,
+    }
   },
 });
 

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -666,7 +666,7 @@ function disableHillShade() {
 
 function updateHillShadeOnMap() {
   const hillshadeVisible = configuration.backgroundHillShade ?? defaultConfiguration.backgroundHillShade
-  map.setLayoutProperty('hillshade', 'visibility', hillshadeVisible ? 'visible' : 'none')
+  map.setGlobalStateProperty('hillshade', hillshadeVisible);
 }
 
 function onStationLabelChange(stationlabel) {
@@ -1136,17 +1136,7 @@ function rewriteGlobalStateDefaults(style) {
   style.state.date.default = selectedDate;
   style.state.theme.default = selectedTheme;
   style.state.stationLowZoomLabel.default = configuration.stationLowZoomLabel ?? defaultConfiguration.stationLowZoomLabel;
-}
-
-function toggleHillShadeLayer(style) {
-  const hillshadeVisible = configuration.backgroundHillShade ?? defaultConfiguration.backgroundHillShade
-  const layer = style.layers.find(layer => layer.id === 'hillshade')
-  if (layer) {
-    layer.layout = {
-      ...layer.layout,
-      visibility: hillshadeVisible ? 'visible' : 'none'
-    }
-  }
+  style.state.hillshade.default = configuration.backgroundHillShade ?? defaultConfiguration.backgroundHillShade;
 }
 
 let lastSetMapStyle = null;
@@ -1167,7 +1157,6 @@ function onStyleChange() {
         rewriteStylePathsToOrigin(next)
         addLanguageToSupportedSources(next, language)
         rewriteGlobalStateDefaults(next)
-        toggleHillShadeLayer(next)
         return next;
       },
     });


### PR DESCRIPTION
Usable since Maplibre GL JS 5.15, see https://github.com/hiddewie/OpenRailwayMap-vector/pull/722 and https://github.com/maplibre/maplibre-gl-js/pull/6659.

The same structure will be used for #600 to toggle layer visibility.