### PR TITLE
Changed color of operators in KR

### DIFF
--- a/features/operators.yaml
+++ b/features/operators.yaml
@@ -1361,7 +1361,7 @@ operators:
 
   - names:
       - '인천교통공사'
-    color: '#009ddc'
+    color: '#ff671f'
 
   - names:
       - '서해철도주식회사'
@@ -1377,10 +1377,11 @@ operators:
 
   - names:
       - '로템SRS'
-      - '(주)우진메트로'
     color: '#ad0003'
 
   - names:
+      - '(주)우진메트로'
+      - '우진메트로양산'
       - '우이신설경전철운영(주)'
     color: '#95296f'
 


### PR DESCRIPTION
1. Changed color of '인천교통공사' to #ff671f, one of another symbolic color of the operator, in order to visually differentiate it from '공항철도주식회사'.
2. Moved '(주)우진메트로' to #95296f because it was wrongly categorized. (and those three operators belong to same parent company)
3. Added '우진메트로양산'.
<img width="1096" height="1392" alt="image" src="https://github.com/user-attachments/assets/affa432e-2aaa-474a-a7fc-38059939123d" />
