### PR TITLE
Update Postgres 18, Martin, Python, Node, Debian images

### DIFF
--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -11,7 +11,7 @@ RUN --mount=type=bind,source=api/features.mjs,target=features.mjs \
   node /build/features.mjs \
     > /build/features.json
 
-FROM python:3-alpine@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
+FROM python:3-alpine@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a
 
 RUN apk add --no-cache \
         curl \

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM imresamu/postgis:18-3.6-alpine@sha256:1bb65bfdeaed8609b93f1d3bc8e2b2ec2d7d7e0fa54770f9f56db0c6c1fc982b
+FROM imresamu/postgis:18-3.6-alpine@sha256:5603f164abe087bf3c3bf779f1e47a0e17ff197b594730c55e55bfd2d288f79a
 
 COPY tune-postgis.sh /docker-entrypoint-initdb.d/tune-postgis.sh
 COPY operators.sql /docker-entrypoint-initdb.d/operators.sql

--- a/features/test/Dockerfile
+++ b/features/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine@sha256:dbcedd8aeab47fbc0f4dd4bffa55b7c3c729a707875968d467aaaea42d6225af
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
 WORKDIR /build
 

--- a/import/Dockerfile
+++ b/import/Dockerfile
@@ -35,7 +35,7 @@ RUN --mount=type=bind,source=import/sql/operators.sql.js,target=operators.sql.js
   node operators.sql.js \
     > /build/operators.sql
 
-FROM debian:trixy-slim@sha256:1caf1c703c8f7e15dcf2e7769b35000c764e6f50e4d7401c355fb0248f3ddfdb AS test
+FROM debian:trixie-slim@sha256:cedb1ef40439206b673ee8b33a46a03a0c9fa90bf3732f54704f99cb061d2c5a AS test
 
 # https://serverfault.com/questions/949991/how-to-install-tzdata-on-a-ubuntu-docker-image
 ARG DEBIAN_FRONTEND=noninteractive
@@ -54,7 +54,7 @@ COPY import/test test
 
 CMD ["lua", "test/test_all.lua"]
 
-FROM debian:trixy-slim@sha256:1caf1c703c8f7e15dcf2e7769b35000c764e6f50e4d7401c355fb0248f3ddfdb
+FROM debian:trixie-slim@sha256:cedb1ef40439206b673ee8b33a46a03a0c9fa90bf3732f54704f99cb061d2c5a
 
 # https://serverfault.com/questions/949991/how-to-install-tzdata-on-a-ubuntu-docker-image
 ARG DEBIAN_FRONTEND=noninteractive

--- a/import/Dockerfile
+++ b/import/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine@sha256:dbcedd8aeab47fbc0f4dd4bffa55b7c3c729a707875968d467aaaea42d6225af AS build-lua
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS build-lua
 
 WORKDIR /build
 
@@ -12,7 +12,7 @@ RUN --mount=type=bind,source=import/tags.lua.js,target=tags.lua.js \
   node tags.lua.js \
     > /build/tags.lua
 
-FROM node:22-alpine@sha256:dbcedd8aeab47fbc0f4dd4bffa55b7c3c729a707875968d467aaaea42d6225af AS build-signals
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS build-signals
 
 WORKDIR /build
 
@@ -24,7 +24,7 @@ RUN --mount=type=bind,source=import/sql/signal_features.sql.js,target=signal_fea
   node signal_features.sql.js \
     > /build/signal_features.sql
 
-FROM node:22-alpine@sha256:dbcedd8aeab47fbc0f4dd4bffa55b7c3c729a707875968d467aaaea42d6225af AS build-operators
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS build-operators
 
 WORKDIR /build
 

--- a/martin.Dockerfile
+++ b/martin.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/maplibre/martin:main@sha256:5668210f16293b1769f72671ea5aed9dee16cf7bfdb039798f7cd88415704749
+FROM ghcr.io/maplibre/martin:latest@sha256:077329dbde8d791f030b9eab63f4681772480be2f6ceebab0108cb79cebb4aa3
 
 COPY martin /config
 COPY symbols /symbols

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=bind,source=proxy,target=proxy \
   node proxy/js/taginfo.mjs \
     > /build/taginfo.json
 
-FROM python:3-alpine@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510 AS build-preset
+FROM python:3-alpine@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a AS build-preset
 
 RUN apk add --no-cache zip
 


### PR DESCRIPTION
See https://hub.docker.com/r/imresamu/postgis/tags?name=18-
See https://hub.docker.com/_/python/tags?name=3-alpine
See https://hub.docker.com/_/node/tags?name=24-
See https://hub.docker.com/_/debian/tags?name=trixie-slim
See https://github.com/maplibre/martin/pkgs/container/martin/versions