### PR TITLE
Wait for database to start after initialization restart

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -6,4 +6,4 @@ COPY types.sql /docker-entrypoint-initdb.d/types.sql
 COPY extensions.sql /docker-entrypoint-initdb.d/extensions.sql
 
 HEALTHCHECK --interval=5s --timeout=5s --retries=3 --start-period=1m --start-interval=1s \
-  CMD ["psql", "-U", "postgres", "-d", "gis", "-c", "SELECT st_buffer(ST_SetSRID('POINT(0 0)'::GEOMETRY, 4326), 1)"]
+  CMD ["psql", "-h", "127.0.0.1", "-U", "postgres", "-d", "gis", "-c", "SELECT st_buffer(ST_SetSRID('POINT(0 0)'::GEOMETRY, 4326), 1)"]


### PR DESCRIPTION
The nightly update sometimes fails, e.g. https://github.com/hiddewie/OpenRailwayMap-vector/actions/runs/24751576065/job/72415668706  with 
```
 == Importing data (8 processes) == 
2026-04-21 23:26:00  osm2pgsql version 2.1.1
2026-04-21 23:26:00  ERROR: Connecting to database failed (context=check): connection to server at "db" (172.18.0.2), port 5432 failed: Connection refused
	Is the server running on that host and accepting TCP/IP connections?
.
```

During initialization the Postgres database restarts once. The healthcheck should only verify if the database is ready after restart. See https://github.com/docker-library/postgres/issues/146#issuecomment-3553955164, which suggests to explicitly connect to `127.0.0.1` in the health check.