### PR TITLE
Ensure boolean popup attributes have no colon

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -2581,8 +2581,9 @@ function popupContent(feature, abortController) {
           popupValue.style.cursor = 'help';
         }
 
+        const containsAnyBodyValue = body.some(([_, bodyValue]) => bodyValue);
         const popupValueTitle = createDomElement('span', 'fw-bold', popupValue);
-        popupValueTitle.innerText = `${title}: `;
+        popupValueTitle.innerText = `${title}${containsAnyBodyValue ? ': ' : ''}`;
 
         let first = true
         body.forEach(([key, bodyValue]) => {


### PR DESCRIPTION
Boolean attributes show when the value is `true`. Currently it shows a `:` in the label, even if there is no value.

Before:
<img width="480" height="313" alt="image" src="https://github.com/user-attachments/assets/bed5562b-ff77-40ff-9b14-7934c96e2e5d" />

After:
<img width="480" height="313" alt="image" src="https://github.com/user-attachments/assets/cb0dfd8c-5bf1-4cb1-b841-1b20243ae706" />
