### PR TITLE
Fix missing ETCS location/stop icons at layer transition markers

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -4794,36 +4794,45 @@ features:
 
   # See https://wiki.openstreetmap.org/wiki/Proposal:Unified_ETCS_Signals_(railway)
 
-  - description: ETCS transition marker
-    icon: [ default: 'etcs/level_transition' ]
-    tags:
-      - { tag: 'railway:signal:train_protection', value: 'ETCS:marker' }
-      - { tag: 'railway:signal:train_protection:system_change', value: 'ETCS:level_transition' }
-      - { tag: 'railway:signal:train_protection:system_change:form', value: 'sign' }
-
-  - description: ETCS stop marker
+  - description: ETCS marker
     icon:
       - match: 'railway:signal:position'
         cases:
           - { exact: 'left', value: 'etcs/stop_marker-right' }
           - { any: ['overhead', 'bridge'], value: 'etcs/stop_marker-down' }
         default: 'etcs/stop_marker-left'
+      - match: 'railway:signal:train_protection:system_change'
+        cases:
+          - { exact: 'ETCS:level_transition', value: 'etcs/level_transition' }
+        position: bottom
     tags:
       - { tag: 'railway:signal:train_protection', value: 'ETCS:marker' }
       - { tag: 'railway:signal:train_protection:main', value: 'ETCS:stop_marker' }
       - { tag: 'railway:signal:train_protection:main:form', value: 'sign' }
 
-  - description: ETCS location marker
+  - description: ETCS marker
     icon:
       - match: 'railway:signal:position'
         cases:
           - { exact: 'left', value: 'etcs/location_marker-right' }
           - { any: ['overhead', 'bridge'], value: 'etcs/location_marker-down' }
         default: 'etcs/location_marker-left'
+      - match: 'railway:signal:train_protection:system_change'
+        cases:
+          - { exact: 'ETCS:level_transition', value: 'etcs/level_transition' }
+        position: bottom
     tags:
       - { tag: 'railway:signal:train_protection', value: 'ETCS:marker' }
       - { tag: 'railway:signal:train_protection:main', value: 'ETCS:location_marker' }
       - { tag: 'railway:signal:train_protection:main:form', value: 'sign' }
+
+  - description: ETCS marker
+    icon:
+      - default: 'etcs/level_transition'
+    tags:
+      - { tag: 'railway:signal:train_protection', value: 'ETCS:marker' }
+      - { tag: 'railway:signal:train_protection:system_change', value: 'ETCS:level_transition' }
+      - { tag: 'railway:signal:train_protection:system_change:form', value: 'sign' }
 
   - description: Distant begin of neutral section
     icon: [ default: 'etcs/power_off_advance' ]


### PR DESCRIPTION
This fixes the problem mentioned here:
- https://discord.com/channels/413070382636072960/706530768180215808/1483403536502095985
- https://github.com/hiddewie/OpenRailwayMap-vector/pull/882#discussion_r3079745160

Which is that when there are two ETCS markers on one osm `node`, specifically a combination of `location_marker` (or `stop_marker`) with a `layer_transition` marker, only one of them, the `layer_transition` marker, gets rendered.

This PR fixes that, but has a few drawbacks
- `railway:signal:train_protection:system_change:form=sign` is not always checked and required
- For consistency of naming, all those signals are now called just `ETCS marker` (with no differentiation of location/stop/transition markers)
  - This could be fixed by adding more *"virtual" signal types*: `location`, `stop`, `transition`, `stop+transition`, `location+transition`
  - Currently this PR uses three `location(+transition)`, `stop(+transition)` (e.g. transition marker is present optionally) and `transition` (by itself as a fallback)

http://localhost:8000/#view=19.19/45.4270749/11.8548628&style=signals
Previously:
<img width="436" height="1030" alt="image" src="https://github.com/user-attachments/assets/6721d37f-6a16-494e-a4bd-6ce2482e6f66" />
Now:
<img width="436" height="1030" alt="image" src="https://github.com/user-attachments/assets/e1e38d2d-616d-4236-aa1a-5c41e2275673" />



