### PR TITLE
Fix missing default configuration for gauge in track layer

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -1142,7 +1142,8 @@ const defaultConfiguration = {
   view: {},
   stationLowZoomLabel: 'label',
   localization: 'automatic',
-  electrificationRailwayLine: 'voltageFrequency'
+  electrificationRailwayLine: 'voltageFrequency',
+  trackRailwayLine: 'gauge',
 };
 let configuration = readConfiguration(localStorage);
 configuration = migrateConfiguration(localStorage, configuration);


### PR DESCRIPTION
Fixes #794

If the user has not configured the preferred track layer visualization, the track layer will default to the gauge. The configuration UI also shows this default. However the map did not incorporate it in all places, showing every line as having an unknown gauge.