### PR TITLE
Improved controls for date

### DIFF
--- a/proxy/css/ui.css
+++ b/proxy/css/ui.css
@@ -397,7 +397,7 @@ body {
 .maplibregl-ctrl-group.maplibregl-ctrl-date .date-input {
   width: 200px;
   padding: 0;
-  margin: 0 .5rem 0 .2rem;
+  margin: 0 .3rem 0 0;
   vertical-align: middle;
 }
 @media (max-width: 767px) {
@@ -421,13 +421,13 @@ body {
   }
 }
 .maplibregl-ctrl-group.maplibregl-ctrl-date .date-display {
-  padding-right: .5rem;
   display: inline-block;
   width: 4rem;
   text-align: center;
   font-weight: bold;
   font-size: 0.9rem;
   vertical-align: middle;
+  border: none;
 }
 
 .maplibregl-popup-content img.osm-type-icon {

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -1450,19 +1450,27 @@ class DateControl {
     this.dateDisplay.max = defaultDate
     this.dateDisplay.step = 1
     this.dateDisplay.onchange = () => {
-      const value = Math.min(
-        this.dateDisplay.max,
-        Math.max(this.dateDisplay.min, this.dateDisplay.valueAsNumber),
-      );
-      this.onExternalDateChange(this.allDates.checked ? 'all' : value);
-      this.options.onChange(this.showAllDates ? 'all' : this.showDate);
+      if (this.dateDisplay.type === 'number') {
+        const value = Math.min(
+          this.dateDisplay.max,
+          Math.max(this.dateDisplay.min, this.dateDisplay.valueAsNumber),
+        );
+        this.onExternalDateChange(this.allDates.checked ? 'all' : value);
+        this.options.onChange(this.showAllDates ? 'all' : this.showDate);
+      } else {
+        const value = this.dateDisplay.value;
+        if (value === 'present') {
+          this.onExternalDateChange(this.allDates.checked ? 'all' : defaultDate);
+          this.options.onChange(this.showAllDates ? 'all' : defaultDate);
+        }
+      }
     }
     this.dateDisplay.oninput = () => {
-      const value = Math.min(
-        this.dateDisplay.max,
-        Math.max(this.dateDisplay.min, this.dateDisplay.valueAsNumber),
-      );
-      this.onExternalDateChange(this.allDates.checked ? 'all' : value);
+      const value = this.dateDisplay.valueAsNumber;
+      if (this.dateDisplay.min <= value && value <= this.dateDisplay.max) {
+        this.onExternalDateChange(this.allDates.checked ? 'all' : value);
+        this.options.onChange(this.allDates.checked ? 'all' : value);
+      }
     }
 
     this.onExternalDateChange(this.options.initialSelection);
@@ -1478,6 +1486,7 @@ class DateControl {
   onExternalDateChange(date) {
     this.showAllDates = date === 'all';
     this.showDate = (date === 'all' ? defaultDate : date) ?? defaultDate;
+    console.info(date, this.showAllDates, this.showDate)
 
     this.updateDisplay();
   }

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -664,7 +664,7 @@ function determineZoomCenterFromHash(hash) {
 function putParametersInHash(hash, style, date) {
   const hashObject = hashToObject(hash);
   hashObject.style = style !== defaultStyle ? style : undefined;
-  hashObject.date = dateControl.active ? date : undefined;
+  hashObject.date = dateControl.isActive() ? date : undefined;
   return `#${Object.entries(hashObject).filter(([_, value]) => value).map(([key, value]) => `${key}=${value}`).join('&')}`;
 }
 
@@ -1420,11 +1420,9 @@ class DateControl {
     this.allDates.id = 'all-dates'
     this.allDates.type = 'checkbox'
     this.allDates.style = 'text-align: center;font-weight: bold;font-size: 0.9rem;vertical-align: middle;margin-right: .3rem;' // TODO
-    this.allDates.checked = this.options.initialSelection === 'all';
     this.allDates.onchange = () => {
-      this.detectChanges();
-      this.updateDisplay();
-      this.options.onChange(this.allDates.checked ? 'all' : this.slider.valueAsNumber);
+      this.onExternalDateChange(this.allDates.checked ? 'all' : this.slider.valueAsNumber);
+      this.options.onChange(this.showAllDates ? 'all' : this.showDate);
     }
 
     this.label = createDomElement('label', 'all-dates-label hide-mobile-show-desktop', this._container);
@@ -1438,24 +1436,36 @@ class DateControl {
     this.slider.min = 1758
     this.slider.max = defaultDate
     this.slider.step = 1
-    this.slider.valueAsNumber = (this.options.initialSelection === 'all' ? defaultDate : this.options.initialSelection) ?? defaultDate;
-    this.slider.disabled = this.options.initialSelection === 'all';
     this.slider.onchange = () => {
-      this.detectChanges();
-      this.updateDisplay();
-      this.options.onChange(this.allDates.checked ? 'all' : this.slider.valueAsNumber);
+      this.onExternalDateChange(this.allDates.checked ? 'all' : this.slider.valueAsNumber);
+      this.options.onChange(this.showAllDates ? 'all' : this.showDate);
     }
     this.slider.oninput = () => {
-      this.detectChanges();
-      this.updateDisplay();
+      this.onExternalDateChange(this.allDates.checked ? 'all' : this.slider.valueAsNumber);
     }
 
-    this.dateDisplay = createDomElement('span', 'date-display hide-mobile-show-desktop', this._container);
+    this.dateDisplay = createDomElement('input', 'date-display hide-mobile-show-desktop', this._container);
+    this.dateDisplay.type = 'number'
+    this.dateDisplay.min = 1758
+    this.dateDisplay.max = defaultDate
+    this.dateDisplay.step = 1
+    this.dateDisplay.onchange = () => {
+      const value = Math.min(
+        this.dateDisplay.max,
+        Math.max(this.dateDisplay.min, this.dateDisplay.valueAsNumber),
+      );
+      this.onExternalDateChange(this.allDates.checked ? 'all' : value);
+      this.options.onChange(this.showAllDates ? 'all' : this.showDate);
+    }
+    this.dateDisplay.oninput = () => {
+      const value = Math.min(
+        this.dateDisplay.max,
+        Math.max(this.dateDisplay.min, this.dateDisplay.valueAsNumber),
+      );
+      this.onExternalDateChange(this.allDates.checked ? 'all' : value);
+    }
 
-    this.active = null;
-
-    this.detectChanges();
-    this.updateDisplay();
+    this.onExternalDateChange(this.options.initialSelection);
 
     return this._container;
   }
@@ -1466,27 +1476,9 @@ class DateControl {
   }
 
   onExternalDateChange(date) {
-    if (date === 'all') {
-      if (this.allDates.checked !== true) {
-        this.allDates.checked = true;
-      }
-      // Leave the date slider value alone
-      if (this.slider.disabled !== true) {
-        this.slider.disabled = true;
-      }
-    } else {
-      if (this.allDates.checked !== false) {
-        this.allDates.checked = false;
-      }
-      if (this.slider.valueAsNumber !== date) {
-        this.slider.valueAsNumber = date ?? defaultDate;
-      }
-      if (this.slider.disabled !== false) {
-        this.slider.disabled = false;
-      }
-    }
+    this.showAllDates = date === 'all';
+    this.showDate = (date === 'all' ? defaultDate : date) ?? defaultDate;
 
-    this.detectChanges();
     this.updateDisplay();
   }
 
@@ -1502,25 +1494,45 @@ class DateControl {
     this._container.style.visibility = 'hidden'
   }
 
-  detectChanges() {
-    const previouslyActive = this.active;
-    this.active = this.allDates.checked || this.slider.valueAsNumber !== defaultDate;
-
-    if (this.active === true && previouslyActive !== true) {
-      this.icon.classList.add('active')
-      this.dateDisplay.classList.add('active')
-    } else if (this.active === false && previouslyActive !== false) {
-      this.icon.classList.remove('active')
-      this.dateDisplay.classList.remove('active')
-    }
+  isActive() {
+    return this.showAllDates || (this.showDate ?? defaultDate) !== defaultDate;
   }
 
   updateDisplay() {
-    this.dateDisplay.innerText = this.allDates.checked
-      ? 'all'
-      : this.slider.valueAsNumber === defaultDate
-        ? 'present'
-        : this.slider.value;
+    if (this.isActive()) {
+      this.icon.classList.add('active')
+      this.dateDisplay.classList.add('active')
+    } else {
+      this.icon.classList.remove('active')
+      this.dateDisplay.classList.remove('active')
+    }
+
+    if (this.showAllDates) {
+      this.allDates.checked = true;
+      this.slider.disabled = true;
+      // Leave the date slider value alone
+      this.dateDisplay.disabled = true;
+    } else {
+      this.allDates.checked = false;
+      this.slider.disabled = false;
+      this.slider.valueAsNumber = this.showDate ?? defaultDate;
+      this.slider.disabled = false;
+      this.dateDisplay.disabled = false;
+    }
+
+    if (this.showAllDates) {
+      this.dateDisplay.type = 'text'
+      this.dateDisplay.value = 'all';
+      this.dateDisplay.disabled = true;
+    } else if (this.showDate === defaultDate) {
+      this.dateDisplay.type = 'text'
+      this.dateDisplay.value = 'present';
+      this.dateDisplay.disabled = true;
+    } else {
+      this.dateDisplay.type = 'number'
+      this.dateDisplay.value = this.showDate;
+      this.dateDisplay.disabled = false;
+    }
   }
 }
 

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -1486,7 +1486,6 @@ class DateControl {
   onExternalDateChange(date) {
     this.showAllDates = date === 'all';
     this.showDate = (date === 'all' ? defaultDate : date) ?? defaultDate;
-    console.info(date, this.showAllDates, this.showDate)
 
     this.updateDisplay();
   }

--- a/proxy/test/ui/cypress/e2e/home.cy.js
+++ b/proxy/test/ui/cypress/e2e/home.cy.js
@@ -13,7 +13,7 @@ describe('home page', () => {
     cy.screenshot()
 
     cy.get('.maplibregl-ctrl-date input[type=range]').invoke('val', 1947).trigger('input').trigger('change')
-    cy.get('.date-display').should('include.text', '1947')
+    cy.get('.date-display').should('have.value', '1947')
     cy.url().should('include', 'date=1947')
 
     cy.wait(3000)
@@ -67,7 +67,7 @@ describe('home page', () => {
     cy.screenshot()
 
     cy.get('.maplibregl-ctrl-date input[type=range]').invoke('val', 1947).trigger('input').trigger('change')
-    cy.get('.date-display').should('include.text', '1947')
+    cy.get('.date-display').should('have.value', '1947')
     cy.url().should('include', 'date=1947')
 
     cy.wait(3000)


### PR DESCRIPTION
For https://github.com/hiddewie/OpenRailwayMap-vector/issues/719

This pull request increases the control over the selected date value.

The shown date can be selected by the slider or by inputting a year manually by clicking the value and typing a value. The input is a number, so the "up" and "down" arrows can also be used, or the up and down keyboard keys. It depends on the browser how it looks visually.

Holding the "up" or "down" arrow will smoothly move the slider forwards or backwards together with the shown year.

If invalid values are manually input, like `100`, `2222` or `bla`, the selected date is reset to the nearest valid value.

All dates:
<img width="923" height="427" alt="image" src="https://github.com/user-attachments/assets/a04bc86a-e12e-47e9-87ae-4704b0d95ab9" />

Historical date:
<img width="923" height="427" alt="image" src="https://github.com/user-attachments/assets/e44f9e1f-a987-407f-a73b-6d46d6d6839d" />

Present date:
<img width="923" height="427" alt="image" src="https://github.com/user-attachments/assets/23b10b55-3431-43a4-adef-4da329c3a69c" />

Small screens show only the date selection by default. Clicking the date icon toggles this feature:
<img width="561" height="427" alt="image" src="https://github.com/user-attachments/assets/6982b76d-da44-4b57-96a8-637635d58a8f" />
