### PR TITLE
Create AWS&TPWS legend in train_protection.yaml

### DIFF
--- a/features/train_protection.yaml
+++ b/features/train_protection.yaml
@@ -25,6 +25,7 @@ train_protections:
   - { train_protection: 'als', legend: 'Автоматическая локомотивная сигнализация (ALS)', color: 'hsl(284, 100%, 40%)' }
   - { train_protection: 'atp', legend: 'Automatic Train Protection (ATP)', color: 'hsl(305, 100%, 40%)' }
   - { train_protection: 'aws', legend: 'Automatic Warning System (AWS)', color: 'hsl(50, 100%, 40%)' }
+  - { train_protection: 'aws&tpws', legend: 'Automatic Warning System (AWS) & Train Protection & Warning System (TPWS)', color: 'pink' }
   - { train_protection: 'caws', legend: 'Continuous Automatic Warning System (CAWS)', color: 'hsl(60, 100%, 40%)' }
   - { train_protection: 'tcb', legend: 'Track Circuit Block (TCB)', color: 'hsl(147, 100%, 40%)' }
   - { train_protection: 'cbtc', legend: 'Communications Based Train Control (CBTC)', color: 'hsl(336, 100%, 40%)' }
@@ -205,6 +206,11 @@ features:
   - train_protection: atp
     tags:
       - { tag: 'railway:atp', value: 'yes' }
+
+- train_protection: aws&tpws
+    tags:
+      - { tag: 'railway:aws', value: 'yes' }
+      - { tag: 'railway:tpws', value: 'yes' }
 
   - train_protection: aws
     tags:


### PR DESCRIPTION
In Great Britain, most lines are equipped with AWS, which provides information about the next signal aspect and only applies intervention braking if the driver does not acknowledge the information in time. Some lines are also equipped with the complimentary TPWS system, which provides intervention braking if a signal is passed at danger. On these lines, both AWS and TPWS work simultaneously.

At present, the AWS tag takes precedent over the TPWS tag, so in areas where both systems are installed it appears as if only AWS is installed. My pull request would create a new legend for AWS&TPWS which takes precedent over AWS, correcting this issue.

The reason for doing it this way rather than just renaming the TPWS legend to AWS&TPWS is that there are lines which use TPWS without AWS in Australia, so the existing TPWS legend needs to remain in place for use on them.

Information on AWS/TPWS:
https://www.railengineer.co.uk/tpws-a-retrospective/

Thanks :)