### PR TITLE
Fix missing stations without routes

### DIFF
--- a/import/sql/tile_views.sql
+++ b/import/sql/tile_views.sql
@@ -853,7 +853,7 @@ RETURN (
     FROM (
       SELECT
         *,
-        UNNEST(route_ids`) as route_id
+        UNNEST(route_ids) as route_id
       FROM grouped_stations_with_importance
 
       UNION ALL


### PR DESCRIPTION
Fixes #787

For (grouped) stations that have no `route_ids`, also query `null` values for the routes IDs, to allow a null-join.

Now yards and service stations and and junctions are shown again.

<img width="860" height="627" alt="image" src="https://github.com/user-attachments/assets/1db4dd54-bb4c-43df-8bde-d4446b34841e" />
