### PR TITLE
 Do not import platform edges as platforms for public transport only 

### DIFF
--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -1022,6 +1022,7 @@ function is_railway_platform(tags)
   return tags.railway == 'platform'
     or (
       tags.public_transport == 'platform'
+      and tags.railway ~= 'platform_edge'
       and (
         tags.train == 'yes'
         or tags.tram == 'yes'

--- a/import/test/test_import_platform.lua
+++ b/import/test/test_import_platform.lua
@@ -199,3 +199,19 @@ assert.eq(osm2pgsql.get_and_clear_imported_data(), {
     { ref = '4', height = '0.4', tactile_paving = true, way = way },
   },
 })
+
+osm2pgsql.process_way({
+  tags = {
+    ['railway'] = 'platform_edge',
+    ['public_transport'] = 'platform',
+  },
+  as_linestring = function ()
+    return way
+  end,
+})
+assert.eq(osm2pgsql.get_and_clear_imported_data(), {
+  platform_edge = {
+    { way = way },
+  },
+  -- Not imported as platform
+})

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -2581,8 +2581,9 @@ function popupContent(feature, abortController) {
           popupValue.style.cursor = 'help';
         }
 
+        const containsAnyBodyValue = body.some(([_, bodyValue]) => bodyValue);
         const popupValueTitle = createDomElement('span', 'fw-bold', popupValue);
-        popupValueTitle.innerText = `${title}: `;
+        popupValueTitle.innerText = `${title}${containsAnyBodyValue ? ': ' : ''}`;
 
         let first = true
         body.forEach(([key, bodyValue]) => {


### PR DESCRIPTION
Platform edges are always imported. Public transport platforms are not imported as platforms if they are platform edges.

Fixes https://github.com/hiddewie/OpenRailwayMap-vector/issues/901

Tested on Divača, Slovenia, for example https://www.openstreetmap.org/way/1193835009.
Before:
<img width="857" height="644" alt="image" src="https://github.com/user-attachments/assets/8605b6c7-e9fc-40c6-992c-52d0be84415d" />

After:
<img width="857" height="644" alt="image" src="https://github.com/user-attachments/assets/a659ae5d-2033-41dc-9caa-5be737d6d443" />
