### PR TITLE
Improve DE-BOStrab departure signal and Fahrsignal

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -3784,7 +3784,7 @@ features:
 
   - description: tram Fahrsignal
     country: DE
-    exampleIcon: de/bostrab/f1
+    exampleIcon: de/bostrab/f1-old
     icon:
       - match: 'railway:signal:main:PT_priority'
         cases:
@@ -3793,50 +3793,47 @@ features:
 
       - match: 'railway:signal:main:states'
         cases:
-          - {
-              any: [
-              'DE-AVG:f4', 'DE-BOStrab:f4',
-              'DE-AVG:f1', 'DE-BOStrab:f1',
-              'DE-AVG:f2', 'DE-BOStrab:f2',
-              'DE-AVG:f3', 'DE-BOStrab:f3',
-              'DE-AVG:f5', 'DE-BOStrab:f5',
-              ],
-              value: 'de/bostrab/fahrsignal-empty'
-            }
+          - { any: [ 'DE-AVG:f0', 'DE-BOStrab:f0' ], value: 'de/bostrab/f0', description: 'F 0' }
         position: bottom
 
       - match: 'railway:signal:main:states'
         cases:
-          - { any: [ 'DE-AVG:f4', 'DE-BOStrab:f4' ], value: 'de/bostrab/f4' }
+          - { any: [ 'DE-AVG:f4', 'DE-BOStrab:f4' ], value: 'de/bostrab/f4', description: 'F 4' }
         position: bottom
 
       - match: 'railway:signal:main:states'
         cases:
-          - { any: [ 'DE-AVG:f1', 'DE-BOStrab:f1' ], value: 'de/bostrab/f1' }
+          - { any: [ 'DE-AVG:f1', 'DE-BOStrab:f1' ], value: 'de/bostrab/f1', description: 'F 1' }
         position: bottom
 
       - match: 'railway:signal:main:states'
         cases:
-          - { any: [ 'DE-AVG:f2', 'DE-BOStrab:f2' ], value: 'de/bostrab/f2' }
+          - { any: [ 'DE-AVG:f2', 'DE-BOStrab:f2' ], value: 'de/bostrab/f2', description: 'F 2' }
         position: bottom
 
       - match: 'railway:signal:main:states'
         cases:
-          - { any: [ 'DE-AVG:f3', 'DE-BOStrab:f3' ], value: 'de/bostrab/f3' }
+          - { any: [ 'DE-AVG:f3', 'DE-BOStrab:f3' ], value: 'de/bostrab/f3', description: 'F 3' }
         position: bottom
 
       - match: 'railway:signal:main:states'
         cases:
-          - { any: [ 'DE-AVG:f5', 'DE-BOStrab:f5' ], value: 'de/bostrab/f5' }
+          - { any: [ 'DE-AVG:f5', 'DE-BOStrab:f5' ], value: 'de/bostrab/f5', description: 'F 5' }
+        position: bottom
+
+      - match: 'railway:signal:main:states'
+        cases:
+          - { exact: '?', value: 'de/bostrab/fahrsignal-empty', description: 'further, unidentified aspects' }
         position: bottom
 
     tags:
       - { tag: 'railway:signal:main', any: [ 'DE-AVG:f', 'DE-BOStrab:f' ] }
       - { tag: 'railway:signal:main:form', value: 'light' }
+      - { tag: 'railway:signal:main:states', any: [ 'DE-BOStrab:f0', 'DE-BOStrab:f1', 'DE-BOStrab:f2', 'DE-BOStrab:f3', 'DE-BOStrab:f4', 'DE-BOStrab:f5', 'DE-AVG:f0', 'DE-AVG:f1', 'DE-AVG:f2', 'DE-AVG:f3', 'DE-AVG:f4', 'DE-AVG:f5' ] }
 
-  - description: tram Fahrsignal (unknown)
+  - description: tram Fahrsignal (aspects unknown)
     country: DE
-    icon: [ default: 'de/bostrab/f-unknown' ]
+    icon: [ default: 'de/bostrab/f0-old' ]
     tags:
       - { tag: 'railway:signal:main', any: [ 'DE-AVG:f', 'DE-BOStrab:f' ] }
       - { tag: 'railway:signal:main:form', value: 'light' }

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -3299,13 +3299,18 @@ features:
       - { tag: 'railway:signal:departure', value: 'DE-ESO:zp' }
       - { tag: 'railway:signal:departure:form', value: 'light' }
 
-  - description: tram departure signals
+  - description: tram departure signal
     country: DE
+    exampleIcon: de/bostrab/a1
     icon:
       - match: 'railway:signal:departure:states'
         cases:
-          - { exact: 'DE-BOStrab:a2', value: 'de/bostrab/a2' }
-        default: 'de/bostrab/a1'
+          - { exact: 'DE-BOStrab:a1', value: 'de/bostrab/a1', description: 'close doors (A 1)' }
+        position: bottom
+      - match: 'railway:signal:departure:states'
+        cases:
+          - { exact: 'DE-BOStrab:a2', value: 'de/bostrab/a2', description: 'depart (A 2)' }
+        position: bottom
     tags:
       - { tag: 'railway:signal:departure', any: [ 'DE-BOStrab:a', 'DE-BOStrab:a1', 'DE-BOStrab:a2' ] }
       - { tag: 'railway:signal:departure:form', value: 'light' }


### PR DESCRIPTION
This improves two German tram signals as part of #811.

### Departure signals A 1 / A 2
Currently, at departure signals ([documentation](https://wiki.openstreetmap.org/wiki/DE:OpenRailwayMap/Tagging_Trams_in_Germany#Abfertigungssignale_(A))) which can show both the A 1 and A 2 aspect, only the A 2 one is rendered. This PR fixes that.

#### Example
([12377252458](https://www.openstreetmap.org/node/12377252458))
<img width="442" height="472" alt="Screenshot 2026-03-01 162702" src="https://github.com/user-attachments/assets/d1f01920-6eab-4e53-a862-839f52f97d09" />

### Fahrsignal
The Fahrsignal `DE-BOStrab:f` ([documentation](https://wiki.openstreetmap.org/wiki/DE:OpenRailwayMap/Tagging_Trams_in_Germany#Fahrsignale_(F))) has two problems at the moment:
* The F 0 aspect is not rendered. Instead, every Fahrsignal has an additional "empty" signal light. I don't know whether this was an intentional choice, but (as noted in #811) this makes it impossible to distinguish (rare) signals without an F 0 aspect.
* Signals where the states are not explicitly tagged are not rendered at all. There is a `tram Fahrsignal (unknown)` in the signal specification, but this is never reached as these signals also match the section above.

This PR makes the following changes:
* The F 0 aspect is rendered when tagged.
* The rendering of the additional "empty" signal light is removed.
* Instead, an additional empty light is rendered if there are further, untagged aspects (indicated by a `?` in `railway:signal:main:states`). This allows to visually distinguish signals which are tagged completely from those which are not. It also ensures that (as before) no signals are rendered with only one light, as this looks not nice – except for the case where there really is only one light on the ground (see example).
* Signals without any tagged states are now rendered, as the "normal" Fahrsignal now matches only to those signals where at least one state has been tagged.
* For this case, I replaced the previous symbol `de/bostrab/f-unknown` (traffic light showing a question mark) by `de/bostrab/f0-old` (traffic light showing F 0). I think this is better since it allows to visually recognize the signal as a Fahrsignal (as opposed to e.g. a switch signal which also "looks like a traffic light"). There are several hundred Fahrsignale without tagged states. Almost every Fahrsignal has an F 0 aspect, which is also why F 0 was the default icon for the Fahrsignal before the more detailed rendering was introduced. 

#### Examples (before/after)
typical case ([13015719193](https://www.openstreetmap.org/node/13015719193))
<img width="210" height="198" alt="Screenshot 2026-03-01 165253" src="https://github.com/user-attachments/assets/564be6bd-204f-4010-81b5-305ae7255d83" /><img width="205" height="197" alt="Screenshot 2026-03-01 165304" src="https://github.com/user-attachments/assets/11d16675-38a6-45c2-aec5-c932ec61a092" />

without specified states ([10963864069](https://www.openstreetmap.org/node/10963864069))
<img width="313" height="284" alt="Screenshot 2026-03-01 162616" src="https://github.com/user-attachments/assets/0b48a8b2-c24e-43ca-8352-39d7c9e08bc3" /><img width="299" height="268" alt="Screenshot 2026-03-01 162627" src="https://github.com/user-attachments/assets/7187b65f-797c-4358-b127-946075e96858" />

without F 0 state ([13015719198](https://www.openstreetmap.org/node/13015719198))
<img width="226" height="194" alt="Screenshot 2026-03-01 165147" src="https://github.com/user-attachments/assets/d2d9af1f-4715-4e5c-b2d2-8dfff03c74ce" /><img width="201" height="174" alt="Screenshot 2026-03-01 165153" src="https://github.com/user-attachments/assets/5e8f25a9-03ad-421a-ba46-1e9dd8a0c82f" />

with additional `?` states (on the left, [13449257639](https://www.openstreetmap.org/node/13449257639))
<img width="205" height="174" alt="Screenshot 2026-03-01 165945" src="https://github.com/user-attachments/assets/d33f4c5f-7738-4a96-b08f-908e6fd70234" /><img width="202" height="176" alt="Screenshot 2026-03-01 165959" src="https://github.com/user-attachments/assets/33eff484-1b38-423b-910d-e245abe75388" />