### PR TITLE
Offset signal reference/caption based on icon height

### DIFF
--- a/import/sql/signal_features.sql.js
+++ b/import/sql/signal_features.sql.js
@@ -328,6 +328,7 @@ CREATE OR REPLACE FUNCTION speed_railway_signals(z integer, x integer, y integer
         features[2] as feature1,
         deactivated[1] as deactivated0,
         deactivated[2] as deactivated1,
+        CEIL(icon_height[1] / 2) as offset0,
         CEIL(icon_height[1] / 2 + icon_height[2] / 2) as offset1,
         type
       FROM signals s
@@ -369,6 +370,7 @@ DO $do$ BEGIN
           "feature1": "string",
           "deactivated0": "boolean",
           "deactivated1": "boolean",
+          "offset0": "number",
           "offset1": "number",
           "type": "string"
         }
@@ -421,6 +423,7 @@ CREATE OR REPLACE FUNCTION signals_railway_signals(z integer, x integer, y integ
         deactivated[4] as deactivated3,
         deactivated[5] as deactivated4,
         deactivated[6] as deactivated5,
+        CEIL(icon_height[1] / 2) as offset0,
         CEIL(icon_height[1] / 2 + icon_height[2] / 2) as offset1,
         CEIL(icon_height[1] / 2 + icon_height[2] + icon_height[3] / 2) as offset2,
         CEIL(icon_height[1] / 2 + icon_height[2] + icon_height[3] + icon_height[4] / 2) as offset3,
@@ -475,6 +478,7 @@ DO $do$ BEGIN
           "deactivated3": "boolean",
           "deactivated4": "boolean",
           "deactivated5": "boolean",
+          "offset0": "number",
           "offset1": "number",
           "offset2": "number",
           "offset3": "number",
@@ -520,6 +524,7 @@ CREATE OR REPLACE FUNCTION electrification_signals(z integer, x integer, y integ
         ${tag.type === 'array' ? `array_to_string("${tag.tag}", U&'\\001E') as "${tag.tag}"` : `"${tag.tag}"`},`).join('')}
         features[1] as feature,
         deactivated[1] as deactivated,
+        CEIL(icon_height[1] / 2) as offset,
         type as type
       FROM signals s
       JOIN signal_features sf
@@ -559,7 +564,8 @@ DO $do$ BEGIN
           "description": "string",${signals_railway_signals.tags.map(tag => `
           "${tag.tag}": "${tag.type === 'boolean' ? `boolean` : `string`}",`).join('')}
           "feature": "string",
-          "deactivated": "boolean"
+          "deactivated": "boolean",
+          "offset": "number"
         }
       }
     ]

--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -3587,7 +3587,12 @@ const layers = {
         'text-font': font.regular,
         'text-size': 9,
         'text-anchor': 'top',
-        'text-offset': [0, 1.5],
+        'text-offset': ['interpolate', ['linear'],
+          // 2 pixel spacing under icon
+          ['/', ['+', ['get', 'offset0'], 2], 9],
+          0, ['literal', [0, 0]],
+          20, ['literal', [0, 20]],
+        ],
       },
     },
     searchResults,
@@ -3977,7 +3982,12 @@ const layers = {
         'text-font': font.regular,
         'text-size': 9,
         'text-anchor': 'top',
-        'text-offset': [0, 1.5],
+        'text-offset': ['interpolate', ['linear'],
+          // 2 pixel spacing under icon
+          ['/', ['+', ['get', 'offset0'], 2], 9],
+          0, ['literal', [0, 0]],
+          20, ['literal', [0, 20]],
+        ],
       },
     },
     {
@@ -4384,7 +4394,12 @@ const layers = {
         'text-font': font.regular,
         'text-size': 9,
         'text-anchor': 'top',
-        'text-offset': [0, 1.5],
+        'text-offset': ['interpolate', ['linear'],
+          // 2 pixel spacing under icon
+          ['/', ['+', ['get', 'offset'], 2], 9],
+          0, ['literal', [0, 0]],
+          20, ['literal', [0, 20]],
+        ],
       },
     },
     {


### PR DESCRIPTION
Noticed during https://github.com/hiddewie/OpenRailwayMap-vector/pull/734#issue-3751404295

For tall icons for the bottom icon of a signal feature, the reference is always offset using the same fixed offset. This will overlap the reference text with the icon.

Instead, output the icon offset such that the text label for the reference can be offset by the same value (plus some padding).

(http://localhost:8000/#view=18.41/49.010647/8.384991/-19.5&style=signals): 
<img width="1074" height="574" alt="image" src="https://github.com/user-attachments/assets/c2288181-d5f6-4327-ab5d-0ac441065624" />

(http://localhost:8000/#view=18.08/49.00242/8.394911/-19.5&style=signals)
<img width="1074" height="574" alt="image" src="https://github.com/user-attachments/assets/8ab6c7b6-c929-4611-9b9d-beadda7b015b" />

(http://localhost:8000/#view=19/48.9970422/8.4158721/-19.5&style=signals)
<img width="1074" height="574" alt="image" src="https://github.com/user-attachments/assets/283ae76b-cfd9-44cc-8129-b91b11545251" />
