### PR TITLE
Tests for feature file structure 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,3 +147,22 @@ jobs:
         if: always()
         run: |
           docker compose logs
+
+  feature-test:
+    name: Feature test
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run feature tests
+        run: |
+          docker compose run --rm --build feature-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,10 +156,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -121,6 +121,15 @@ Run the tests in interactive mode with:
 npx cypress open
 ```
 
+### Feature tests
+
+The feature tests validate the contents of the `features` directory, by matching the files against the JSON schema specification.
+
+Run the feature tests with:
+```shell
+docker compose run --rm --build feature-test
+```
+
 ## Development
 
 ### Code generation

--- a/compose.yaml
+++ b/compose.yaml
@@ -139,3 +139,8 @@ services:
       '--variable', 'base_url=http://api:5000/api',
       '/hurl/api.hurl'
     ]
+
+  feature-test:
+    build:
+      context: features
+      dockerfile: test/Dockerfile

--- a/features/loading_gauge.yaml
+++ b/features/loading_gauge.yaml
@@ -1,3 +1,5 @@
+$schema: ./schema/loading_gauge.yaml
+
 loading_gauges:
   - { value: 'TSI_GA', legend: 'GA', color: 'hsl(96, 100%, 40%)' }
   - { value: 'TSI_GB', legend: 'GB', color: 'hsl(72, 100%, 40%)' }
@@ -61,4 +63,3 @@ loading_gauges:
   - { value: 'EBV 2', legend: 'EBV2', color: 'hsl(130, 80%, 50%)' }
   - { value: 'EBV 3', legend: 'EBV3', color: 'hsl(215, 100%, 40%)' }
   - { value: 'EBV 4', legend: 'EBV4', color: 'hsl(270, 80%, 50%)' }
-  

--- a/features/operators.yaml
+++ b/features/operators.yaml
@@ -1,6 +1,8 @@
 # Mapping of known operators to their color and other metadata
 # Unknown operators will get assigned a generated color
 
+$schema: ./schema/operators.yaml
+
 operators:
 
   # --- AE --- #

--- a/features/poi.yaml
+++ b/features/poi.yaml
@@ -1,3 +1,5 @@
+$schema: ./schema/poi.yaml
+
 features:
   - description: Border crossing
     feature: 'general/border'

--- a/features/railway_line.yaml
+++ b/features/railway_line.yaml
@@ -1,3 +1,5 @@
+$schema: ./schema/railway_line.yaml
+
 features:
   - type: rail
     description: Railway

--- a/features/schema/loading_gauge.yaml
+++ b/features/schema/loading_gauge.yaml
@@ -4,15 +4,19 @@ type: object
 properties:
   loading_gauges:
     type: array
+    description: Defines the loading gauges on the map
     items:
       type: object
       properties:
         value:
           type: string
+          description: The value in the loading gauge tag
         legend:
           type: string
+          description: The description shown in the legend
         color:
           type: string
+          description: The color used to show this loading gauge on the map
       additionalProperties: false
   $schema:
     type: string

--- a/features/schema/loading_gauge.yaml
+++ b/features/schema/loading_gauge.yaml
@@ -1,0 +1,19 @@
+"$id": "https://openrailwaymap.app/schema/signals_railway_signals.yaml"
+"$schema": "https://json-schema.org/draft/2020-12/schema"
+type: object
+properties:
+  loading_gauges:
+    type: array
+    items:
+      type: object
+      properties:
+        value:
+          type: string
+        legend:
+          type: string
+        color:
+          type: string
+      additionalProperties: false
+  $schema:
+    type: string
+additionalProperties: false

--- a/features/schema/operators.yaml
+++ b/features/schema/operators.yaml
@@ -4,17 +4,22 @@ type: object
 properties:
   operators:
     type: array
+    description: Defines the list of known operators
     items:
       type: object
       properties:
         country:
           type: string
+          description: The country this operator primarily operates in
         names:
           type: array
+          description: The names that the operator is known by. Multiple names may be used, for example when the operator operates in a multilingual country.
           items:
             type: string
+            description: A name that the operator operates by
         color:
           type: string
+          description: The color used to show the operator on the map
       additionalProperties: false
   $schema:
     type: string

--- a/features/schema/operators.yaml
+++ b/features/schema/operators.yaml
@@ -11,7 +11,8 @@ properties:
           type: string
         names:
           type: array
-          items: string
+          items:
+            type: string
         color:
           type: string
       additionalProperties: false

--- a/features/schema/operators.yaml
+++ b/features/schema/operators.yaml
@@ -1,0 +1,20 @@
+"$id": "https://openrailwaymap.app/schema/signals_railway_signals.yaml"
+"$schema": "https://json-schema.org/draft/2020-12/schema"
+type: object
+properties:
+  operators:
+    type: array
+    items:
+      type: object
+      properties:
+        country:
+          type: string
+        names:
+          type: array
+          items: string
+        color:
+          type: string
+      additionalProperties: false
+  $schema:
+    type: string
+additionalProperties: false

--- a/features/schema/poi.yaml
+++ b/features/schema/poi.yaml
@@ -1,0 +1,73 @@
+"$id": "https://openrailwaymap.app/schema/signals_railway_signals.yaml"
+"$schema": "https://json-schema.org/draft/2020-12/schema"
+type: object
+properties:
+  features:
+    type: array
+    items:
+      type: object
+      properties:
+        description:
+          type: string
+        feature:
+          type: string
+        layer:
+          type: string
+          enum:
+            - standard
+            - electrification
+            - operator
+        minzoom:
+          type: number
+          minimum: 1
+          maximum: 20
+        tags:
+          type: array
+          items:
+            type: object
+            properties:
+              tag:
+                type: string
+              value:
+                type: string
+              values:
+                type: array
+                items:
+                  type: string
+        variants:
+          type: array
+          items:
+            type: object
+            properties:
+              description:
+                type: string
+              feature:
+                type: string
+              layer:
+                type: string
+                enum:
+                  - standard
+                  - electrification
+                  - operator
+              minzoom:
+                type: number
+                minimum: 1
+                maximum: 20
+              tags:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    tag:
+                      type: string
+                    value:
+                      type: string
+                    values:
+                      type: array
+                      items:
+                        type: string
+            additionalProperties: false
+      additionalProperties: false
+  $schema:
+    type: string
+additionalProperties: false

--- a/features/schema/poi.yaml
+++ b/features/schema/poi.yaml
@@ -4,15 +4,19 @@ type: object
 properties:
   features:
     type: array
+    description: Defines the places of interest on the map
     items:
       type: object
       properties:
         description:
           type: string
+          description: The description used in the legend
         feature:
           type: string
+          description: The icon used to show the place of interest
         layer:
           type: string
+          description: The layer that the place of interest will be shown in
           enum:
             - standard
             - electrification
@@ -21,49 +25,56 @@ properties:
           type: number
           minimum: 1
           maximum: 20
+          description: The minimum zoom that this place of interest will be shown from
         tags:
           type: array
+          description: The tags to match for determining the place of interest
           items:
             type: object
             properties:
               tag:
                 type: string
+                description: The tag
               value:
                 type: string
+                description: The tag value
               values:
                 type: array
+                description: Multiple tag values
                 items:
                   type: string
         variants:
           type: array
+          description: Other variants of the same feature
           items:
             type: object
             properties:
               description:
                 type: string
+                description: The description used in the legend
               feature:
                 type: string
-              layer:
-                type: string
-                enum:
-                  - standard
-                  - electrification
-                  - operator
+                description: The icon used to show the place of interest
               minzoom:
                 type: number
                 minimum: 1
                 maximum: 20
+                description: The minimum zoom that this place of interest will be shown from
               tags:
                 type: array
+                description: The tags to match for determining the place of interest
                 items:
                   type: object
                   properties:
                     tag:
                       type: string
+                      description: The tag
                     value:
                       type: string
+                      description: The tag value
                     values:
                       type: array
+                      description: Multiple tag values
                       items:
                         type: string
             additionalProperties: false

--- a/features/schema/railway_line.yaml
+++ b/features/schema/railway_line.yaml
@@ -1,0 +1,17 @@
+"$id": "https://openrailwaymap.app/schema/signals_railway_signals.yaml"
+"$schema": "https://json-schema.org/draft/2020-12/schema"
+type: object
+properties:
+  features:
+    type: array
+    items:
+      type: object
+      properties:
+        type:
+          type: string
+        description:
+          type: string
+      additionalProperties: false
+  $schema:
+    type: string
+additionalProperties: false

--- a/features/schema/railway_line.yaml
+++ b/features/schema/railway_line.yaml
@@ -4,13 +4,16 @@ type: object
 properties:
   features:
     type: array
+    description: Defines the railway line features on the map
     items:
       type: object
       properties:
         type:
           type: string
+          description: The type of the railway line
         description:
           type: string
+          description: The description that will be used in the legend
       additionalProperties: false
   $schema:
     type: string

--- a/features/schema/signals_railway_signals.yaml
+++ b/features/schema/signals_railway_signals.yaml
@@ -4,25 +4,33 @@ type: object
 properties:
   tags:
     type: array
+    description: The imported tags used to identify signal features
     items:
       type: object
       properties:
         tag:
           type: string
+          description: The tag
         title:
           type: string
+          description: The description used in the popup to label the tag value
         type:
           type: string
+          description: Determines how the tag should be imported. Strings are imported as the tag value. Booleans are imported as false if the tag value is `no` or empty, otherwise true. Arrays are imported by splitting the tag value on `;`.
+          default: string
           enum:
+            - string
             - array
             - boolean
         format:
           type: object
+          description: The formatting used to display the value in the popup
           properties:
             template:
               type: string
         description:
           type: string
+          description: A tooltip to show in the popup
       additionalProperties: false
   types:
     type: array
@@ -31,8 +39,10 @@ properties:
       properties:
         type:
           type: string
+          description: The type of tag, sometimes named category
         layer:
           type: string
+          description: The layer that features using this type are shown in.
           enum:
             - signals
             - speed
@@ -40,52 +50,68 @@ properties:
       additionalProperties: false
   features:
     type: array
+    description: The signal features shown on the map
     items:
       type: object
       properties:
         description:
           type: string
+          description: Used in the legend for the feature
         country:
           type: string
+          description: The country where this signal is used
         type:
           type: string
+          description: The type of signal. Line signals are used only on main/branch lines, and tram signals are used for tram lines.
           enum:
             - line
             - tram
         exampleIcon:
           type: string
+          description: Used when a complex icon is used, to show a representative example of this feature using a single icon.
         icon:
           type: array
+          description: Determines the icon used to show the feature on the map
           items:
             type: object
             properties:
               default:
                 type: string
+                description: Used when no matching is present, or no case is matched
               match:
                 type: string
+                description: The tag used for matching the icon cases against
               cases:
                 type: array
+                description: Defines cases to match the match tag against in order
                 items:
                   type: object
                   properties:
-                    regex:
-                      type: string
                     value:
                       type: string
-                    example:
+                      description: Match against a simple value
+                    regex:
                       type: string
+                      description: Match against a regular expression
                     exact:
                       type: string
+                      description: Match against the exact value
                     any:
                       type: array
+                      description: Match against any of the values
                       items:
                         type: string
                     all:
                       type: array
+                      description: Match against all of the values
                       items:
                         type: string
+                    example:
+                      type: string
+                      description: An icon that can be used in the legend when regular expression matching is used
                     description:
                       type: string
+                      description: The legend description
                   additionalProperties: false
               position:
                 type: string
@@ -95,22 +121,29 @@ properties:
                   - left
                   - right
                   - center
+                default: center
+                description: Determines where the icon component is placed, in relation to the previous icon components
             additionalProperties: false
         tags:
           type: array
+          description: Tags that determine the feature
           items:
             type: object
             properties:
               tag:
                 type: string
+                description: The tag to match against
               value:
                 type: string
+                description: Match against the value
               any:
                 type: array
+                description: Match against any of the values
                 items:
                   type: string
               all:
                 type: array
+                description: Match against all of the values
                 items:
                   type: string
             additionalProperties: false

--- a/features/schema/signals_railway_signals.yaml
+++ b/features/schema/signals_railway_signals.yaml
@@ -1,0 +1,120 @@
+"$id": "https://openrailwaymap.app/schema/signals_railway_signals.yaml"
+"$schema": "https://json-schema.org/draft/2020-12/schema"
+type: object
+properties:
+  tags:
+    type: array
+    items:
+      type: object
+      properties:
+        tag:
+          type: string
+        title:
+          type: string
+        type:
+          type: string
+          enum:
+            - array
+            - boolean
+        format:
+          type: object
+          properties:
+            template:
+              type: string
+        description:
+          type: string
+      additionalProperties: false
+  types:
+    type: array
+    items:
+      type: object
+      properties:
+        type:
+          type: string
+        layer:
+          type: string
+          enum:
+            - signals
+            - speed
+            - electrification
+      additionalProperties: false
+  features:
+    type: array
+    items:
+      type: object
+      properties:
+        description:
+          type: string
+        country:
+          type: string
+        type:
+          type: string
+          enum:
+            - line
+            - tram
+        exampleIcon:
+          type: string
+        icon:
+          type: array
+          items:
+            type: object
+            properties:
+              default:
+                type: string
+              match:
+                type: string
+              cases:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    regex:
+                      type: string
+                    value:
+                      type: string
+                    example:
+                      type: string
+                    exact:
+                      type: string
+                    any:
+                      type: array
+                      items:
+                        type: string
+                    all:
+                      type: array
+                      items:
+                        type: string
+                    description:
+                      type: string
+                  additionalProperties: false
+              position:
+                type: string
+                enum:
+                  - top
+                  - bottom
+                  - left
+                  - right
+                  - center
+            additionalProperties: false
+        tags:
+          type: array
+          items:
+            type: object
+            properties:
+              tag:
+                type: string
+              value:
+                type: string
+              any:
+                type: array
+                items:
+                  type: string
+              all:
+                type: array
+                items:
+                  type: string
+            additionalProperties: false
+      additionalProperties: false
+  $schema:
+    type: string
+additionalProperties: false

--- a/features/schema/stations.yaml
+++ b/features/schema/stations.yaml
@@ -4,21 +4,27 @@ type: object
 properties:
   features:
     type: array
+    description: Defines the station features shown on the map
     items:
       type: object
       properties:
         description:
           type: string
+          description: Description to show in the legend
         feature:
           type: string
+          description: The tag value to match
         example:
           type: object
+          description: An example of a station feature, used in the legend
         minzoom:
           type: number
           minimum: 1
           maximum: 20
+          description: The minimum zoom that this station should be shown from
         mapState:
           type: object
+          description: Map state to match to determine if the feature should be shown in the legend
         variants:
           type: array
           items:
@@ -26,35 +32,47 @@ properties:
             properties:
               description:
                 type: string
+                description: Description to show in the legend
               feature:
                 type: string
+                description: The tag value to match
               example:
                 type: object
+                description: An example of a station feature, used in the legend. Will be merged with the feature example.
               minzoom:
                 type: number
                 minimum: 1
                 maximum: 20
+                description: The minimum zoom that this station should be shown from
               mapState:
                 type: object
+                description: Map state to match to determine if the feature should be shown in the legend
             additionalProperties: false
       additionalProperties: false
   references:
     type: array
+    description: Station reference tags
     items:
       type: object
       properties:
         id:
           type: string
+          description: An identifier for the reference
         description:
           type: string
+          description: The name for the reference shown in the popup
         country:
           type: string
+          description: The country this reference is used in
         map:
           type: boolean
+          description: Whether to use this reference as station reference on the map
         tags:
           type: array
+          description: The reference tags
           items:
             type: string
+            description: A reference tag
       additionalProperties: false
   $schema:
     type: string

--- a/features/schema/stations.yaml
+++ b/features/schema/stations.yaml
@@ -1,0 +1,61 @@
+"$id": "https://openrailwaymap.app/schema/signals_railway_signals.yaml"
+"$schema": "https://json-schema.org/draft/2020-12/schema"
+type: object
+properties:
+  features:
+    type: array
+    items:
+      type: object
+      properties:
+        description:
+          type: string
+        feature:
+          type: string
+        example:
+          type: object
+        minzoom:
+          type: number
+          minimum: 1
+          maximum: 20
+        mapState:
+          type: object
+        variants:
+          type: array
+          items:
+            type: object
+            properties:
+              description:
+                type: string
+              feature:
+                type: string
+              example:
+                type: object
+              minzoom:
+                type: number
+                minimum: 1
+                maximum: 20
+              mapState:
+                type: object
+            additionalProperties: false
+      additionalProperties: false
+  references:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: string
+        description:
+          type: string
+        country:
+          type: string
+        map:
+          type: boolean
+        tags:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+  $schema:
+    type: string
+additionalProperties: false

--- a/features/schema/track_class.yaml
+++ b/features/schema/track_class.yaml
@@ -9,8 +9,10 @@ properties:
       properties:
         value:
           type: string
+          description: The name of the track class
         color:
           type: string
+          description: The color used to show the track class on the map
       additionalProperties: false
   $schema:
     type: string

--- a/features/schema/track_class.yaml
+++ b/features/schema/track_class.yaml
@@ -1,0 +1,17 @@
+"$id": "https://openrailwaymap.app/schema/signals_railway_signals.yaml"
+"$schema": "https://json-schema.org/draft/2020-12/schema"
+type: object
+properties:
+  track_classes:
+    type: array
+    items:
+      type: object
+      properties:
+        value:
+          type: string
+        color:
+          type: string
+      additionalProperties: false
+  $schema:
+    type: string
+additionalProperties: false

--- a/features/schema/train_protection.yaml
+++ b/features/schema/train_protection.yaml
@@ -4,15 +4,19 @@ type: object
 properties:
   train_protections:
     type: array
+    description: The train protection systems
     items:
       type: object
       properties:
         train_protection:
           type: string
+          description: The identifier of the train protection
         legend:
           type: string
+          description: The description used in the legend and popup
         color:
           type: string
+          description: The color used to display the train protection on the map
       additionalProperties: false
   features:
     type: array
@@ -21,19 +25,25 @@ properties:
       properties:
         train_protection:
           type: string
+          description: The identifier of the train protection
         tags:
           type: array
+          description: The tags used to tag this train protection system
           items:
             type: object
             properties:
               tag:
                 type: string
+                description: The tag
               value:
                 type: string
+                description: The tag value
               values:
                 type: array
+                description: Multiple tag values
                 items:
                   type: string
+                  description: A tag value
             additionalProperties: false
       additionalProperties: false
   $schema:

--- a/features/schema/train_protection.yaml
+++ b/features/schema/train_protection.yaml
@@ -1,0 +1,41 @@
+"$id": "https://openrailwaymap.app/schema/signals_railway_signals.yaml"
+"$schema": "https://json-schema.org/draft/2020-12/schema"
+type: object
+properties:
+  train_protections:
+    type: array
+    items:
+      type: object
+      properties:
+        train_protection:
+          type: string
+        legend:
+          type: string
+        color:
+          type: string
+      additionalProperties: false
+  features:
+    type: array
+    items:
+      type: object
+      properties:
+        train_protection:
+          type: string
+        tags:
+          type: array
+          items:
+            type: object
+            properties:
+              tag:
+                type: string
+              value:
+                type: string
+              values:
+                type: array
+                items:
+                  type: string
+            additionalProperties: false
+      additionalProperties: false
+  $schema:
+    type: string
+additionalProperties: false

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -1,4 +1,4 @@
-"$schema": features/schema/signals_railway_signals.yaml
+"$schema": ./schema/signals_railway_signals.yaml
 
 tags:
   # railway tag is included by default

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -1,3 +1,5 @@
+"$schema": features/schema/signals_railway_signals.yaml
+
 tags:
   # railway tag is included by default
   - { tag: 'railway:signal:brake_test', title: 'Brake test' }

--- a/features/stations.yaml
+++ b/features/stations.yaml
@@ -1,3 +1,5 @@
+$schema: ./schema/stations.yaml
+
 features:
   - description: Station
     feature: station

--- a/features/test/Dockerfile
+++ b/features/test/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-alpine@sha256:dbcedd8aeab47fbc0f4dd4bffa55b7c3c729a707875968d467aaa
 
 WORKDIR /build
 
-RUN npm install -g ajv-cli@5.0.0
+RUN npm install -g @jirutka/ajv-cli@6.0.0
 
 COPY . .
 

--- a/features/test/Dockerfile
+++ b/features/test/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:22-alpine@sha256:dbcedd8aeab47fbc0f4dd4bffa55b7c3c729a707875968d467aaaea42d6225af
+
+WORKDIR /build
+
+RUN npm install -g ajv-cli@5.0.0
+
+COPY . .
+
+ENTRYPOINT ["sh"]
+CMD ["test/test.sh"]

--- a/features/test/Dockerfile.dockerignore
+++ b/features/test/Dockerfile.dockerignore
@@ -1,0 +1,4 @@
+**
+!*.yaml
+!schema/*.yaml
+!test/test.sh

--- a/features/test/test.sh
+++ b/features/test/test.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
-set -eof pipefail
+set -eo pipefail
 
-ajv validate --spec draft2020 --strict true --all-errors -s schema/signals_railway_signals.yaml signals_railway_signals.yaml
+for file in *.yaml
+do
+  ajv validate --spec draft2020 --strict true --all-errors -s "schema/$file" "$file"
+done

--- a/features/test/test.sh
+++ b/features/test/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eof pipefail
+
+ajv validate --spec draft2020 --errors text --strict true --all-errors -s schema/signals_railway_signals.yaml -d signals_railway_signals.yaml

--- a/features/test/test.sh
+++ b/features/test/test.sh
@@ -2,4 +2,4 @@
 
 set -eof pipefail
 
-ajv validate --spec draft2020 --errors text --strict true --all-errors -s schema/signals_railway_signals.yaml -d signals_railway_signals.yaml
+ajv validate --spec draft2020 --strict true --all-errors -s schema/signals_railway_signals.yaml signals_railway_signals.yaml

--- a/features/track_class.yaml
+++ b/features/track_class.yaml
@@ -1,3 +1,5 @@
+$schema: ./schema/track_class.yaml
+
 track_classes:
   - { value: 'A', color: 'hsl(248, 100%, 40%)' }
   - { value: 'B1', color: 'hsl(220, 100%, 40%)' }

--- a/features/train_protection.yaml
+++ b/features/train_protection.yaml
@@ -1,3 +1,5 @@
+$schema: ./schema/train_protection.yaml
+
 train_protections:
   - { train_protection: 'etcs', legend: 'European Train Control System (ETCS)', color: 'hsl(214, 100%, 70%)' }
   - { train_protection: 'etcs_1', legend: 'European Train Control System (ETCS) level 1', color: 'hsl(214, 100%, 50%)' }


### PR DESCRIPTION
Add a set of tests for the structure of the YAML feature files in the `features` directory.

This will allow testing for structural correctness of the files, and allow auto-completion in IDEs when editing the files:
<img width="637" height="157" alt="image" src="https://github.com/user-attachments/assets/04791430-ff6b-473b-b80e-c4118f9bad67" />
<img width="637" height="157" alt="image" src="https://github.com/user-attachments/assets/baefd8a6-bebf-4d61-b906-74674e0ad0f8" />

Example output for failing features test:
```
signals_railway_signals.yaml invalid
--> signals_railway_signals.yaml:3802:9
    #/features/372/tags/0

     |           - { regex: '^(5|[1-7][0-5])$', value: 'de/bostrab/g1a-{}', e...
     |         default: 'de/bostrab/g1a-empty'
     |     tags:
3802 |       - { tag: 'railway:signal:speed_limit_distant', bla: [ 'DE-BOStrab:g1', 'DE-BOStrab:g1a', 'DE-BSVG:g1a' ] }
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must not include property 'bla'
     |       - { tag: 'railway:signal:speed_limit_distant:form', value: 'sign' }
     | 
     |   - description: Tram distance speed limit (G 1b) (light)

--> signals_railway_signals.yaml:3814:9
    #/features/373/tags/0

     |           - { regex: '^[1-7]0$', value: 'de/bostrab/g1b-{}', example: ...
     |         default: 'de/bostrab/g1b-empty'
     |     tags:
3814 |       - { tag: 'railway:signal:speed_limit_distant', bla: [ 'DE-BOStrab:g1', 'DE-BOStrab:g1b' ] }
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must not include property 'bla'
     |       - { tag: 'railway:signal:speed_limit_distant:form', value: 'ligh...
     | 
     |   - description: distant signal announcement signs Ne 3 (dwarf)
```