### PR TITLE
Train protection: ATS, ATACS, KTCS

### DIFF
--- a/features/train_protection.yaml
+++ b/features/train_protection.yaml
@@ -38,6 +38,7 @@ train_protections:
   - { train_protection: 'tasc', legend: '定位置停止装置 (TASC)', color: 'hsl(155, 100%, 40%)' }
   - { train_protection: 'ats', legend: 'Automatic Train Stop (ATS)', color: '#b58a00' }
   - { train_protection: 'atacs', legend: 'Advanced Train Administration and Communications System (ATACS)', color: '#008e2d' }
+  - { train_protection: 'ktcs', legend: '한국형 열차제어시스템 (KTCS)', color: '#008e2d' }
   - { train_protection: 'tbl', legend: 'Transmissie Baken-Lokomotief (TBL)', color: 'hsl(305, 100%, 40%)' }
   - { train_protection: 'tmacs', legend: 'Train Management and Control System (TMACS)', color: '#ffcc00' }
   - { train_protection: 'tpws', legend: 'Train Protection & Warning System (TPWS)', color: 'pink' }
@@ -265,6 +266,10 @@ features:
   - train_protection: atacs
     tags:
       - { tag: 'railway:atacs', value: 'yes' }
+
+  - train_protection: ktcs
+    tags:
+      - { tag: 'railway:ktcs', values: ['yes', '2', '3', 'M'] }
 
   - train_protection: tbl
     tags:


### PR DESCRIPTION
From https://wiki.openstreetmap.org/wiki/OpenRailwayMap/Tagging

See https://en.wikipedia.org/wiki/ATACS, https://en.wikipedia.org/wiki/Automatic_train_stop, https://en.wikipedia.org/wiki/Korean_Train_Control_System.

South Korea (http://localhost:8000/#view=7.85/36.168/128.101&style=signals):

Some lines are combined ATS and ETCS actually, this will be shown once #549 is implemented.

Before:
<img width="1431" height="1115" alt="image" src="https://github.com/user-attachments/assets/8c1235c6-ecc7-41c6-b493-d6c6cd42f44e" />


After:
<img width="1431" height="1115" alt="image" src="https://github.com/user-attachments/assets/34ac45b1-fee7-4b71-9ba3-5fde498b57b5" />
