### PR TITLE
GB (non-)passable block markers and directional arrows

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -6172,14 +6172,26 @@ features:
 
   - description: Cab Signalling Start Warning Board
     country: GB
-    icon: [ default: 'gb/cab-entry-warning' ]
+    icon:
+      - default: 'gb/cab-entry-warning'
+      - match: 'railway:signal:train_protection:turn_direction'
+        cases:
+          - { exact: 'left', value: 'gb/cab-arrow-left' }
+          - { exact: 'right', value: 'gb/cab-arrow-right' }
+        position: top
     tags:
       - { tag: 'railway:signal:train_protection', value: 'GB-NR:warning' }
       - { tag: 'railway:signal:train_protection:form', value: 'sign' }
 
   - description: Cab Signalling Start Board
     country: GB
-    icon: [ default: 'gb/cab-entry' ]
+    icon:
+      - default: 'gb/cab-entry'
+      - match: 'railway:signal:train_protection:turn_direction'
+        cases:
+          - { exact: 'left', value: 'gb/cab-arrow-left' }
+          - { exact: 'right', value: 'gb/cab-arrow-right' }
+        position: top
     tags:
       - { tag: 'railway:signal:train_protection', value: 'GB-NR:entry' }
       - { tag: 'railway:signal:train_protection:form', value: 'sign' }
@@ -6187,22 +6199,17 @@ features:
 
   - description: Cab Signalling End Board
     country: GB
-    icon: [ default: 'gb/cab-exit' ]
+    icon:
+      - default: 'gb/cab-exit'
+      - match: 'railway:signal:train_protection:turn_direction'
+        cases:
+          - { exact: 'left', value: 'gb/cab-arrow-left' }
+          - { exact: 'right', value: 'gb/cab-arrow-right' }
+        position: top
     tags:
       - { tag: 'railway:signal:train_protection', value: 'GB-NR:exit' }
       - { tag: 'railway:signal:train_protection:form', value: 'sign' }
       - { tag: 'railway:signal:train_protection:type', value: 'end' }
-
-  - description: Cab Signalling Directional arrow
-    country: GB
-    icon:
-      - match: 'railway:signal:train_protection:turn_direction'
-        cases:
-          - { exact: 'GB-NR:left', value: 'gb/cab-arrow-left' }
-          - { exact: 'GB-NR:right', value: 'gb/cab-arrow-right' }
-        default: 'gb/cab-arrow-unknown'
-    tags:
-      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
 
   - description: ETCS Block Marker
     country: GB
@@ -6216,6 +6223,7 @@ features:
         cases:
           - { exact: 'passable', value: 'gb/block-passable', description: 'passable' }
           - { exact: 'absolute', value: 'gb/block-absolute', description: 'non-passable' }
+        position: bottom
     tags:
       - { tag: 'railway:signal:train_protection', value: 'GB-NR:ETCS' }
       - { tag: 'railway:signal:train_protection:form', value: 'sign' }
@@ -6233,6 +6241,7 @@ features:
         cases:
           - { exact: 'passable', value: 'gb/block-passable', description: 'passable' }
           - { exact: 'absolute', value: 'gb/block-absolute', description: 'non-passable' }
+        position: bottom
     tags:
       - { tag: 'railway:signal:train_protection', value: 'GB-NR:TVM-CBTC' }
       - { tag: 'railway:signal:train_protection:form', value: 'sign' }

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -6204,20 +6204,6 @@ features:
     tags:
       - { tag: 'railway:signal:train_protection:form', value: 'sign' }
 
-  - description: Block Marker Passable Plate
-    country: GB
-    icon: [ default: 'gb/block-passable' ]
-    tags:
-      - { tag: 'railway:signal:train_protection:block_marker:type', value: 'passable' }
-      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
-
-  - description: Block Marker Non-Passable Plate
-    country: GB
-    icon: [ default: 'gb/block-absolute' ]
-    tags:
-      - { tag: 'railway:signal:train_protection:block_marker:type', value: 'absolute' }
-      - { tag: 'railway:signal:train_protection:form', value: 'sign' }
-
   - description: ETCS Block Marker
     country: GB
     icon:
@@ -6226,6 +6212,10 @@ features:
           - { exact: 'right', value: 'gb/ETCS-left' }
           - { exact: 'overhead', value: 'gb/ETCS-overhead' }
         default: 'gb/ETCS-right'
+      - match: 'railway:signal:train_protection:block_marker:type'
+        cases:
+          - { exact: 'passable', value: 'gb/block-passable', description: 'passable' }
+          - { exact: 'absolute', value: 'gb/block-absolute', description: 'non-passable' }
     tags:
       - { tag: 'railway:signal:train_protection', value: 'GB-NR:ETCS' }
       - { tag: 'railway:signal:train_protection:form', value: 'sign' }
@@ -6239,6 +6229,10 @@ features:
           - { exact: 'right', value: 'gb/TVM-CBTC-left' }
           - { exact: 'overhead', value: 'gb/TVM-CBTC-overhead' }
         default: 'gb/TVM-CBTC-right'
+      - match: 'railway:signal:train_protection:block_marker:type'
+        cases:
+          - { exact: 'passable', value: 'gb/block-passable', description: 'passable' }
+          - { exact: 'absolute', value: 'gb/block-absolute', description: 'non-passable' }
     tags:
       - { tag: 'railway:signal:train_protection', value: 'GB-NR:TVM-CBTC' }
       - { tag: 'railway:signal:train_protection:form', value: 'sign' }


### PR DESCRIPTION
Currently on http://localhost:8000/#view=17.58/51.544988/-0.006158/-87.3&style=signals, the passable / non-passable markers are not rendered:
<img width="1429" height="1111" alt="image" src="https://github.com/user-attachments/assets/72584212-73f6-4caf-a6aa-752f7cdaf237" />
With this pull request:
<img width="1429" height="1111" alt="image" src="https://github.com/user-attachments/assets/a2f4df5d-a564-4885-aaa9-35cad9f0cd85" />

The directional arrows are also not rendered, on http://localhost:8000/#view=19/52.724148/-4.059062&style=signals. The tag was matched on the wrong values of `railway:signal:train_protection:turn_direction` and matched separately from the signal features:
<img width="699" height="375" alt="image" src="https://github.com/user-attachments/assets/1a788d47-6e89-48ae-b643-2c014729024f" />
With this pull request:
<img width="699" height="375" alt="image" src="https://github.com/user-attachments/assets/3f1027c5-361b-4d9c-b8aa-03b8afe9ee48" />

See docs in https://wiki.openstreetmap.org/wiki/OpenRailwayMap/Tagging_in_the_United_Kingdom#Directional_Arrows