### PR TITLE
Enable searching for components of names separated by `/`

### DIFF
--- a/api/test/api.hurl
+++ b/api/test/api.hurl
@@ -245,7 +245,7 @@ GET {{base_url}}/facility
 q: Landsberger Allee
 HTTP 200
 [Asserts]
-jsonpath "$" count == 3
+jsonpath "$" count == 6
 jsonpath "$[0].name" == "Landsberger Allee/Petersburger Straße"
 jsonpath "$[0].feature" == "tram_stop"
 jsonpath "$[0].state" == "present"
@@ -256,13 +256,13 @@ jsonpath "$[0].osm_ids[1]" == 271777826
 jsonpath "$[0].osm_ids[2]" == 1679221136
 jsonpath "$[0].osm_ids[3]" == 1787945074
 jsonpath "$[0].osm_types" count == 4
-jsonpath "$[2].railway_ref" == "BLST"
-jsonpath "$[2].station" == "light_rail"
-jsonpath "$[2].uic_ref" == "8089020"
-jsonpath "$[2].operator[0]" == "DB InfraGO AG"
-jsonpath "$[2].network[0]" == "Verkehrsverbund Berlin-Brandenburg"
-jsonpath "$[2].wikidata[0]" == "Q800507"
-jsonpath "$[2].wikipedia[0]" == "de:Bahnhof Berlin Landsberger Allee"
+jsonpath "$[3].railway_ref" == "BLST"
+jsonpath "$[3].station" == "light_rail"
+jsonpath "$[3].uic_ref" == "8089020"
+jsonpath "$[3].operator[0]" == "DB InfraGO AG"
+jsonpath "$[3].network[0]" == "Verkehrsverbund Berlin-Brandenburg"
+jsonpath "$[3].wikidata[0]" == "Q800507"
+jsonpath "$[3].wikipedia[0]" == "de:Bahnhof Berlin Landsberger Allee"
 
 # Facility request missing required parameter
 GET {{base_url}}/facility

--- a/api/test/api.hurl
+++ b/api/test/api.hurl
@@ -135,7 +135,7 @@ jsonpath "$[6].name" == "Berlin-Spandau West"
 jsonpath "$[7].name" == "Berlin-Spandau Mitte"
 jsonpath "$[8].name" == "Berlin-Spandau Ost"
 
-# Facility request with with diacritics
+# Facility request with diacritics
 GET {{base_url}}/facility
 [QueryStringParams]
 name: Karl-Marx-Straße
@@ -143,6 +143,15 @@ HTTP 200
 [Asserts]
 jsonpath "$" count == 1
 jsonpath "$[0].name" == "Karl-Marx-Straße"
+
+# Facility request with name containing /
+GET {{base_url}}/facility
+[QueryStringParams]
+name: Königsheideweg
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].name" == "Sterndamm/Königsheideweg"
 
 # Facility search for reference
 GET {{base_url}}/facility

--- a/import/sql/api_facility_functions.sql
+++ b/import/sql/api_facility_functions.sql
@@ -1,8 +1,8 @@
 -- SPDX-License-Identifier: GPL-2.0-or-later
 
-CREATE OR REPLACE FUNCTION openrailwaymap_hyphen_to_space(str TEXT) RETURNS TEXT AS $$
+CREATE OR REPLACE FUNCTION openrailwaymap_hyphen_slash_to_space(str TEXT) RETURNS TEXT AS $$
 BEGIN
-  RETURN regexp_replace(str, '(\w)-(\w)', '\1 \2', 'g');
+  RETURN regexp_replace(str, '(\w)[-/](\w)', '\1 \2', 'g');
 END;
 $$ LANGUAGE plpgsql
   IMMUTABLE
@@ -137,9 +137,9 @@ CREATE OR REPLACE FUNCTION query_facilities_by_name(
             fs.description,
             ST_X(ST_Transform(ST_PointOnSurface(fs.geom), 4326)) AS latitude,
             ST_Y(ST_Transform(ST_PointOnSurface(fs.geom), 4326)) AS longitude,
-            openrailwaymap_name_rank(phraseto_tsquery('simple', unaccent(openrailwaymap_hyphen_to_space(input_name))), fs.terms, fs.importance::numeric, fs.feature, fs.station) AS rank
+            openrailwaymap_name_rank(phraseto_tsquery('simple', unaccent(openrailwaymap_hyphen_slash_to_space(input_name))), fs.terms, fs.importance::numeric, fs.feature, fs.station) AS rank
           FROM openrailwaymap_facilities_for_search fs
-          WHERE fs.terms @@ phraseto_tsquery('simple', unaccent(openrailwaymap_hyphen_to_space(input_name)))
+          WHERE fs.terms @@ phraseto_tsquery('simple', unaccent(openrailwaymap_hyphen_slash_to_space(input_name)))
         ) AS a
       ) AS b
       ORDER BY b.rank DESC NULLS LAST

--- a/import/sql/api_facility_views.sql
+++ b/import/sql/api_facility_views.sql
@@ -5,7 +5,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS openrailwaymap_facilities_for_search AS
     id,
     osm_ids,
     osm_types,
-    to_tsvector('simple', unaccent(openrailwaymap_hyphen_to_space(value))) AS terms,
+    to_tsvector('simple', unaccent(openrailwaymap_hyphen_slash_to_space(value))) AS terms,
     name,
     name_tags,
     key AS name_key,


### PR DESCRIPTION
Fixes #896

Allow searching for components of names that contain `/`. 

Before hyphens `-` were already replaced with spaces for searching. The same is done for `/` in names now.

Searching for `domat/ems` works, as well as `domat` or `ems`:
<img width="1432" height="638" alt="image" src="https://github.com/user-attachments/assets/6b22bd79-e595-44fd-9752-3ac552bf87c2" />
<img width="1432" height="638" alt="image" src="https://github.com/user-attachments/assets/12048a4b-bb44-4c7f-be50-4a35da03f845" />
<img width="1432" height="638" alt="image" src="https://github.com/user-attachments/assets/06c33c7d-9b44-4bc4-a808-163937b7f786" />

In the Berlin area, searching for `Königsheideweg` also finds `Sterndamm/Königsheideweg`.