### PR TITLE
Fix yards with area breaking facility search

### DIFF
--- a/api/test/api.hurl
+++ b/api/test/api.hurl
@@ -166,6 +166,15 @@ HTTP 200
 jsonpath "$" count == 1
 jsonpath "$[0].name" == "Berlin Ostkreuz (Ringbahn-F)"
 
+# Facility search by reference for yard (area)
+GET {{base_url}}/facility
+[QueryStringParams]
+ref: BNO
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].name" == "Berlin Nordost"
+
 # Facility search for UIC reference
 GET {{base_url}}/facility
 [QueryStringParams]

--- a/import/sql/api_facility_functions.sql
+++ b/import/sql/api_facility_functions.sql
@@ -135,8 +135,8 @@ CREATE OR REPLACE FUNCTION query_facilities_by_name(
             fs.wikipedia,
             fs.note,
             fs.description,
-            ST_X(ST_Transform(ST_Centroid(fs.geom), 4326)) AS latitude,
-            ST_Y(ST_Transform(ST_Centroid(fs.geom), 4326)) AS longitude,
+            ST_X(ST_Transform(ST_PointOnSurface(fs.geom), 4326)) AS latitude,
+            ST_Y(ST_Transform(ST_PointOnSurface(fs.geom), 4326)) AS longitude,
             openrailwaymap_name_rank(phraseto_tsquery('simple', unaccent(openrailwaymap_hyphen_to_space(input_name))), fs.terms, fs.importance::numeric, fs.feature, fs.station) AS rank
           FROM openrailwaymap_facilities_for_search fs
           WHERE fs.terms @@ phraseto_tsquery('simple', unaccent(openrailwaymap_hyphen_to_space(input_name)))
@@ -203,8 +203,8 @@ CREATE OR REPLACE FUNCTION query_facilities_by_ref(
         array_remove(ARRAY[s.wikipedia], null) AS wikipedia,
         array_remove(ARRAY[s.note], null) AS note,
         array_remove(ARRAY[s.description], null) AS description,
-        ST_X(ST_Transform(ST_Centroid(s.way), 4326)) AS latitude,
-        ST_Y(ST_Transform(ST_Centroid(s.way), 4326)) AS longitude,
+        ST_X(ST_Transform(ST_PointOnSurface(s.way), 4326)) AS latitude,
+        ST_Y(ST_Transform(ST_PointOnSurface(s.way), 4326)) AS longitude,
         -- Determine rank by common facility reference IDs
         (CASE
           WHEN input_ref = s."references"->'railway-ref' THEN 100

--- a/import/sql/api_facility_functions.sql
+++ b/import/sql/api_facility_functions.sql
@@ -135,8 +135,8 @@ CREATE OR REPLACE FUNCTION query_facilities_by_name(
             fs.wikipedia,
             fs.note,
             fs.description,
-            ST_X(ST_Transform(fs.geom, 4326)) AS latitude,
-            ST_Y(ST_Transform(fs.geom, 4326)) AS longitude,
+            ST_X(ST_Transform(ST_Centroid(fs.geom), 4326)) AS latitude,
+            ST_Y(ST_Transform(ST_Centroid(fs.geom), 4326)) AS longitude,
             openrailwaymap_name_rank(phraseto_tsquery('simple', unaccent(openrailwaymap_hyphen_to_space(input_name))), fs.terms, fs.importance::numeric, fs.feature, fs.station) AS rank
           FROM openrailwaymap_facilities_for_search fs
           WHERE fs.terms @@ phraseto_tsquery('simple', unaccent(openrailwaymap_hyphen_to_space(input_name)))
@@ -203,8 +203,8 @@ CREATE OR REPLACE FUNCTION query_facilities_by_ref(
         array_remove(ARRAY[s.wikipedia], null) AS wikipedia,
         array_remove(ARRAY[s.note], null) AS note,
         array_remove(ARRAY[s.description], null) AS description,
-        ST_X(ST_Transform(s.way, 4326)) AS latitude,
-        ST_Y(ST_Transform(s.way, 4326)) AS longitude,
+        ST_X(ST_Transform(ST_Centroid(s.way), 4326)) AS latitude,
+        ST_Y(ST_Transform(ST_Centroid(s.way), 4326)) AS longitude,
         -- Determine rank by common facility reference IDs
         (CASE
           WHEN input_ref = s."references"->'railway-ref' THEN 100


### PR DESCRIPTION
Fixes #890

Yard areas found during search crashed the API because point geometries were expected:
```
asyncpg.exceptions.InternalServerError: Argument to ST_X() must have type POINT
```

Original problem search `BODK` also works
<img width="1430" height="740" alt="image" src="https://github.com/user-attachments/assets/5fdcfe61-70de-4a66-b13a-4c85d80c9e1e" />
<img width="1430" height="740" alt="image" src="https://github.com/user-attachments/assets/5b9f06e6-2e7f-4e09-bb7e-44417930211a" />


