### PR TITLE
Search for station references, case insensitive

### DIFF
--- a/api/openrailwaymap_api/facility_api.py
+++ b/api/openrailwaymap_api/facility_api.py
@@ -62,14 +62,11 @@ class FacilityAPI:
         """
         return await self.query_result(sql_query, (q, language, limit))
 
-    async def _search_by_ref(self, search_function, ref, language, limit):
+    async def search_by_ref(self, ref, language, limit):
         sql_query = f"""
-          SELECT * FROM {search_function}($1, $2, $3)
+          SELECT * FROM query_facilities_by_ref($1, $2, $3)
         """
         return await self.query_result(sql_query, (ref, language, limit))
-
-    async def search_by_ref(self, ref, language, limit):
-        return await self._search_by_ref("query_facilities_by_ref", ref, language, limit)
 
     async def query_result(self, sql_query, parameters):
         async with self.database.acquire() as connection:

--- a/api/test/api.hurl
+++ b/api/test/api.hurl
@@ -19,13 +19,13 @@ Content-Type: application/json
 jsonpath "$" count == 20
 jsonpath "$[0].name" == "Berlin Hauptbahnhof (tief)"
 jsonpath "$[1].name" == "S+U Hauptbahnhof"
-jsonpath "$[2].name" == "Hauptbahnhof"
-jsonpath "$[3].name" == "Berlin Hauptbahnhof"
-jsonpath "$[4].name" == "Berlin Hamburger und Lehrter Bahnhof"
-jsonpath "$[5].name" == "Berlin-Moabit"
+jsonpath "$[2].name" == "Berlin Hauptbahnhof"
+jsonpath "$[3].name" == "Hauptbahnhof"
+jsonpath "$[4].name" == "Berlin-Moabit"
+jsonpath "$[5].name" == "Berlin Hamburger und Lehrter Bahnhof"
 jsonpath "$[6].name" == "Berlin Südkreuz"
-jsonpath "$[7].name" == "Südkreuz (Nord-Süd)"
-jsonpath "$[8].name" == "Südkreuz (Ringbahn)"
+jsonpath "$[7].name" == "Südkreuz (Ringbahn)"
+jsonpath "$[8].name" == "Südkreuz (Nord-Süd)"
 jsonpath "$[9].name" == "Berlin Nordost"
 jsonpath "$[10].name" == "Berlin-Ruhleben"
 jsonpath "$[11].name" == "Berlin Greifswalder Straße"
@@ -35,8 +35,8 @@ jsonpath "$[14].name" == "Berlin-Spandau"
 jsonpath "$[15].name" == "Spandau"
 jsonpath "$[16].name" == "Berlin-Tempelhof"
 jsonpath "$[17].name" == "Berlin-Schönholz"
-jsonpath "$[18].name" == "Berlin Ostbahnhof"
-jsonpath "$[19].name" == "Ostbahnhof"
+jsonpath "$[18].name" == "Ostbahnhof"
+jsonpath "$[19].name" == "Berlin Ostbahnhof"
 
 # Facility request with language
 GET {{base_url}}/facility
@@ -182,8 +182,8 @@ ref: 8089028
 HTTP 200
 [Asserts]
 jsonpath "$" count == 2
-jsonpath "$[0].name" == "Ostkreuz (Ringbahn)"
-jsonpath "$[1].name" == "Ostkreuz"
+jsonpath "$[0].name" == "Ostkreuz"
+jsonpath "$[1].name" == "Ostkreuz (Ringbahn)"
 
 # Facility search for BVG reference
 GET {{base_url}}/facility
@@ -193,7 +193,7 @@ HTTP 200
 [Asserts]
 jsonpath "$" count == 1
 jsonpath "$[0].name" == "Virchowstraße"
-jsonpath "$[0].references.de-bvg" == "309771"
+jsonpath "$[0].references.de-bvg" == "309770"
 
 # Facility search for name or reference
 GET {{base_url}}/facility
@@ -227,8 +227,8 @@ q: 8089028
 HTTP 200
 [Asserts]
 jsonpath "$" count == 2
-jsonpath "$[0].name" == "Ostkreuz (Ringbahn)"
-jsonpath "$[1].name" == "Ostkreuz"
+jsonpath "$[0].name" == "Ostkreuz"
+jsonpath "$[1].name" == "Ostkreuz (Ringbahn)"
 
 # Facility search for name or reference for grouped station
 GET {{base_url}}/facility

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -857,19 +857,17 @@ end
 
 function station_references(tags)
   local found_references = {}
-  local found_search_references = {}
 
   for _, reference in ipairs(tag_functions.station_references) do
     for _, tag in ipairs(reference.tags) do
       if tags[tag] then
         found_references[reference.id] = tags[tag]
-        found_search_references[reference.id] = tags[tag]:lower()
         break
       end
     end
   end
 
-  return found_references, found_search_references
+  return found_references
 end
 
 function position_is_zero(position)
@@ -1108,7 +1106,6 @@ function osm2pgsql.process_node(object)
   local station_feature, station_state, name = railway_feature_and_state(tags, railway_station_values)
   if station_feature then
     for station, _ in pairs(station_type(tags)) do
-      references, search_references = station_references(tags)
       stations:insert({
         way = object:as_point(),
         feature = station_feature,
@@ -1117,7 +1114,6 @@ function osm2pgsql.process_node(object)
         station = station,
         name_tags = name_tags(tags),
         map_reference = map_station_reference(tags),
-        references = station_references(tags),
         references = station_references(tags),
         operator = split_semicolon_to_sql_array(tags.operator),
         owner = tags.owner,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -857,17 +857,19 @@ end
 
 function station_references(tags)
   local found_references = {}
+  local found_search_references = {}
 
   for _, reference in ipairs(tag_functions.station_references) do
     for _, tag in ipairs(reference.tags) do
       if tags[tag] then
         found_references[reference.id] = tags[tag]
+        found_search_references[reference.id] = tags[tag]:lower()
         break
       end
     end
   end
 
-  return found_references
+  return found_references, found_search_references
 end
 
 function position_is_zero(position)
@@ -1106,6 +1108,7 @@ function osm2pgsql.process_node(object)
   local station_feature, station_state, name = railway_feature_and_state(tags, railway_station_values)
   if station_feature then
     for station, _ in pairs(station_type(tags)) do
+      references, search_references = station_references(tags)
       stations:insert({
         way = object:as_point(),
         feature = station_feature,
@@ -1114,6 +1117,7 @@ function osm2pgsql.process_node(object)
         station = station,
         name_tags = name_tags(tags),
         map_reference = map_station_reference(tags),
+        references = station_references(tags),
         references = station_references(tags),
         operator = split_semicolon_to_sql_array(tags.operator),
         owner = tags.owner,

--- a/import/sql/api_facility_functions.sql
+++ b/import/sql/api_facility_functions.sql
@@ -59,90 +59,37 @@ CREATE OR REPLACE FUNCTION query_facilities_by_name(
   "rank" numeric
 ) AS $$
   BEGIN
-    -- We do not sort the result, although we use DISTINCT ON because osm_ids is sufficient to sort out duplicates.
     RETURN QUERY
-      SELECT
-        b.osm_ids,
-        b.osm_types,
-        b.name,
-        b.localized_name,
-        b.feature,
-        b.state,
-        b.station,
-        b.railway_ref,
-        b.uic_ref,
-        b."references",
-        b.operator,
-        b.owner,
-        b.network,
-        b.wikidata,
-        b.wikimedia_commons,
-        b.wikimedia_commons_file,
-        b.image,
-        b.mapillary,
-        b.wikipedia,
-        b.note,
-        b.description,
-        b.latitude,
-        b.longitude,
-        b.rank
-      FROM (
-        SELECT DISTINCT ON (a.osm_ids)
-          a.osm_ids,
-          a.osm_types,
-          a.name,
-          a.localized_name,
-          a.feature,
-          a.state,
-          a.station,
-          a.railway_ref,
-          a.uic_ref,
-          a."references",
-          a.operator,
-          a.owner,
-          a.network,
-          a.wikidata,
-          a.wikimedia_commons,
-          a.wikimedia_commons_file,
-          a.image,
-          a.mapillary,
-          a.wikipedia,
-          a.note,
-          a.description,
-          a.latitude,
-          a.longitude,
-          a.rank
-        FROM (
-          SELECT
-            fs.osm_ids,
-            fs.osm_types,
-            fs.name,
-            COALESCE(fs.name_tags['name:' || input_language], fs.name) as localized_name,
-            fs.feature,
-            fs.state,
-            fs.station,
-            fs.railway_ref,
-            fs.uic_ref,
-            fs."references",
-            fs.operator,
-            fs.owner,
-            fs.network,
-            fs.wikidata,
-            fs.wikimedia_commons,
-            fs.wikimedia_commons_file,
-            fs.image,
-            fs.mapillary,
-            fs.wikipedia,
-            fs.note,
-            fs.description,
-            ST_X(ST_Transform(ST_PointOnSurface(fs.geom), 4326)) AS latitude,
-            ST_Y(ST_Transform(ST_PointOnSurface(fs.geom), 4326)) AS longitude,
-            openrailwaymap_name_rank(phraseto_tsquery('simple', unaccent(openrailwaymap_hyphen_to_space(input_name))), fs.terms, fs.importance::numeric, fs.feature, fs.station) AS rank
-          FROM openrailwaymap_facilities_for_search fs
-          WHERE fs.terms @@ phraseto_tsquery('simple', unaccent(openrailwaymap_hyphen_to_space(input_name)))
-        ) AS a
-      ) AS b
-      ORDER BY b.rank DESC NULLS LAST
+      SELECT DISTINCT ON (rank, gs.osm_ids)
+        gs.osm_ids,
+        gs.osm_types,
+        gs.name,
+        COALESCE(gs.name_tags['name:' || input_language], gs.name) as localized_name,
+        gs.feature,
+        gs.state,
+        gs.station,
+        gs.map_reference as railway_ref,
+        gs.uic_ref,
+        gs."references",
+        gs.operator,
+        gs.owner,
+        gs.network,
+        gs.wikidata,
+        gs.wikimedia_commons,
+        gs.wikimedia_commons_file,
+        gs.image,
+        gs.mapillary,
+        gs.wikipedia,
+        gs.note,
+        gs.description,
+        ST_X(ST_Transform(ST_PointOnSurface(gs.center), 4326)) AS latitude,
+        ST_Y(ST_Transform(ST_PointOnSurface(gs.center), 4326)) AS longitude,
+        openrailwaymap_name_rank(phraseto_tsquery('simple', unaccent(openrailwaymap_hyphen_to_space(input_name))), fs.terms, gs.importance::numeric, gs.feature, gs.station) AS rank
+      FROM openrailwaymap_facilities_for_name_search fs
+      JOIN grouped_stations_with_importance gs
+        ON fs.station_ids = gs.station_ids
+      WHERE fs.terms @@ phraseto_tsquery('simple', unaccent(openrailwaymap_hyphen_to_space(input_name)))
+      ORDER BY rank DESC NULLS LAST
       LIMIT input_limit;
   END
 $$ LANGUAGE plpgsql
@@ -181,61 +128,44 @@ CREATE OR REPLACE FUNCTION query_facilities_by_ref(
 ) AS $$
   BEGIN
     RETURN QUERY
-      SELECT
-        ARRAY[s.osm_id] as osm_ids,
-        ARRAY[s.osm_type] as osm_types,
-        s.name,
-        COALESCE(name_tags['name:' || input_language], s.name) as localized_name,
-        s.feature,
-        s.state,
-        s.station,
-        s.map_reference as railway_ref,
-        s."references"->'uic' as uic_ref,
-        hs_concat(coalesce(sa."references", ''::hstore), coalesce(s."references", ''::hstore)) as "references",
-        s.operator AS operator,
-        array_remove(ARRAY[s.owner], null) AS owner,
-        s.network AS network,
-        array_remove(ARRAY[s.wikidata], null) AS wikidata,
-        array_remove(ARRAY[s.wikimedia_commons], null) AS wikimedia_commons,
-        array_remove(ARRAY[s.wikimedia_commons_file], null) AS wikimedia_commons_file,
-        array_remove(ARRAY[s.image], null) AS image,
-        array_remove(ARRAY[s.mapillary], null) AS mapillary,
-        array_remove(ARRAY[s.wikipedia], null) AS wikipedia,
-        array_remove(ARRAY[s.note], null) AS note,
-        array_remove(ARRAY[s.description], null) AS description,
-        ST_X(ST_Transform(ST_PointOnSurface(s.way), 4326)) AS latitude,
-        ST_Y(ST_Transform(ST_PointOnSurface(s.way), 4326)) AS longitude,
+      SELECT DISTINCT ON (rank, gs.osm_ids)
+        gs.osm_ids,
+        gs.osm_types,
+        gs.name,
+        COALESCE(gs.name_tags['name:' || input_language], gs.name) as localized_name,
+        gs.feature,
+        gs.state,
+        gs.station,
+        gs.map_reference as railway_ref,
+        gs.uic_ref,
+        gs."references",
+        gs.operator,
+        gs.owner,
+        gs.network,
+        gs.wikidata,
+        gs.wikimedia_commons,
+        gs.wikimedia_commons_file,
+        gs.image,
+        gs.mapillary,
+        gs.wikipedia,
+        gs.note,
+        gs.description,
+        ST_X(ST_Transform(ST_PointOnSurface(gs.center), 4326)) AS latitude,
+        ST_Y(ST_Transform(ST_PointOnSurface(gs.center), 4326)) AS longitude,
         -- Determine rank by common facility reference IDs
         (CASE
-          WHEN input_ref = s."references"->'railway-ref' THEN 100
-          WHEN input_ref = s."references"->'uic' THEN 90
-          WHEN input_ref = s."references"->'ibnr' THEN 80
-          WHEN input_ref = s."references"->'ifopt' THEN 70
-          WHEN input_ref = s."references"->'plc' THEN 60
+          WHEN lower(input_ref) = lower(gs."references"->'railway-ref') THEN 100
+          WHEN lower(input_ref) = lower(gs."references"->'uic') THEN 90
+          WHEN lower(input_ref) = lower(gs."references"->'ibnr') THEN 80
+          WHEN lower(input_ref) = lower(gs."references"->'ifopt') THEN 70
+          WHEN lower(input_ref) = lower(gs."references"->'plc') THEN 60
           ELSE 0
         END)::numeric as rank
-      FROM (
-        SELECT s.id
-        FROM stations s
-        WHERE ARRAY[input_ref] <@ avals(s."references")
-
-        UNION
-
-        SELECT s.id
-        FROM stop_areas sa
-        JOIN stations_stop_areas ssa
-          ON ssa.stop_area_osm_id = sa.osm_id
-        JOIN stations s
-          ON ssa.station_id = s.id
-        WHERE ARRAY[input_ref] <@ avals(sa."references")
-      ) station_ids
-      JOIN stations s
-        ON station_ids.id = s.id
-      LEFT JOIN stations_stop_areas ssa
-        ON ssa.station_id = s.id
-      LEFT JOIN stop_areas sa
-        ON ssa.stop_area_osm_id = sa.osm_id
-      ORDER BY rank DESC
+      FROM openrailwaymap_facilities_for_ref_search fs
+      JOIN grouped_stations_with_importance gs
+        ON fs.station_ids = gs.station_ids
+      WHERE ARRAY[lower(input_ref)] <@ fs.terms
+      ORDER BY rank DESC NULLS LAST
       LIMIT input_limit;
   END
 $$ LANGUAGE plpgsql

--- a/import/sql/api_facility_views.sql
+++ b/import/sql/api_facility_views.sql
@@ -8,8 +8,6 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS openrailwaymap_facilities_for_search AS
     to_tsvector('simple', unaccent(openrailwaymap_hyphen_to_space(value))) AS terms,
     name,
     name_tags,
-    key AS name_key,
-    value AS name_value,
     feature,
     state,
     station,
@@ -30,11 +28,10 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS openrailwaymap_facilities_for_search AS
     description,
     geom
   FROM (
-    SELECT DISTINCT ON (osm_ids, key, value, name, feature, state, station, map_reference, uic_ref, importance, geom)
+    SELECT DISTINCT ON (osm_ids, value, name, feature, state, station, map_reference, uic_ref, importance, geom)
       id,
       osm_ids,
       osm_types,
-      (each(name_tags)).key AS key,
       (each(name_tags)).value AS value,
       name,
       name_tags,

--- a/import/sql/api_facility_views.sql
+++ b/import/sql/api_facility_views.sql
@@ -1,62 +1,53 @@
 -- SPDX-License-Identifier: GPL-2.0-or-later
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS openrailwaymap_facilities_for_search AS
+-- Search by name
+CREATE MATERIALIZED VIEW IF NOT EXISTS openrailwaymap_facilities_for_name_search AS
   SELECT
-    id,
-    osm_ids,
-    osm_types,
-    to_tsvector('simple', unaccent(openrailwaymap_hyphen_to_space(value))) AS terms,
-    name,
-    name_tags,
-    feature,
-    state,
-    station,
-    map_reference as railway_ref,
-    uic_ref,
-    "references",
-    importance,
-    operator,
-    owner,
-    network,
-    wikidata,
-    wikimedia_commons,
-    wikimedia_commons_file,
-    image,
-    mapillary,
-    wikipedia,
-    note,
-    description,
-    geom
+    station_ids,
+    found_stations.name as terms
   FROM (
-    SELECT DISTINCT ON (osm_ids, value, name, feature, state, station, map_reference, uic_ref, importance, geom)
-      id,
-      osm_ids,
-      osm_types,
-      (each(name_tags)).value AS value,
-      name,
-      name_tags,
-      feature,
-      state,
-      station,
-      map_reference,
-      "references",
-      uic_ref,
-      importance,
-      operator,
-      owner,
-      network,
-      wikidata,
-      wikimedia_commons,
-      wikimedia_commons_file,
-      image,
-      mapillary,
-      wikipedia,
-      note,
-      description,
-      center as geom
-    FROM grouped_stations_with_importance
-  ) AS duplicated;
+    SELECT
+      s.id,
+      to_tsvector('simple', unaccent(openrailwaymap_hyphen_to_space((each(s.name_tags)).value))) as name
+    FROM stations s
+    WHERE s.name_tags IS NOT NULL
+  ) found_stations
+  JOIN grouped_stations_with_importance gs
+    ON ARRAY[found_stations.id] <@ gs.station_ids
+  GROUP BY station_ids, terms;
 
 CREATE INDEX IF NOT EXISTS openrailwaymap_facilities_name_index
-  ON openrailwaymap_facilities_for_search
+  ON openrailwaymap_facilities_for_name_search
+    USING gin(terms);
+
+-- Search by reference
+CREATE MATERIALIZED VIEW IF NOT EXISTS openrailwaymap_facilities_for_ref_search AS
+  SELECT
+    station_ids,
+    array_agg(DISTINCT reference) as terms
+  FROM (
+    SELECT
+      id,
+      lower(unnest(avals("references"))) as reference
+    FROM stations
+    WHERE "references" IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+      s.id,
+      lower(unnest(avals(sa."references"))) as reference
+    FROM stop_areas sa
+    JOIN stations_stop_areas ssa
+      ON ssa.stop_area_osm_id = sa.osm_id
+    JOIN stations s
+      ON ssa.station_id = s.id
+    WHERE sa."references" IS NOT NULL
+  ) found_stations
+  JOIN grouped_stations_with_importance gs
+    ON ARRAY[found_stations.id] <@ gs.station_ids
+  GROUP BY station_ids;
+
+CREATE INDEX IF NOT EXISTS openrailwaymap_facilities_ref_index
+  ON openrailwaymap_facilities_for_ref_search
     USING gin(terms);

--- a/import/sql/stations_clustered.sql
+++ b/import/sql/stations_clustered.sql
@@ -153,9 +153,9 @@ CREATE INDEX IF NOT EXISTS grouped_stations_with_importance_buffered_index
   ON grouped_stations_with_importance
     USING GIST(buffered);
 
-CREATE INDEX IF NOT EXISTS grouped_stations_with_importance_osm_ids_index
+CREATE INDEX IF NOT EXISTS grouped_stations_with_importance_station_index
   ON grouped_stations_with_importance
-    USING GIN(osm_ids);
+    USING GIN(station_ids);
 
 CLUSTER grouped_stations_with_importance
   USING grouped_stations_with_importance_center_index;
@@ -171,14 +171,8 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS stop_area_groups_buffered AS
      ON ssa.stop_area_osm_id = sa.osm_id
   JOIN stations s
     ON ssa.station_id = s.id
-  JOIN (
-    SELECT
-      unnest(osm_ids) AS osm_id,
-      unnest(osm_types) AS osm_type,
-      buffered
-    FROM grouped_stations_with_importance
-  ) gs
-    ON s.osm_id = gs.osm_id and s.osm_type = gs.osm_type
+  JOIN grouped_stations_with_importance gs
+    ON ARRAY[s.id] <@ gs.station_ids
   GROUP BY sag.osm_id
   -- Only use station area groups that have more than one station area
   HAVING COUNT(distinct sa.osm_id) > 1;

--- a/import/sql/update_api_views.sql
+++ b/import/sql/update_api_views.sql
@@ -1,2 +1,3 @@
 -- Refresh facilities API views
-REFRESH MATERIALIZED VIEW openrailwaymap_facilities_for_search;
+REFRESH MATERIALIZED VIEW openrailwaymap_facilities_for_name_search;
+REFRESH MATERIALIZED VIEW openrailwaymap_facilities_for_ref_search;


### PR DESCRIPTION
Fixes #888

Searching for `bhf` will return Berlin Ostbahnhof (and child stations):
<img width="1428" height="550" alt="image" src="https://github.com/user-attachments/assets/33705e47-75db-49a0-bffd-ff4747a49486" />

During testing I found one interesting problem, where a station Virchowstraße is grouped with multiple BVG references 309770 and 309771 together. Only one reference is stored. All references are searchable.
<img width="1428" height="550" alt="image" src="https://github.com/user-attachments/assets/2ad080cd-a35c-4224-948c-9855226da0a6" />
