### PR TITLE
Clear more disk space during nightly update

### DIFF
--- a/.github/workflows/nightly-update.yml
+++ b/.github/workflows/nightly-update.yml
@@ -64,7 +64,11 @@ jobs:
           OSM2PGSQL_NUMPROC: '8'
         run: |
           docker compose run --no-deps import import
+
+      - name: Clear disk space
+        run: |
           rm -f data/filtered/data.osm.pbf
+          docker system prune -af
 
       - name: Create database image
         run: |


### PR DESCRIPTION
Nightly update still fails sometimes because of disk space: https://github.com/hiddewie/OpenRailwayMap-vector/actions/runs/20937798180/job/60164501320#step:12:9.

Prune the Docker daemon to retrieve disk space before outputting the database image.