### PR TITLE
Specify services to run when running locally

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -10,7 +10,7 @@ Ensure [Docker](https://docs.docker.com/engine/install/) or [Podman](https://pod
 
 Start the services with:
 ```
-docker compose up --build --watch
+docker compose up --build --watch db import martin proxy api
 ```
 
 The command will start the database (service `db`), run the data import (service `import`), start the tile server Martin (service `martin`), start the API (service `api`) and the web server (service `proxy`). The import can take a few minutes depending on the amount of data to be imported.


### PR DESCRIPTION
From #723

Followup from https://github.com/hiddewie/OpenRailwayMap-vector/issues/396.

There are more services than needed in the Docker Compose file. The SETUP.md instructions will only start the actual needed services to run the project, not the tests or extra data services.