### PR TITLE
Fix substations linking to incorrect OSM objects

### DIFF
--- a/proxy/js/features.mjs
+++ b/proxy/js/features.mjs
@@ -1192,6 +1192,7 @@ const features = {
     features: {
       traction: {
         name: 'Traction substation',
+        type: 'polygon',
       },
     },
     properties: {


### PR DESCRIPTION
Fixes #771

(https://openrailwaymap.app/#view=17.47/51.6838/4.66711&style=electrification):
<img width="402" height="415" alt="image" src="https://github.com/user-attachments/assets/730f4a60-efd8-462c-b41f-35fd80de5c5f" />

Now links to https://www.openstreetmap.org/way/163031244 instead of https://www.openstreetmap.org/node/163031244.