### PR TITLE
Add UK gradient post

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -144,6 +144,7 @@ tags:
   - { tag: 'railway:signal:slope:deactivated', title: 'Slope deactivated', type: boolean }
   - { tag: 'railway:signal:slope:incline', title: 'Slope incline' }
   - { tag: 'railway:signal:slope:length', title: 'Slope length' }
+  - { tag: 'railway:signal:slope:shape', title: 'Slope shape' }
   - { tag: 'railway:signal:slope:distance', title: 'Slope distance' }
   - { tag: 'railway:signal:snowplow', title: 'Snowplow' }
   - { tag: 'railway:signal:snowplow:form', title: 'Snowplow form' }

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -6054,6 +6054,17 @@ features:
       - { tag: 'railway:signal:speed_limit', value: 'GB-NR:speed_limit' }
       - { tag: 'railway:signal:speed_limit:form', value: 'sign' }
 
+  - description: Gradient post
+    country: GB
+    icon:
+      - match: 'railway:signal:slope:shape'
+        cases:
+          - { exact: 'board', value: 'gb/gradient-board' }
+        default: 'gb/gradient-arms'
+    tags:
+      - { tag: 'railway:signal:slope', value: 'GB-NR:gradient' }
+      - { tag: 'railway:signal:slope:form', value: 'sign' }
+
   # --- IT --- #
 
   - description: Route

--- a/symbols/gb/gradient-arms.svg
+++ b/symbols/gb/gradient-arms.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="20" height="12" viewBox="0 0 20 12">
+<path stroke="#000000" stroke-width="3.4" stroke-linecap="square" fill="none" d="M 1.7,6 L 10,6 L 17.5,2.5"/>
+<path stroke="#FFFFFF" stroke-width="3" stroke-linecap="square" fill="none" d="M 1.7,6 L 10,6 L 17.5,2.5"/>
+<path fill="#FFFFFF" stroke="#000000" stroke-width="0.2" d="m 9,13 V 2 l 1,-1 l 1,1 V 13 z"/>
+</svg>

--- a/symbols/gb/gradient-board.svg
+++ b/symbols/gb/gradient-board.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="20" height="10" viewBox="0 0 20 10">
+<path fill="#FFFFFF" d="M 0,0 H 20 V 10 H 0 Z"/>
+<path stroke="#000000" stroke-width="1.5" fill="none" d="M 2,6 L 10,6 L 18,3"/>
+</svg>


### PR DESCRIPTION
This adds the slope signal for the UK.

Documentation: https://wiki.openstreetmap.org/wiki/OpenRailwayMap/Tagging_in_the_United_Kingdom#Gradient_post

### Examples
Board shape: [13565427184](https://www.openstreetmap.org/node/13565427184)
<img width="237" height="201" alt="Screenshot 2026-03-10 032425" src="https://github.com/user-attachments/assets/6da79927-b000-4c9e-99a0-82c0be31f41b" />

Arms shape: (test only, not yet used in OSM)
<img width="219" height="200" alt="Screenshot 2026-03-10 034142" src="https://github.com/user-attachments/assets/c1ef1e2b-ef5d-4ce5-a4b9-5c213ef3c7ea" />