### PR TITLE
Fix feature lookup for complex signal icons

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -2052,7 +2052,7 @@ function popupContent(feature) {
 
   const constructCatalogKey = propertyValue => ({
     // Remove the variable part of the property, and icon position to get the key
-    catalogKey: propertyValue && typeof propertyValue === 'string' ? propertyValue.replace(/\{[^}]+}/, '{}').replace(/@([^|]+|$)/, '') : propertyValue,
+    catalogKey: propertyValue && typeof propertyValue === 'string' ? propertyValue.replace(/\{[^}]+}/, '{}').replace(/@([^|]+|$)/g, '') : propertyValue,
     // Capture the variable part as well for display
     keyVariable: propertyValue && typeof propertyValue === 'string'
       ? propertyValue.match(/\{([^}]+)}/)?.[1]
@@ -2115,7 +2115,7 @@ function popupContent(feature) {
             const {catalogKey: lookUpCatalogKey, keyVariable: lookUpKeyVariable} = constructCatalogKey(value);
             const lookedUpValue = lookupCatalog.features[lookUpCatalogKey];
             if (!lookedUpValue) {
-              console.warn('Lookup catalog', format.lookup, 'did not contain value', value, 'for feature', feature);
+              console.warn(`Lookup catalog ${format.lookup} did not contain key ${value} (catalog key ${lookUpCatalogKey}${lookUpKeyVariable ? ` with variable ${lookUpKeyVariable}`: ''}) for feature`, feature);
               return stringValue;
             } else {
               return `${lookedUpValue.name}${lookUpKeyVariable ? ` (${lookUpKeyVariable})` : ''}${lookedUpValue.country ? ` ${getFlagEmoji(lookedUpValue.country)}` : ''}`;


### PR DESCRIPTION
For stacked signal icons, with multiple icons that have an icon with a position defined, only the first position was removed on the catalog lookup.

Found during testing of https://github.com/hiddewie/OpenRailwayMap-vector/pull/734#issuecomment-3704004898

(http://localhost:8000/#view=17.65/49.00464/8.411248/-19.5&style=signals):
<img width="847" height="596" alt="image" src="https://github.com/user-attachments/assets/8a0731fe-6a35-402f-8e44-83b417428464" />
