### PR TITLE
BE traversable main and distant signals

### DIFF
--- a/features/schema/signals_railway_signals.yaml
+++ b/features/schema/signals_railway_signals.yaml
@@ -136,6 +136,11 @@ properties:
               value:
                 type: string
                 description: Match against the value
+              values:
+                type: array
+                items:
+                  type: string
+                description: Match against the exact values
               any:
                 type: array
                 description: Match against any of the values

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -1975,6 +1975,8 @@ features:
         cases:
           - { exact: 'BE:OF', value: 'be/OEF' }
         position: bottom
+      - default: 'be/TR'
+        position: bottom
     tags:
       - { tag: 'railway:signal:main', value: 'BE:GSA' }
       - { tag: 'railway:signal:regime', value: 'opposite' }
@@ -1988,6 +1990,8 @@ features:
       - match: 'railway:signal:main:substitute_signal'
         cases:
           - { exact: 'BE:OF', value: 'be/OEF' }
+        position: bottom
+      - default: 'be/TR'
         position: bottom
     tags:
       - { tag: 'railway:signal:main', value: 'BE:GSA' }

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -1967,17 +1967,41 @@ features:
       - { tag: 'railway:signal:speed_limit', value: 'BE:SSC' }
       - { tag: 'railway:signal:speed_limit:form', value: 'light' }
 
+  - description: Grand Signal d'Arrêt (opposite regime and only for shunting)
+    country: BE
+    icon:
+      - default: 'be/GSA-opposite-RB'
+      - match: 'railway:signal:main:substitute_signal'
+        cases:
+          - { exact: 'BE:OF', value: 'be/OEF' }
+        position: bottom
+    tags:
+      - { tag: 'railway:signal:main', value: 'BE:GSA' }
+      - { tag: 'railway:signal:regime', value: 'opposite' }
+      - { tag: 'railway:signal:main:states', values: ['BE:RB', 'BE:R'] }
+      - { tag: 'railway:signal:traversable', value: 'BE:TR' }
+
+  - description: Grand Signal d'Arrêt (normal regime and only for shunting)
+    country: BE
+    icon:
+      - default: 'be/GSA-RB'
+      - match: 'railway:signal:main:substitute_signal'
+        cases:
+          - { exact: 'BE:OF', value: 'be/OEF' }
+        position: bottom
+    tags:
+      - { tag: 'railway:signal:main', value: 'BE:GSA' }
+      - { tag: 'railway:signal:main:states', values: ['BE:RB', 'BE:R'] }
+      - { tag: 'railway:signal:traversable', value: 'BE:TR' }
+
   - description: Grand Signal d'Arrêt (opposite regime)
     country: BE
-    exampleIcon: be/GSA-opposite-VJH
     icon:
-      - match: 'railway:signal:main:states'
+      - match: 'railway:signal:traversable'
         cases:
-          - { exact: 'BE:RB', value: 'be/GSA-opposite-RB' }
-          - { exact: 'BE:2J', value: 'be/GSA-opposite-2J' }
-          - { exact: 'BE:VJV', value: 'be/GSA-opposite-VJV' }
-          - { exact: 'BE:VJH', value: 'be/GSA-opposite-VJH' }
-          - { exact: 'BE:V', value: 'be/GSA-opposite-V' }
+          - { exact: 'BE:TR', value: 'be/GSA-opposite-R' }
+          - { exact: 'BE:DBR', value: 'be/GSA-opposite-V' }
+          - { exact: 'BE:CF', value: 'be/GSA-opposite-V' }
         default: 'be/GSA-opposite-R'
       - match: 'railway:signal:main:substitute_signal'
         cases:
@@ -1995,15 +2019,12 @@ features:
 
   - description: Grand Signal d'Arrêt (normal regime)
     country: BE
-    exampleIcon: be/GSA-VJH
     icon:
-      - match: 'railway:signal:main:states'
+      - match: 'railway:signal:traversable'
         cases:
-          - { exact: 'BE:RB', value: 'be/GSA-RB' }
-          - { exact: 'BE:2J', value: 'be/GSA-2J' }
-          - { exact: 'BE:VJV', value: 'be/GSA-VJV' }
-          - { exact: 'BE:VJH', value: 'be/GSA-VJH' }
-          - { exact: 'BE:V', value: 'be/GSA-V' }
+          - { exact: 'BE:TR', value: 'be/GSA-R' }
+          - { exact: 'BE:DBR', value: 'be/GSA-V' }
+          - { exact: 'BE:CF', value: 'be/GSA-V' }
         default: 'be/GSA-R'
       - match: 'railway:signal:main:substitute_signal'
         cases:
@@ -2020,26 +2041,14 @@ features:
 
   - description: Distant signal (opposite regime)
     country: BE
-    icon:
-      - match: 'railway:signal:distant:states'
-        cases:
-          - { exact: 'BE:2J', value: 'be/SAI-opposite-2J' }
-          - { exact: 'BE:VJV', value: 'be/SAI-opposite-VJV' }
-          - { exact: 'BE:VJH', value: 'be/SAI-opposite-VJH' }
-        default: 'be/SAI-opposite-V'
+    icon: [ default: 'be/SAI-opposite-2J' ]
     tags:
       - { tag: 'railway:signal:distant', value: 'BE:SAI' }
       - { tag: 'railway:signal:regime', value: 'opposite' }
 
   - description: Distant signal (normal regime)
     country: BE
-    icon:
-      - match: 'railway:signal:distant:states'
-        cases:
-          - { exact: 'BE:2J', value: 'be/SAI-2J' }
-          - { exact: 'BE:VJV', value: 'be/SAI-VJV' }
-          - { exact: 'BE:VJH', value: 'be/SAI-VJH' }
-        default: 'be/SAI-V'
+    icon: [ default: 'be/SAI-2J' ]
     tags:
       - { tag: 'railway:signal:distant', value: 'BE:SAI' }
 

--- a/import/sql/signal_features.sql.js
+++ b/import/sql/signal_features.sql.js
@@ -72,6 +72,16 @@ function matchTagValueSql(tag, value) {
   }
 }
 
+function matchTagValuesSql(tag, values) {
+  switch (tagTypes[tag]) {
+    case 'array':
+      const sqlArray = `ARRAY[${values.map(value => `'${value}'`).join(', ')}]`
+      return `${sqlArray} <@ "${tag}" AND ${sqlArray} @> "${tag}"`
+    default:
+      throw new Error(`values matching cannot be used for non-array tag '${tag}' ('${values}')`)
+  }
+}
+
 function matchTagAllValuesSql(tag, values) {
   switch (tagTypes[tag]) {
     case 'array':
@@ -130,7 +140,12 @@ function stringSql(tag, matchCase) {
 }
 
 function matchFeatureTagsSql(tags) {
-  return tags.map(tag => tag.value ? matchTagValueSql(tag.tag, tag.value) : tag.all ? matchTagAllValuesSql(tag.tag, tag.all) : matchTagAnyValueSql(tag.tag, tag.any)).join(' AND ')
+  return tags.map(tag =>
+    tag.value ? matchTagValueSql(tag.tag, tag.value)
+      : tag.all ? matchTagAllValuesSql(tag.tag, tag.all)
+        : tag.any ? matchTagAnyValueSql(tag.tag, tag.any)
+          : matchTagValuesSql(tag.tag, tag.values)
+  ).join(' AND ')
 }
 
 function matchIconCase(tag, iconCase) {

--- a/import/sql/signal_features.sql.js
+++ b/import/sql/signal_features.sql.js
@@ -143,8 +143,8 @@ function matchFeatureTagsSql(tags) {
   return tags.map(tag =>
     tag.value ? matchTagValueSql(tag.tag, tag.value)
       : tag.all ? matchTagAllValuesSql(tag.tag, tag.all)
-        : tag.any ? matchTagAnyValueSql(tag.tag, tag.any)
-          : matchTagValuesSql(tag.tag, tag.values)
+        : tag.values ? matchTagValuesSql(tag.tag, tag.values)
+          : matchTagAnyValueSql(tag.tag, tag.any)
   ).join(' AND ')
 }
 

--- a/proxy/js/legend.mjs
+++ b/proxy/js/legend.mjs
@@ -141,24 +141,28 @@ const gaugeLegends = [
 
 const signalFeatures = (feature) =>
   // Generate signal features for each icon variant. For an icon variant, use the default (or last) variant of the other icon cases.
-  feature.icon.map((icon, i) => ({
-    legend: icon.default ? icon.description : icon.cases[0].description,
-    icon: feature.icon
-      .map((otherIcon, j) => i === j
-        ? `${icon.default ?? icon.cases[0].example ?? icon.cases[0].value}${icon.position ? `@${icon.position}` : ''}`
-        : `${otherIcon.default ?? otherIcon.cases[otherIcon.cases.length - 1].example ?? otherIcon.cases[otherIcon.cases.length - 1].value}${otherIcon.position ? `@${otherIcon.position}` : ''}`
-      )
-      .join('|'),
-    variants: (icon.cases ?? []).slice(icon.default ? 0 : 1).map(item => ({
-      legend: item.description,
+  feature.icon
+    .filter((icon, i) => i === 0 || icon.cases)
+    .map((icon, i) => ({
+      legend: icon.default ? icon.description : icon.cases[0].description,
       icon: feature.icon
         .map((otherIcon, j) => i === j
-          ? `${item.example ?? item.value}${icon.position ? `@${icon.position}` : ''}`
-          : `${otherIcon.default ?? otherIcon.cases[otherIcon.cases.length - 1].example ?? otherIcon.cases[otherIcon.cases.length - 1].value}${otherIcon.position ? `@${otherIcon.position}` : ''}`
+          ? `${icon.default ?? icon.cases[0].example ?? icon.cases[0].value}${icon.position ? `@${icon.position}` : ''}`
+          : (otherIcon.default ? `${otherIcon.default}${otherIcon.position ? `@${otherIcon.position}` : ''}` : null)
         )
+        .filter(it => it)
         .join('|'),
-    })),
-  }));
+      variants: (icon.cases ?? []).slice(icon.default ? 0 : 1).map(item => ({
+        legend: item.description,
+        icon: feature.icon
+          .map((otherIcon, j) => i === j
+            ? `${item.example ?? item.value}${icon.position ? `@${icon.position}` : ''}`
+            : (otherIcon.default ? `${otherIcon.default}${otherIcon.position ? `@${otherIcon.position}` : ''}` : null)
+          )
+          .filter(it => it)
+          .join('|'),
+      })),
+    }));
 
 const legendData = {
   standard: {


### PR DESCRIPTION
For #763

Distant signals always show warning state.

Shunting main signals show their shunting state.

Main signals show clear or stop based on their traversability.

This will make most signals show red, and only a few green. ~No signals are currently tagged in the shunting form.~

http://localhost:8000/#view=18.62/50.4421739/4.272502&style=signals:
<img width="1030" height="561" alt="image" src="https://github.com/user-attachments/assets/d6f1212f-131f-41bc-92a4-97893d34afaf" />

http://localhost:8000/#view=16.62/50.893985/4.410399&style=signals:
<img width="1432" height="1113" alt="image" src="https://github.com/user-attachments/assets/c1a556f9-25dd-4fa5-9f12-843e09280962" />

http://localhost:8000/#view=19/50.83072/4.328741&style=signals:
<img width="475" height="588" alt="image" src="https://github.com/user-attachments/assets/f57f8060-d837-4174-a457-e687cac549e5" />

http://localhost:8000/#view=19/50.889224/4.413782&style=signals:
<img width="601" height="619" alt="image" src="https://github.com/user-attachments/assets/c91e5b36-03fb-44f2-bf04-e760445d30e8" />

http://localhost:8000/#view=16.53/50.900585/4.412167&style=signals:
<img width="789" height="905" alt="image" src="https://github.com/user-attachments/assets/a38c62a6-1c06-4135-a24d-03c5dfe052a8" />

Legend:
<img width="467" height="558" alt="image" src="https://github.com/user-attachments/assets/def821b4-bd2b-40c0-8f9f-73d247808288" />

