### PR TITLE
Pin Docker image digests

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine
+FROM python:3-alpine@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
 RUN apk add --no-cache \
         curl \

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM imresamu/postgis:18-3.6-alpine
+FROM imresamu/postgis:18-3.6-alpine@sha256:93e9dbe9fb7d35b2cabed8e819d385d5b5f1acb516351f5d2c5a240783b75e4f
 
 COPY tune-postgis.sh /docker-entrypoint-initdb.d/tune-postgis.sh
 COPY operators.sql /docker-entrypoint-initdb.d/operators.sql

--- a/martin.Dockerfile
+++ b/martin.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/maplibre/martin:main
+FROM ghcr.io/maplibre/martin:main@sha256:5668210f16293b1769f72671ea5aed9dee16cf7bfdb039798f7cd88415704749
 
 COPY martin /config
 COPY symbols /symbols

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS build-yaml
+FROM node:22-alpine@sha256:e4bf2a82ad0a4037d28035ae71529873c069b13eb0455466ae0bc13363826e34 AS build-yaml
 
 WORKDIR /build
 
@@ -33,7 +33,7 @@ RUN --mount=type=bind,source=proxy/js/features.mjs,target=features.mjs \
   node /build/features.mjs \
     > /build/features.json
 
-FROM python:3-alpine AS build-preset
+FROM python:3-alpine@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510 AS build-preset
 
 RUN apk add --no-cache zip
 
@@ -54,7 +54,7 @@ RUN --mount=type=bind,source=symbols,target=symbols \
     symbols \
     preset.xml
 
-FROM nginx:1-alpine
+FROM nginx:1-alpine@sha256:1d13701a5f9f3fb01aaa88cef2344d65b6b5bf6b7d9fa4cf0dca557a8d7702ba
 
 COPY proxy/script/with-news-hash.sh /with-news-hash.sh
 COPY proxy/proxy.conf.template /etc/nginx/templates/proxy.conf.template


### PR DESCRIPTION
This allows offline starting of the Docker services. Without an image pin, the Docker daemon will try to fetch the (possibly updated) image digest before starting the service.

This can be integrated with Renovate in the future, to automatically receive pull requests to update the source images.