### PR TITLE
Revert Martin update from 1.7.0 to 1.2.0, breaks map label rendering

### DIFF
--- a/martin.Dockerfile
+++ b/martin.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/maplibre/martin:latest@sha256:077329dbde8d791f030b9eab63f4681772480be2f6ceebab0108cb79cebb4aa3
+FROM ghcr.io/maplibre/martin:main@sha256:5668210f16293b1769f72671ea5aed9dee16cf7bfdb039798f7cd88415704749
 
 COPY martin /config
 COPY symbols /symbols

--- a/martin.Dockerfile
+++ b/martin.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/maplibre/martin:main@sha256:5668210f16293b1769f72671ea5aed9dee16cf7bfdb039798f7cd88415704749
+FROM ghcr.io/maplibre/martin:1.2.0@sha256:e53c0bb7e478617c603ee06f37f2e9ecee952d999d952a5173cad5dca281c442
 
 COPY martin /config
 COPY symbols /symbols


### PR DESCRIPTION
Upgraded in https://github.com/hiddewie/OpenRailwayMap-vector/pull/914

Martin 1.3.0, https://github.com/maplibre/martin/releases/tag/martin-v1.3.0, seems to break the reference label rendering:
<img width="808" height="533" alt="image" src="https://github.com/user-attachments/assets/27b2be70-c0ac-4a97-bc2a-7fd4df4c946e" />

Reverted for now, until a proper fix can be found.
<img width="808" height="533" alt="image" src="https://github.com/user-attachments/assets/e7a7ebf5-381f-431d-b5b9-bb7e5d8a5545" />
