### PR TITLE
Fix invalid color for "Toronto Transit Commission" operator

### DIFF
--- a/features/operators.yaml
+++ b/features/operators.yaml
@@ -252,7 +252,7 @@ operators:
 
   - names:
       - 'Toronto Transit Commission'
-    color: '#da251dc'
+    color: '#da251d'
 
   # --- CA: Genesee & Wyoming subsidiaries --- #
   - names:


### PR DESCRIPTION
<img width="1435" height="57" alt="image" src="https://github.com/user-attachments/assets/c05481b5-2e8e-4412-a61e-40ca5b05d664" />
