### PR TITLE
Persistent primary key

### DIFF
--- a/import/docker-startup.sh
+++ b/import/docker-startup.sh
@@ -154,10 +154,10 @@ import)
 
   filter_data
   import_db
-#  reduce_data
-#  transform_data
-#  create_update_functions_views
-#  print_summary
+  reduce_data
+  transform_data
+  create_update_functions_views
+  print_summary
 
   ;;
 

--- a/import/docker-startup.sh
+++ b/import/docker-startup.sh
@@ -154,10 +154,10 @@ import)
 
   filter_data
   import_db
-  reduce_data
-  transform_data
-  create_update_functions_views
-  print_summary
+#  reduce_data
+#  transform_data
+#  create_update_functions_views
+#  print_summary
 
   ;;
 

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -643,9 +643,8 @@ local landuse = osm2pgsql.define_table({
 
 local substation = osm2pgsql.define_table({
   name = 'substation',
-  ids = { type = 'way', id_column = 'osm_id' },
+  ids = { type = 'way', id_column = 'osm_id', create_index = 'primary_key' },
   columns = {
-    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'polygon', not_null = true },
     { column = 'feature', type = 'text' },
     { column = 'ref', type = 'text' },
@@ -661,10 +660,6 @@ local substation = osm2pgsql.define_table({
     { column = 'wikipedia', type = 'text' },
     { column = 'note', type = 'text' },
     { column = 'description', type = 'text' },
-  },
-  indexes = {
-    { column = 'id', method = 'btree', unique = true },
-    { column = 'way', method = 'gist' },
   },
 })
 
@@ -1576,7 +1571,6 @@ function osm2pgsql.process_way(object)
 
   if tags.power == 'substation' and tags.substation == 'traction' then
     substation:insert({
-      id = string.format("%d", object.id),
       way = object:as_polygon(),
       feature = 'traction',
       name = tags.name,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -523,7 +523,7 @@ local railway_switches = osm2pgsql.define_table({
   name = 'railway_switches',
   ids = { type = 'node', id_column = 'osm_id' },
   columns = {
-    { column = 'id', sql_type = 'serial', create_only = true },
+    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'point', not_null = true },
     { column = 'railway', type = 'text' },
     { column = 'ref', type = 'text' },
@@ -541,6 +541,10 @@ local railway_switches = osm2pgsql.define_table({
     { column = 'note', type = 'text' },
     { column = 'description', type = 'text' },
   },
+  indexes = {
+    { column = 'id', method = 'btree', unique = true },
+    { column = 'way', method = 'gist' },
+   },
 })
 
 local routes = osm2pgsql.define_table({
@@ -1310,6 +1314,7 @@ function osm2pgsql.process_node(object)
 
   if railway_switch_values(tags.railway) then
     railway_switches:insert({
+      id = string.format("%d", object.id),
       way = object:as_point(),
       railway = tags.railway,
       ref = tags.ref,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -356,9 +356,8 @@ local platform_edge = osm2pgsql.define_table({
 
 local station_entrances = osm2pgsql.define_table({
   name = 'station_entrances',
-  ids = { type = 'node', id_column = 'osm_id' },
+  ids = { type = 'node', id_column = 'osm_id', create_index = 'primary_key' },
   columns = {
-    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'point', not_null = true },
     { column = 'name', type = 'text' },
     { column = 'type', type = 'text' },
@@ -373,10 +372,7 @@ local station_entrances = osm2pgsql.define_table({
     { column = 'description', type = 'text' },
   },
   indexes = {
-    { column = 'id', method = 'btree', unique = true },
     { column = 'way', method = 'gist' },
-    -- For joining clustered station areas with entrances
-    { column = 'osm_id', method = 'btree' },
   },
 })
 
@@ -1248,7 +1244,6 @@ function osm2pgsql.process_node(object)
 
   if railway_entrances_values(tags.railway) then
     station_entrances:insert({
-      id = string.format("%d", object.id),
       way = object:as_point(),
       type = entrance_types[tags.railway],
       ref = tags.ref,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -257,7 +257,7 @@ local stations = osm2pgsql.define_table({
   name = 'stations',
   ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
   columns = {
-    { column = 'id', sql_type = 'serial', create_only = true },
+    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'geometry', not_null = true },
     { column = 'feature', type = 'text' },
     { column = 'state', type = 'text' },
@@ -282,9 +282,8 @@ local stations = osm2pgsql.define_table({
     { column = 'description', type = 'text' },
   },
   indexes = {
-    { column = 'way', method = 'gist' },
-    -- For joining grouped_stations_with_importance with metadata from this table
     { column = 'id', method = 'btree', unique = true },
+    { column = 'way', method = 'gist' },
     -- For building linking table between stations and stop areas
     { column = 'osm_type', method = 'btree' },
     -- Search by reference
@@ -1112,6 +1111,7 @@ function osm2pgsql.process_node(object)
   if station_feature then
     for station, _ in pairs(station_type(tags)) do
       stations:insert({
+        id = string.format("%s-%d-%s", object.type, object.id, station),
         way = object:as_point(),
         feature = station_feature,
         state = station_state,
@@ -1404,6 +1404,7 @@ function osm2pgsql.process_way(object)
 
     for station, _ in pairs(station_type(tags)) do
       stations:insert({
+        id = string.format("%s-%d-%s", object.type, object.id, station),
         way = object.is_closed and object:as_polygon() or object:as_linestring(),
         feature = station_feature,
         state = station_state,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -339,11 +339,15 @@ local platform_edge = osm2pgsql.define_table({
   name = 'platform_edge',
   ids = { type = 'way', id_column = 'osm_id' },
   columns = {
-    { column = 'id', sql_type = 'serial', create_only = true },
+    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'linestring', not_null = true },
     { column = 'ref', sql_type = 'text' },
     { column = 'height', type = 'real' },
     { column = 'tactile_paving', type = 'boolean' },
+  },
+  indexes = {
+    { column = 'id', method = 'btree', unique = true },
+    { column = 'way', method = 'gist' },
   },
 })
 
@@ -1536,6 +1540,7 @@ function osm2pgsql.process_way(object)
 
   if tags.railway == 'platform_edge' then
     platform_edge:insert({
+      id = string.format("%d", object.id),
       way = object:as_linestring(),
       ref = tags.ref,
       height = tags.height,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -424,7 +424,7 @@ local boxes = osm2pgsql.define_table({
   name = 'boxes',
   ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
   columns = {
-    { column = 'id', sql_type = 'serial', create_only = true },
+    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'geometry', not_null = true },
     { column = 'center', type = 'geometry', not_null = true },
     { column = 'way_area', type = 'real' },
@@ -441,6 +441,10 @@ local boxes = osm2pgsql.define_table({
     { column = 'wikipedia', type = 'text' },
     { column = 'note', type = 'text' },
     { column = 'description', type = 'text' },
+  },
+  indexes = {
+    { column = 'id', method = 'btree', unique = true },
+    { column = 'way', method = 'gist' },
   },
 })
 
@@ -1103,6 +1107,7 @@ function osm2pgsql.process_node(object)
   if railway_box_values(tags.railway) then
     local point = object:as_point()
     boxes:insert({
+      id = string.format("%s-%d", object.type, object.id),
       way = point,
       center = point,
       way_area = 0,
@@ -1480,6 +1485,7 @@ function osm2pgsql.process_way(object)
     local position, position_exact, line_positions = find_position_tags(tags)
 
     boxes:insert({
+      id = string.format("%s-%d", object.type, object.id),
       way = polygon,
       center = polygon:centroid(),
       way_area = polygon:area(),

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -378,7 +378,7 @@ local station_entrances = osm2pgsql.define_table({
 })
 
 local signal_columns = {
-  { column = 'id', sql_type = 'serial', create_only = true },
+  { column = 'id', type = 'text', not_null = true },
   { column = 'way', type = 'point', not_null = true },
   { column = 'railway', type = 'text' },
   { column = 'ref', type = 'text' },
@@ -414,6 +414,10 @@ local signals = osm2pgsql.define_table({
   name = 'signals',
   ids = { type = 'node', id_column = 'osm_id' },
   columns = signal_columns,
+  indexes = {
+    { column = 'id', method = 'btree', unique = true },
+    { column = 'way', method = 'gist' },
+  },
 })
 
 local boxes = osm2pgsql.define_table({
@@ -1227,6 +1231,7 @@ function osm2pgsql.process_node(object)
 
   if railway_signal_values(tags.railway) then
     local signal = {
+      id = string.format("%d", object.id),
       way = object:as_point(),
       railway = tags.railway,
       ref = tags.ref,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -640,9 +640,11 @@ local stop_area_groups = osm2pgsql.define_table({
   name = 'stop_area_groups',
   ids = { type = 'relation', id_column = 'osm_id' },
   columns = {
+    { column = 'id', type = 'text', not_null = true },
     { column = 'stop_area_ref_ids', sql_type = 'int8[]' },
   },
   indexes = {
+    { column = 'id', method = 'btree', unique = true },
     { column = 'stop_area_ref_ids', method = 'gin' },
   },
 })
@@ -1723,6 +1725,7 @@ function osm2pgsql.process_relation(object)
 
     if has_members then
       stop_area_groups:insert({
+        id = string.format("%d", object.id),
         stop_area_ref_ids = '{' .. table.concat(stop_area_members, ',') .. '}',
       })
     end

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -466,7 +466,7 @@ local railway_positions = osm2pgsql.define_table({
   name = 'railway_positions',
   ids = { type = 'node', id_column = 'osm_id' },
   columns = {
-    { column = 'id', sql_type = 'serial', create_only = true },
+    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'point', not_null = true },
     { column = 'railway', type = 'text' },
     { column = 'position_numeric', type = 'real' },
@@ -488,8 +488,10 @@ local railway_positions = osm2pgsql.define_table({
     { column = 'description', type = 'text' },
   },
   indexes = {
+    { column = 'id', method = 'btree', unique = true },
     { column = 'way', method = 'gist' },
-    { column = 'position_numeric', method = 'btree', where = 'position_numeric IS NOT NULL' },
+    { column = 'position_numeric', method = 'btree', where = 'position_numeric IS NOT NULL'
+   },
   },
 })
 
@@ -1276,8 +1278,9 @@ function osm2pgsql.process_node(object)
   end
 
   if railway_position_values(tags.railway) and (position or position_exact) then
-    for _, position in ipairs(parse_railway_positions(position, position_exact, line_positions)) do
+    for position_index, position in ipairs(parse_railway_positions(position, position_exact, line_positions)) do
       railway_positions:insert({
+        id = string.format("%d-%d", object.id, position_index),
         way = object:as_point(),
         railway = tags.railway,
         position_numeric = position.numeric,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -340,17 +340,12 @@ local platforms = osm2pgsql.define_table({
 
 local platform_edge = osm2pgsql.define_table({
   name = 'platform_edge',
-  ids = { type = 'way', id_column = 'osm_id' },
+  ids = { type = 'way', id_column = 'osm_id', create_index = 'primary_key' },
   columns = {
-    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'linestring', not_null = true },
     { column = 'ref', sql_type = 'text' },
     { column = 'height', type = 'real' },
     { column = 'tactile_paving', type = 'boolean' },
-  },
-  indexes = {
-    { column = 'id', method = 'btree', unique = true },
-    { column = 'way', method = 'gist' },
   },
 })
 
@@ -1565,7 +1560,6 @@ function osm2pgsql.process_way(object)
 
   if tags.railway == 'platform_edge' then
     platform_edge:insert({
-      id = string.format("%d", object.id),
       way = object:as_linestring(),
       ref = tags.ref,
       height = tags.height,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -528,9 +528,8 @@ local railway_switches = osm2pgsql.define_table({
 
 local routes = osm2pgsql.define_table({
   name = 'routes',
-  ids = { type = 'relation', id_column = 'osm_id' },
+  ids = { type = 'relation', id_column = 'osm_id', create_index = 'primary_key' },
   columns = {
-    { column = 'id', type = 'text', not_null = true },
     { column = 'type', sql_type = 'route_type', not_null = true },
     { column = 'from', type = 'text' },
     { column = 'to', type = 'text' },
@@ -542,10 +541,7 @@ local routes = osm2pgsql.define_table({
     { column = 'platform_ref_ids', sql_type = 'int8[]' },
   },
   indexes = {
-    { column = 'id', method = 'btree', unique = true },
     { column = 'platform_ref_ids', method = 'gin' },
-    -- For querying routes with railway lines
-    { column = 'osm_id', method = 'btree' },
   },
 })
 
@@ -1639,7 +1635,6 @@ function osm2pgsql.process_relation(object)
 
     if has_members then
       routes:insert({
-        id = string.format("%d", object.id),
         type = tags.route,
         from = tags.from,
         to = tags.to,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -168,7 +168,7 @@ local railway_line = osm2pgsql.define_table({
   name = 'railway_line',
   ids = { type = 'way', id_column = 'osm_id' },
   columns = {
-    { column = 'id', sql_type = 'serial', create_only = true },
+    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'linestring', not_null = true },
     { column = 'way_length', type = 'real' },
     { column = 'feature', type = 'text' },
@@ -216,6 +216,7 @@ local railway_line = osm2pgsql.define_table({
     { column = 'description', type = 'text' },
   },
   indexes = {
+    { column = 'id', method = 'btree', unique = true },
     { column = 'way', method = 'gist' },
     -- For querying routes with railway lines
     { column = 'osm_id', method = 'btree' },
@@ -1336,8 +1337,10 @@ function osm2pgsql.process_way(object)
     local dominant_speed, speed_label = dominant_speed_label(state, preferred_direction, tags['maxspeed'], tags['maxspeed:forward'], tags['maxspeed:backward'])
 
     -- Segmentize linestring to optimize tile queries
+    local way_index = 0
     for way in object:as_linestring():transform(3857):segmentize(max_segment_length):geometries() do
       railway_line:insert({
+        id = string.format("%d-%d", object.id, way_index),
         way = way,
         way_length = way:length(),
         feature = feature,
@@ -1385,6 +1388,8 @@ function osm2pgsql.process_way(object)
         note = tags.note,
         description = tags.description,
       })
+
+      way_index = way_index + 1
     end
   end
 

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -293,9 +293,8 @@ local stations = osm2pgsql.define_table({
 
 local stop_positions = osm2pgsql.define_table({
   name = 'stop_positions',
-  ids = { type = 'node', id_column = 'osm_id' },
+  ids = { type = 'node', id_column = 'osm_id', create_index = 'primary_key' },
   columns = {
-    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'point', not_null = true },
     { column = 'type', type = 'text' },
     { column = 'name', type = 'text' },
@@ -303,10 +302,7 @@ local stop_positions = osm2pgsql.define_table({
     { column = 'local_ref', type = 'text' },
   },
   indexes = {
-    { column = 'id', method = 'btree', unique = true },
     { column = 'way', method = 'gist' },
-    -- For querying stop positions for routes
-    { column = 'osm_id', method = 'btree', unique = true },
   },
 })
 
@@ -1215,7 +1211,6 @@ function osm2pgsql.process_node(object)
     local type = stop_position_type(tags)
     if type then
       stop_positions:insert({
-        id = string.format("%d", object.id),
         way = object:as_point(),
         type = type,
         name = tags.name,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -452,9 +452,13 @@ local turntables = osm2pgsql.define_table({
   name = 'turntables',
   ids = { type = 'way', id_column = 'osm_id' },
   columns = {
-    { column = 'id', sql_type = 'serial', create_only = true },
+    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'polygon', not_null = true },
     { column = 'feature', type = 'text' },
+  },
+  indexes = {
+    { column = 'id', method = 'btree', unique = true },
+    { column = 'way', method = 'gist' },
   },
 })
 
@@ -1475,6 +1479,7 @@ function osm2pgsql.process_way(object)
 
   if railway_turntable_values(tags.railway) then
     turntables:insert({
+      id = string.format("%d", object.id),
       way = object:as_polygon(),
       feature = tags.railway,
     })

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -572,17 +572,14 @@ local route_stop = osm2pgsql.define_table({
 
 local stop_areas = osm2pgsql.define_table({
   name = 'stop_areas',
-  ids = { type = 'relation', id_column = 'osm_id' },
+  ids = { type = 'relation', id_column = 'osm_id', create_index = 'primary_key' },
   columns = {
-    { column = 'id', type = 'text', not_null = true },
     { column = 'platform_ref_ids', sql_type = 'int8[]' },
     { column = 'node_ref_ids', sql_type = 'int8[]' },
     { column = 'way_ref_ids', sql_type = 'int8[]' },
     { column = 'references', type = 'hstore' },
   },
   indexes = {
-    { column = 'id', method = 'btree', unique = true },
-    { column = 'osm_id', method = 'btree' },
     { column = 'platform_ref_ids', method = 'gin' },
     -- Search by reference
     { expression = 'avals("references")', method = 'gin', where = '"references" IS NOT NULL' },
@@ -1677,7 +1674,6 @@ function osm2pgsql.process_relation(object)
 
     if has_members then
       stop_areas:insert({
-        id = string.format("%d", object.id),
         node_ref_ids = '{' .. table.concat(node_members, ',') .. '}',
         way_ref_ids = '{' .. table.concat(way_members, ',') .. '}',
         references = station_references(tags),

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -295,7 +295,7 @@ local stop_positions = osm2pgsql.define_table({
   name = 'stop_positions',
   ids = { type = 'node', id_column = 'osm_id' },
   columns = {
-    { column = 'id', sql_type = 'serial', create_only = true },
+    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'point', not_null = true },
     { column = 'type', type = 'text' },
     { column = 'name', type = 'text' },
@@ -303,6 +303,7 @@ local stop_positions = osm2pgsql.define_table({
     { column = 'local_ref', type = 'text' },
   },
   indexes = {
+    { column = 'id', method = 'btree', unique = true },
     { column = 'way', method = 'gist' },
     -- For querying stop positions for routes
     { column = 'osm_id', method = 'btree', unique = true },
@@ -1168,6 +1169,7 @@ function osm2pgsql.process_node(object)
     local type = stop_position_type(tags)
     if type then
       stop_positions:insert({
+        id = string.format("%d", object.id),
         way = object:as_point(),
         type = type,
         name = tags.name,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -227,7 +227,7 @@ local pois = osm2pgsql.define_table({
   name = 'pois',
   ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
   columns = {
-    { column = 'id', sql_type = 'serial', create_only = true },
+    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'point', not_null = true },
     { column = 'feature', type = 'text' },
     { column = 'rank', type = 'integer' },
@@ -246,6 +246,10 @@ local pois = osm2pgsql.define_table({
     { column = 'wikipedia', type = 'text' },
     { column = 'note', type = 'text' },
     { column = 'description', type = 'text' },
+  },
+  indexes = {
+    { column = 'id', method = 'btree', unique = true },
+    { column = 'way', method = 'gist' },
   },
 })
 
@@ -1138,6 +1142,7 @@ function osm2pgsql.process_node(object)
     local feature, rank, minzoom, layer = tag_functions.poi(tags)
 
     pois:insert({
+      id = string.format("%s-%d", object.type, object.id),
       way = object:as_point(),
       feature = feature,
       rank = rank,
@@ -1479,6 +1484,7 @@ function osm2pgsql.process_way(object)
     local position, position_exact, line_positions = find_position_tags(tags)
 
     pois:insert({
+      id = string.format("%s-%d", object.type, object.id),
       way = object:as_polygon():centroid(),
       feature = feature,
       rank = rank,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -551,6 +551,7 @@ local routes = osm2pgsql.define_table({
   name = 'routes',
   ids = { type = 'relation', id_column = 'osm_id' },
   columns = {
+    { column = 'id', type = 'text', not_null = true },
     { column = 'type', sql_type = 'route_type', not_null = true },
     { column = 'from', type = 'text' },
     { column = 'to', type = 'text' },
@@ -562,6 +563,7 @@ local routes = osm2pgsql.define_table({
     { column = 'platform_ref_ids', sql_type = 'int8[]' },
   },
   indexes = {
+    { column = 'id', method = 'btree', unique = true },
     { column = 'platform_ref_ids', method = 'gin' },
     -- For querying routes with railway lines
     { column = 'osm_id', method = 'btree' },
@@ -1656,6 +1658,7 @@ function osm2pgsql.process_relation(object)
 
     if has_members then
       routes:insert({
+        id = string.format("%d", object.id),
         type = tags.route,
         from = tags.from,
         to = tags.to,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -377,7 +377,6 @@ local station_entrances = osm2pgsql.define_table({
 })
 
 local signal_columns = {
-  { column = 'id', type = 'text', not_null = true },
   { column = 'way', type = 'point', not_null = true },
   { column = 'railway', type = 'text' },
   { column = 'ref', type = 'text' },
@@ -411,12 +410,8 @@ for _, tag in ipairs(tag_functions.signal_tags) do
 end
 local signals = osm2pgsql.define_table({
   name = 'signals',
-  ids = { type = 'node', id_column = 'osm_id' },
+  ids = { type = 'node', id_column = 'osm_id', create_index = 'primary_key' },
   columns = signal_columns,
-  indexes = {
-    { column = 'id', method = 'btree', unique = true },
-    { column = 'way', method = 'gist' },
-  },
 })
 
 local boxes = osm2pgsql.define_table({
@@ -1261,7 +1256,6 @@ function osm2pgsql.process_node(object)
 
   if railway_signal_values(tags.railway) then
     local signal = {
-      id = string.format("%d", object.id),
       way = object:as_point(),
       railway = tags.railway,
       ref = tags.ref,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -164,6 +164,13 @@ function signal_caption(tags)
     or tags['railway:signal:radio:frequency']
 end
 
+-- Table definitions --
+
+-- Note on primary keys:
+-- Some tables import a single row per table per OSM object, and only of a single type. In those cases the OSM id is the primary key, and the OSM type is implicit.
+-- Some tables import more than a single row per table per OSM object, or of multiple OSM types. In those cases the the OSM ID and type are imported in `osm_id` and `osm_type` columns, and the column `id` is the primary key.
+-- See https://osm2pgsql.org/doc/manual.html#unique-ids
+
 local railway_line = osm2pgsql.define_table({
   name = 'railway_line',
   ids = { type = 'way', id_column = 'osm_id' },

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -515,9 +515,8 @@ local catenary = osm2pgsql.define_table({
 
 local railway_switches = osm2pgsql.define_table({
   name = 'railway_switches',
-  ids = { type = 'node', id_column = 'osm_id' },
+  ids = { type = 'node', id_column = 'osm_id', create_index = 'primary_key' },
   columns = {
-    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'point', not_null = true },
     { column = 'railway', type = 'text' },
     { column = 'ref', type = 'text' },
@@ -535,10 +534,6 @@ local railway_switches = osm2pgsql.define_table({
     { column = 'note', type = 'text' },
     { column = 'description', type = 'text' },
   },
-  indexes = {
-    { column = 'id', method = 'btree', unique = true },
-    { column = 'way', method = 'gist' },
-   },
 })
 
 local routes = osm2pgsql.define_table({
@@ -1319,7 +1314,6 @@ function osm2pgsql.process_node(object)
 
   if railway_switch_values(tags.railway) then
     railway_switches:insert({
-      id = string.format("%d", object.id),
       way = object:as_point(),
       railway = tags.railway,
       ref = tags.ref,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -444,15 +444,10 @@ local boxes = osm2pgsql.define_table({
 
 local turntables = osm2pgsql.define_table({
   name = 'turntables',
-  ids = { type = 'way', id_column = 'osm_id' },
+  ids = { type = 'way', id_column = 'osm_id', create_index = 'primary_key' },
   columns = {
-    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'polygon', not_null = true },
     { column = 'feature', type = 'text' },
-  },
-  indexes = {
-    { column = 'id', method = 'btree', unique = true },
-    { column = 'way', method = 'gist' },
   },
 })
 
@@ -1491,7 +1486,6 @@ function osm2pgsql.process_way(object)
 
   if railway_turntable_values(tags.railway) then
     turntables:insert({
-      id = string.format("%d", object.id),
       way = object:as_polygon(),
       feature = tags.railway,
     })

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -314,7 +314,7 @@ local platforms = osm2pgsql.define_table({
   name = 'platforms',
   ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
   columns = {
-    { column = 'id', sql_type = 'serial', create_only = true },
+    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'geometry', not_null = true },
     { column = 'name', type = 'text' },
     { column = 'ref', sql_type = 'text[]' },
@@ -328,6 +328,10 @@ local platforms = osm2pgsql.define_table({
     { column = 'wheelchair', type = 'boolean' },
     { column = 'departures_board', type = 'boolean' },
     { column = 'tactile_paving', type = 'boolean' },
+  },
+  indexes = {
+    { column = 'id', method = 'btree', unique = true },
+    { column = 'way', method = 'gist' },
   },
 })
 
@@ -1181,6 +1185,7 @@ function osm2pgsql.process_node(object)
 
   if is_railway_platform(tags) then
     platforms:insert({
+      id = string.format("%s-%d", object.type, object.id),
       way = object:as_point(),
       name = tags.name,
       ref = split_semicolon_to_sql_array(tags.ref),
@@ -1435,6 +1440,7 @@ function osm2pgsql.process_way(object)
 
   if is_railway_platform(tags) then
     platforms:insert({
+      id = string.format("%s-%d", object.type, object.id),
       way = object.is_closed and object:as_polygon() or object:as_linestring(),
       name = tags.name,
       ref = split_semicolon_to_sql_array(tags.ref),
@@ -1573,6 +1579,7 @@ function osm2pgsql.process_relation(object)
 
   if is_railway_platform(tags) then
     platforms:insert({
+      id = string.format("%s-%d", object.type, object.id),
       way = object:as_multipolygon(),
       name = tags.name,
       ref = split_semicolon_to_sql_array(tags.ref),

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -499,7 +499,7 @@ local catenary = osm2pgsql.define_table({
   name = 'catenary',
   ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
   columns = {
-    { column = 'id', sql_type = 'serial', create_only = true },
+    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'geometry', not_null = true },
     { column = 'feature', type = 'text' },
     { column = 'ref', type = 'text' },
@@ -513,6 +513,10 @@ local catenary = osm2pgsql.define_table({
     { column = 'note', type = 'text' },
     { column = 'description', type = 'text' },
   },
+  indexes = {
+    { column = 'id', method = 'btree', unique = true },
+    { column = 'way', method = 'gist' },
+   },
 })
 
 local railway_switches = osm2pgsql.define_table({
@@ -1327,6 +1331,7 @@ function osm2pgsql.process_node(object)
 
   if tags.power == 'catenary_mast' then
     catenary:insert({
+      id = string.format("%d-mast", object.id),
       way = object:as_point(),
       ref = tags.ref,
       feature = 'mast',
@@ -1544,6 +1549,7 @@ function osm2pgsql.process_way(object)
     local position, position_exact, line_positions = find_position_tags(tags)
 
     catenary:insert({
+      id = string.format("%d-portal", object.id),
       way = object:as_linestring(),
       ref = tags.ref,
       feature = 'portal',

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -599,12 +599,14 @@ local stop_areas = osm2pgsql.define_table({
   name = 'stop_areas',
   ids = { type = 'relation', id_column = 'osm_id' },
   columns = {
+    { column = 'id', type = 'text', not_null = true },
     { column = 'platform_ref_ids', sql_type = 'int8[]' },
     { column = 'node_ref_ids', sql_type = 'int8[]' },
     { column = 'way_ref_ids', sql_type = 'int8[]' },
     { column = 'references', type = 'hstore' },
   },
   indexes = {
+    { column = 'id', method = 'btree', unique = true },
     { column = 'osm_id', method = 'btree' },
     { column = 'platform_ref_ids', method = 'gin' },
     -- Search by reference
@@ -1701,6 +1703,7 @@ function osm2pgsql.process_relation(object)
 
     if has_members then
       stop_areas:insert({
+        id = string.format("%d", object.id),
         node_ref_ids = '{' .. table.concat(node_members, ',') .. '}',
         way_ref_ids = '{' .. table.concat(way_members, ',') .. '}',
         references = station_references(tags),

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -353,9 +353,9 @@ local platform_edge = osm2pgsql.define_table({
 
 local station_entrances = osm2pgsql.define_table({
   name = 'station_entrances',
-  ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+  ids = { type = 'node', id_column = 'osm_id' },
   columns = {
-    { column = 'id', sql_type = 'serial', create_only = true },
+    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'point', not_null = true },
     { column = 'name', type = 'text' },
     { column = 'type', type = 'text' },
@@ -370,6 +370,7 @@ local station_entrances = osm2pgsql.define_table({
     { column = 'description', type = 'text' },
   },
   indexes = {
+    { column = 'id', method = 'btree', unique = true },
     { column = 'way', method = 'gist' },
     -- For joining clustered station areas with entrances
     { column = 'osm_id', method = 'btree' },
@@ -1208,6 +1209,7 @@ function osm2pgsql.process_node(object)
 
   if railway_entrances_values(tags.railway) then
     station_entrances:insert({
+      id = string.format("%d", object.id),
       way = object:as_point(),
       type = entrance_types[tags.railway],
       ref = tags.ref,

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -653,8 +653,12 @@ local landuse = osm2pgsql.define_table({
   name = 'landuse',
   ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
   columns = {
-    { column = 'id', sql_type = 'serial', create_only = true },
+    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'geometry', not_null = true },
+  },
+  indexes = {
+    { column = 'id', method = 'btree', unique = true },
+    { column = 'way', method = 'gist' },
   },
 })
 
@@ -1588,6 +1592,7 @@ function osm2pgsql.process_way(object)
 
   if tags.landuse == 'railway' then
     landuse:insert({
+      id = string.format("%s-%d", object.type, object.id),
       way = object:as_polygon(),
     })
   end
@@ -1733,6 +1738,7 @@ function osm2pgsql.process_relation(object)
 
   if tags.landuse == 'railway' then
     landuse:insert({
+      id = string.format("%s-%d", object.type, object.id),
       way = object:as_multipolygon(),
     })
   end

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -610,13 +610,11 @@ local stop_area_platforms = osm2pgsql.define_table({
 
 local stop_area_groups = osm2pgsql.define_table({
   name = 'stop_area_groups',
-  ids = { type = 'relation', id_column = 'osm_id' },
+  ids = { type = 'relation', id_column = 'osm_id', create_index = 'primary_key' },
   columns = {
-    { column = 'id', type = 'text', not_null = true },
     { column = 'stop_area_ref_ids', sql_type = 'int8[]' },
   },
   indexes = {
-    { column = 'id', method = 'btree', unique = true },
     { column = 'stop_area_ref_ids', method = 'gin' },
   },
 })
@@ -1693,7 +1691,6 @@ function osm2pgsql.process_relation(object)
 
     if has_members then
       stop_area_groups:insert({
-        id = string.format("%d", object.id),
         stop_area_ref_ids = '{' .. table.concat(stop_area_members, ',') .. '}',
       })
     end

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -666,7 +666,7 @@ local substation = osm2pgsql.define_table({
   name = 'substation',
   ids = { type = 'way', id_column = 'osm_id' },
   columns = {
-    { column = 'id', sql_type = 'serial', create_only = true },
+    { column = 'id', type = 'text', not_null = true },
     { column = 'way', type = 'polygon', not_null = true },
     { column = 'feature', type = 'text' },
     { column = 'ref', type = 'text' },
@@ -682,6 +682,10 @@ local substation = osm2pgsql.define_table({
     { column = 'wikipedia', type = 'text' },
     { column = 'note', type = 'text' },
     { column = 'description', type = 'text' },
+  },
+  indexes = {
+    { column = 'id', method = 'btree', unique = true },
+    { column = 'way', method = 'gist' },
   },
 })
 
@@ -1599,6 +1603,7 @@ function osm2pgsql.process_way(object)
 
   if tags.power == 'substation' and tags.substation == 'traction' then
     substation:insert({
+      id = string.format("%d", object.id),
       way = object:as_polygon(),
       feature = 'traction',
       name = tags.name,

--- a/import/sql/get_station_importance.sql
+++ b/import/sql/get_station_importance.sql
@@ -159,7 +159,8 @@ CREATE OR REPLACE VIEW stations_with_importance_view AS
 
 -- Not a materialized view because the Osm2Pgsql scripts update the discrete isolation values
 CREATE TABLE IF NOT EXISTS stations_with_importance (
-  id BIGINT NOT NULL PRIMARY KEY,
+  id SERIAL NOT NULL PRIMARY KEY,
+  station_id TEXT NOT NULL,
   way GEOMETRY NOT NULL,
   importance NUMERIC NOT NULL DEFAULT 0,
   discr_iso REAL NOT NULL DEFAULT 0.0, -- Column name is fixed

--- a/import/sql/signal_features.sql.js
+++ b/import/sql/signal_features.sql.js
@@ -204,7 +204,7 @@ function featureIconsSql(icons) {
 const sql = `
 CREATE OR REPLACE VIEW signal_direction_view AS
   SELECT
-    s.id as signal_id,
+    s.osm_id as signal_id,
     (signal_direction = 'both') as direction_both,
     degrees(ST_Azimuth(
       st_lineinterpolatepoint(sl.way, greatest(0, st_linelocatepoint(sl.way, ST_ClosestPoint(sl.way, s.way)) - 0.01)),
@@ -241,7 +241,7 @@ CREATE OR REPLACE VIEW signal_features_view AS
   -- For every type of signal, generate the feature and related metadata
   WITH signals_with_features_0 AS (
     SELECT
-      id as signal_id,
+      osm_id as signal_id,
       railway,
       ${signals_railway_signals.types.map(type => `
       CASE 
@@ -331,7 +331,7 @@ CREATE OR REPLACE FUNCTION speed_railway_signals(z integer, x integer, y integer
       ST_AsMVT(tile, 'speed_railway_signals', 4096, 'way', 'id')
     FROM (
       SELECT
-        id,
+        osm_id as id,
         osm_id,
         railway,
         ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
@@ -358,9 +358,9 @@ CREATE OR REPLACE FUNCTION speed_railway_signals(z integer, x integer, y integer
         type
       FROM signals s
       JOIN signal_features sf
-        ON s.id = sf.signal_id
+        ON s.osm_id = sf.signal_id
       JOIN signal_direction sd
-        ON s.id = sd.signal_id
+        ON s.osm_id = sd.signal_id
       WHERE way && ST_TileEnvelope(z, x, y)
         AND layer = 'speed'
       ORDER BY rank NULLS FIRST
@@ -419,7 +419,7 @@ CREATE OR REPLACE FUNCTION signals_railway_signals(z integer, x integer, y integ
       ST_AsMVT(tile, 'signals_railway_signals', 4096, 'way', 'id')
     FROM (
       SELECT
-        id,
+        osm_id as id,
         osm_id,
         ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
         sd.direction_both,
@@ -458,9 +458,9 @@ CREATE OR REPLACE FUNCTION signals_railway_signals(z integer, x integer, y integ
         type
       FROM signals s
       JOIN signal_features sf
-        ON s.id = sf.signal_id
+        ON s.osm_id = sf.signal_id
       JOIN signal_direction sd
-        ON s.id = sd.signal_id
+        ON s.osm_id = sd.signal_id
       WHERE way && ST_TileEnvelope(z, x, y)
         AND layer = 'signals'
       ORDER BY rank NULLS FIRST
@@ -531,7 +531,7 @@ CREATE OR REPLACE FUNCTION electrification_signals(z integer, x integer, y integ
       ST_AsMVT(tile, 'electrification_signals', 4096, 'way', 'id')
     FROM (
       SELECT
-        id,
+        osm_id as id,
         osm_id,
         railway,
         ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
@@ -555,9 +555,9 @@ CREATE OR REPLACE FUNCTION electrification_signals(z integer, x integer, y integ
         type as type
       FROM signals s
       JOIN signal_features sf
-        ON s.id = sf.signal_id
+        ON s.osm_id = sf.signal_id
       JOIN signal_direction sd
-        ON s.id = sd.signal_id
+        ON s.osm_id = sd.signal_id
       WHERE way && ST_TileEnvelope(z, x, y)
         AND layer = 'electrification'
       ORDER BY rank NULLS FIRST

--- a/import/sql/stations_clustered.sql
+++ b/import/sql/stations_clustered.sql
@@ -157,6 +157,10 @@ CREATE INDEX IF NOT EXISTS grouped_stations_with_importance_station_index
   ON grouped_stations_with_importance
     USING GIN(station_ids);
 
+CREATE UNIQUE INDEX IF NOT EXISTS grouped_stations_with_importance_id
+  ON grouped_stations_with_importance
+    USING BTREE(id);
+
 CLUSTER grouped_stations_with_importance
   USING grouped_stations_with_importance_center_index;
 

--- a/import/sql/stations_clustered.sql
+++ b/import/sql/stations_clustered.sql
@@ -1,7 +1,7 @@
 -- Clustered stations without importance
 CREATE MATERIALIZED VIEW IF NOT EXISTS stations_clustered AS
   SELECT
-    row_number() over (order by name, station, map_reference, uic_ref, feature) as id,
+    (MIN(facilities.id)::TEXT || '-' || station || '-' || feature) as id,
     name,
     station,
     map_reference,
@@ -118,7 +118,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS grouped_stations_with_importance AS
   JOIN stations s
     ON clustered.station_id = s.id
   JOIN stations_with_importance si
-    ON clustered.station_id = si.id
+    ON clustered.station_id = si.station_id
   LEFT JOIN (
     SELECT
       id,

--- a/import/sql/tile_views.sql
+++ b/import/sql/tile_views.sql
@@ -191,7 +191,7 @@ DO $do$ BEGIN
       {
         "id": "railway_line_high",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "osm_id": "integer",
           "way_length": "number",
           "feature": "string",
@@ -357,7 +357,7 @@ DO $do$ BEGIN
       {
         "id": "standard_railway_line_low",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "feature": "string",
           "state": "string",
           "usage": "string",
@@ -465,7 +465,7 @@ RETURN (
   FROM (
     SELECT
       ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
-      id as id,
+      id,
       osm_id,
       osm_type,
       feature,
@@ -513,7 +513,7 @@ DO $do$ BEGIN
       {
         "id": "standard_railway_text_stations_low",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "osm_id": "string",
           "osm_type": "string",
           "feature": "string",
@@ -607,7 +607,7 @@ DO $do$ BEGIN
       {
         "id": "standard_railway_text_stations_med",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "osm_id": "string",
           "osm_type": "string",
           "feature": "string",
@@ -797,7 +797,7 @@ DO $do$ BEGIN
       {
         "id": "standard_railway_text_stations",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "osm_id": "string",
           "osm_type": "string",
           "feature": "string",
@@ -903,7 +903,7 @@ DO $do$ BEGIN
       {
         "id": "standard_railway_grouped_stations",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "osm_id": "string",
           "osm_type": "string",
           "feature": "string",
@@ -978,7 +978,7 @@ DO $do$ BEGIN
       {
         "id": "standard_railway_symbols",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "osm_id": "integer",
           "osm_type": "string",
           "feature": "string",
@@ -1044,7 +1044,7 @@ DO $do$ BEGIN
       {
         "id": "standard_railway_platforms",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "osm_id": "string",
           "osm_type": "string",
           "feature": "string",
@@ -1199,7 +1199,7 @@ DO $do$ BEGIN
       {
         "id": "railway_text_km",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "osm_id": "integer",
           "railway": "string",
           "pos": "string",
@@ -1373,7 +1373,7 @@ DO $do$ BEGIN
       {
         "id": "speed_railway_line_low",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "feature": "string",
           "state": "string",
           "usage": "string",
@@ -1437,7 +1437,7 @@ DO $do$ BEGIN
       {
         "id": "signals_railway_line_low",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "feature": "string",
           "state": "string",
           "usage": "string",
@@ -1510,7 +1510,7 @@ DO $do$ BEGIN
       {
         "id": "signals_signal_boxes",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "osm_id": "integer",
           "osm_type": "string",
           "feature": "string",
@@ -1584,7 +1584,7 @@ DO $do$ BEGIN
       {
         "id": "electrification_railway_line_low",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "feature": "string",
           "state": "string",
           "usage": "string",
@@ -1647,7 +1647,7 @@ DO $do$ BEGIN
       {
         "id": "electrification_railway_symbols",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "osm_id": "integer",
           "osm_type": "string",
           "feature": "string",
@@ -1707,7 +1707,7 @@ DO $do$ BEGIN
       {
         "id": "electrification_catenary",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "osm_id": "integer",
           "osm_type": "string",
           "ref": "string",
@@ -1842,7 +1842,7 @@ DO $do$ BEGIN
       {
         "id": "track_railway_line_low",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "feature": "string",
           "state": "string",
           "usage": "string",
@@ -1906,7 +1906,7 @@ DO $do$ BEGIN
       {
         "id": "operator_railway_line_low",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "feature": "string",
           "state": "string",
           "usage": "string",
@@ -1934,28 +1934,28 @@ RETURN (
   SELECT
     ST_AsMVT(tile, 'operator_railway_symbols', 4096, 'way', 'id')
   FROM (
-         SELECT
-           ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
-           id,
-           osm_id,
-           osm_type,
-           feature,
-           ref,
-           nullif(array_to_string(position, U&'\001E'), '') as position,
-           wikidata,
-           wikimedia_commons,
-           wikimedia_commons_file,
-           image,
-           mapillary,
-           wikipedia,
-           note,
-           description
-         FROM pois
-         WHERE way && ST_TileEnvelope(z, x, y)
-           AND z >= minzoom
-           AND layer = 'operator'
-         ORDER BY rank DESC
-       ) as tile
+    SELECT
+      ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
+      id,
+      osm_id,
+      osm_type,
+      feature,
+      ref,
+      nullif(array_to_string(position, U&'\001E'), '') as position,
+      wikidata,
+      wikimedia_commons,
+      wikimedia_commons_file,
+      image,
+      mapillary,
+      wikipedia,
+      note,
+      description
+    FROM pois
+    WHERE way && ST_TileEnvelope(z, x, y)
+      AND z >= minzoom
+      AND layer = 'operator'
+    ORDER BY rank DESC
+  ) as tile
   WHERE way IS NOT NULL
 );
 
@@ -1966,7 +1966,7 @@ DO $do$ BEGIN
       {
         "id": "operator_railway_symbols",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "osm_id": "integer",
           "osm_type": "string",
           "feature": "string",
@@ -2036,7 +2036,7 @@ DO $do$ BEGIN
       {
         "id": "route_railway_line_low",
         "fields": {
-          "id": "integer",
+          "id": "string",
           "feature": "string",
           "state": "string",
           "usage": "string",

--- a/import/sql/tile_views.sql
+++ b/import/sql/tile_views.sql
@@ -653,7 +653,7 @@ RETURN (
     ST_AsMVT(tile, 'standard_railway_turntables', 4096, 'way', 'id')
   FROM (
     SELECT
-      id,
+      osm_id as id,
       ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
       osm_id,
       feature
@@ -692,7 +692,7 @@ RETURN (
   FROM (
     SELECT
       ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
-      id,
+      osm_id as id,
       osm_id,
       type,
       name,
@@ -1078,7 +1078,7 @@ RETURN (
     ST_AsMVT(tile, 'standard_railway_platform_edges', 4096, 'way', 'id')
   FROM (
     SELECT
-      id,
+      osm_id as id,
       osm_id,
       ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
       'platform_edge' as feature,
@@ -1122,7 +1122,7 @@ RETURN (
     ST_AsMVT(tile, 'standard_railway_stop_positions', 4096, 'way', 'id')
   FROM (
     SELECT
-      id,
+      osm_id as id,
       osm_id,
       ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
       name,
@@ -1233,7 +1233,7 @@ RETURN (
     ST_AsMVT(tile, 'standard_railway_switch_ref', 4096, 'way', 'id')
   FROM (
     SELECT
-      id,
+      osm_id as id,
       osm_id,
       ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
       railway,
@@ -1739,7 +1739,7 @@ RETURN (
     ST_AsMVT(tile, 'electrification_substation', 4096, 'way', 'id')
   FROM (
     SELECT
-      id,
+      osm_id as id,
       osm_id,
       ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
       feature,

--- a/import/sql/tile_views.sql
+++ b/import/sql/tile_views.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE FUNCTION railway_line_high(z integer, x integer, y integer)
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'railway_line_high', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'railway_line_high', 4096, 'way')
   FROM (
     -- TODO calculate labels in frontend
     SELECT
@@ -320,7 +320,7 @@ CREATE OR REPLACE FUNCTION standard_railway_line_low(z integer, x integer, y int
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'standard_railway_line_low', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'standard_railway_line_low', 4096, 'way')
   FROM (
     SELECT
       min(id) as id,
@@ -461,7 +461,7 @@ CREATE OR REPLACE FUNCTION standard_railway_text_stations_low(z integer, x integ
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'standard_railway_text_stations_low', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'standard_railway_text_stations_low', 4096, 'way')
   FROM (
     SELECT
       ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
@@ -556,7 +556,7 @@ CREATE OR REPLACE FUNCTION standard_railway_text_stations_med(z integer, x integ
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'standard_railway_text_stations_med', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'standard_railway_text_stations_med', 4096, 'way')
   FROM (
     SELECT
       ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
@@ -650,7 +650,7 @@ CREATE OR REPLACE FUNCTION standard_railway_turntables(z integer, x integer, y i
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'standard_railway_turntables', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'standard_railway_turntables', 4096, 'way')
   FROM (
     SELECT
       osm_id as id,
@@ -688,7 +688,7 @@ CREATE OR REPLACE FUNCTION standard_station_entrances(z integer, x integer, y in
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'standard_station_entrances', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'standard_station_entrances', 4096, 'way')
   FROM (
     SELECT
       ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
@@ -750,7 +750,7 @@ CREATE OR REPLACE FUNCTION standard_railway_text_stations(z integer, x integer, 
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'standard_railway_text_stations', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'standard_railway_text_stations', 4096, 'way')
   FROM (
     SELECT
       ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
@@ -841,7 +841,7 @@ CREATE OR REPLACE FUNCTION standard_railway_grouped_stations(z integer, x intege
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'standard_railway_grouped_stations', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'standard_railway_grouped_stations', 4096, 'way')
   FROM (
     SELECT
       gs.id,
@@ -941,7 +941,7 @@ CREATE OR REPLACE FUNCTION standard_railway_symbols(z integer, x integer, y inte
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'standard_railway_symbols', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'standard_railway_symbols', 4096, 'way')
   FROM (
     SELECT
       ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
@@ -1010,7 +1010,7 @@ CREATE OR REPLACE FUNCTION standard_railway_platforms(z integer, x integer, y in
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'standard_railway_platforms', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'standard_railway_platforms', 4096, 'way')
   FROM (
     SELECT
       id,
@@ -1075,7 +1075,7 @@ CREATE OR REPLACE FUNCTION standard_railway_platform_edges(z integer, x integer,
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'standard_railway_platform_edges', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'standard_railway_platform_edges', 4096, 'way')
   FROM (
     SELECT
       osm_id as id,
@@ -1119,7 +1119,7 @@ CREATE OR REPLACE FUNCTION standard_railway_stop_positions(z integer, x integer,
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'standard_railway_stop_positions', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'standard_railway_stop_positions', 4096, 'way')
   FROM (
     SELECT
       osm_id as id,
@@ -1164,7 +1164,7 @@ CREATE OR REPLACE FUNCTION railway_text_km(z integer, x integer, y integer)
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'railway_text_km', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'railway_text_km', 4096, 'way')
   FROM (
     SELECT
       id,
@@ -1230,7 +1230,7 @@ CREATE OR REPLACE FUNCTION standard_railway_switch_ref(z integer, x integer, y i
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'standard_railway_switch_ref', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'standard_railway_switch_ref', 4096, 'way')
   FROM (
     SELECT
       osm_id as id,
@@ -1298,7 +1298,7 @@ CREATE OR REPLACE FUNCTION standard_railway_grouped_station_areas(z integer, x i
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'standard_railway_grouped_station_areas', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'standard_railway_grouped_station_areas', 4096, 'way')
   FROM (
     SELECT
       osm_id as id,
@@ -1338,7 +1338,7 @@ CREATE OR REPLACE FUNCTION speed_railway_line_low(z integer, x integer, y intege
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'speed_railway_line_low', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'speed_railway_line_low', 4096, 'way')
   FROM (
     SELECT
       min(id) as id,
@@ -1399,7 +1399,7 @@ CREATE OR REPLACE FUNCTION signals_railway_line_low(z integer, x integer, y inte
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'signals_railway_line_low', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'signals_railway_line_low', 4096, 'way')
   FROM (
     SELECT
       min(id) as id,
@@ -1464,7 +1464,7 @@ CREATE OR REPLACE FUNCTION signals_signal_boxes(z integer, x integer, y integer)
   PARALLEL SAFE
   RETURN (
     SELECT
-      ST_AsMVT(tile, 'signals_signal_boxes', 4096, 'way', 'id')
+      ST_AsMVT(tile, 'signals_signal_boxes', 4096, 'way')
     FROM (
       SELECT
         ST_AsMVTGeom(
@@ -1544,7 +1544,7 @@ CREATE OR REPLACE FUNCTION electrification_railway_line_low(z integer, x integer
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'electrification_railway_line_low', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'electrification_railway_line_low', 4096, 'way')
   FROM (
     SELECT
       min(id) as id,
@@ -1613,7 +1613,7 @@ CREATE OR REPLACE FUNCTION electrification_railway_symbols(z integer, x integer,
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'electrification_railway_symbols', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'electrification_railway_symbols', 4096, 'way')
   FROM (
     SELECT
       ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
@@ -1676,7 +1676,7 @@ CREATE OR REPLACE FUNCTION electrification_catenary(z integer, x integer, y inte
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'electrification_catenary', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'electrification_catenary', 4096, 'way')
   FROM (
     SELECT
       id,
@@ -1736,7 +1736,7 @@ CREATE OR REPLACE FUNCTION electrification_substation(z integer, x integer, y in
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'electrification_substation', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'electrification_substation', 4096, 'way')
   FROM (
     SELECT
       osm_id as id,
@@ -1802,7 +1802,7 @@ CREATE OR REPLACE FUNCTION track_railway_line_low(z integer, x integer, y intege
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'track_railway_line_low', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'track_railway_line_low', 4096, 'way')
   FROM (
     SELECT
       min(id) as id,
@@ -1868,7 +1868,7 @@ CREATE OR REPLACE FUNCTION operator_railway_line_low(z integer, x integer, y int
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'operator_railway_line_low', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'operator_railway_line_low', 4096, 'way')
   FROM (
     SELECT
       min(id) as id,
@@ -1932,7 +1932,7 @@ CREATE OR REPLACE FUNCTION operator_railway_symbols(z integer, x integer, y inte
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'operator_railway_symbols', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'operator_railway_symbols', 4096, 'way')
   FROM (
     SELECT
       ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
@@ -1997,7 +1997,7 @@ CREATE OR REPLACE FUNCTION route_railway_line_low(z integer, x integer, y intege
   PARALLEL SAFE
 RETURN (
   SELECT
-    ST_AsMVT(tile, 'route_railway_line_low', 4096, 'way', 'id')
+    ST_AsMVT(tile, 'route_railway_line_low', 4096, 'way')
   FROM (
     SELECT
       min(id) as id,

--- a/import/sql/update_station_importance.sql
+++ b/import/sql/update_station_importance.sql
@@ -2,10 +2,10 @@ BEGIN;
 
 TRUNCATE stations_with_importance;
 
-INSERT INTO stations_with_importance (id, way, importance)
+INSERT INTO stations_with_importance (station_id, way, importance)
   SELECT
-    s.id as id,
-    ST_Centroid(s.way) as way,
+    s.id,
+    ST_Centroid(s.way),
     siv.importance
   FROM stations_with_importance_view siv
   JOIN stations s

--- a/import/test/test_import_box.lua
+++ b/import/test/test_import_box.lua
@@ -26,6 +26,8 @@ end
 -- Boxes
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'signal_box',
     ['railway:position'] = '1.2',
@@ -38,11 +40,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   boxes = {
-    { way_area = 0, feature = 'signal_box', ref = 'ref', name = 'name', operator = 'operator', position = '{"1.2 @ 1.2345 (km)"}' },
+    { id = 'node-123', way_area = 0, feature = 'signal_box', ref = 'ref', name = 'name', operator = 'operator', position = '{"1.2 @ 1.2345 (km)"}' },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'crossing_box',
     ['railway:position'] = '1.2',
@@ -55,11 +59,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   boxes = {
-    { way_area = 0, feature = 'crossing_box', ref = 'ref', name = 'name', operator = 'operator', position = '{"1.2 @ 1.2345 (km)"}' },
+    { id = 'node-123', way_area = 0, feature = 'crossing_box', ref = 'ref', name = 'name', operator = 'operator', position = '{"1.2 @ 1.2345 (km)"}' },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'blockpost',
     ['railway:position'] = '1.2',
@@ -72,11 +78,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   boxes = {
-    { way_area = 0, feature = 'blockpost', ref = 'ref', name = 'name', operator = 'operator', position = '{"1.2 @ 1.2345 (km)"}' },
+    { id = 'node-123', way_area = 0, feature = 'blockpost', ref = 'ref', name = 'name', operator = 'operator', position = '{"1.2 @ 1.2345 (km)"}' },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'signal_box',
     ['railway:position'] = '1.2',
@@ -89,6 +97,6 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   boxes = {
-    { way_area = 2.0, feature = 'signal_box', ref = 'ref', name = 'name', operator = 'operator', position = '{"1.2 @ 1.2345 (km)"}', way = polygon_way },
+    { id = 'way-123', way_area = 2.0, feature = 'signal_box', ref = 'ref', name = 'name', operator = 'operator', position = '{"1.2 @ 1.2345 (km)"}', way = polygon_way },
   },
 })

--- a/import/test/test_import_catenary.lua
+++ b/import/test/test_import_catenary.lua
@@ -14,6 +14,8 @@ local way = {
 -- Catenary mast
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['power'] = 'catenary_mast',
     ['ref'] = '22',
@@ -28,13 +30,15 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   catenary = {
-    { structure = 'structure', tensioning = 'tensioning', ref = '22', feature = 'mast', supporting = 'supporting', transition = true, insulator = 'insulator', attachment = 'attachment' },
+    { id = '123-mast', structure = 'structure', tensioning = 'tensioning', ref = '22', feature = 'mast', supporting = 'supporting', transition = true, insulator = 'insulator', attachment = 'attachment' },
   },
 })
 
 -- Catenary portal
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['power'] = 'catenary_portal',
     ['ref'] = '22',
@@ -49,6 +53,6 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   catenary = {
-    { structure = 'structure', tensioning = 'tensioning', ref = '22', feature = 'portal', transition = true, insulator = 'insulator', way = way },
+    { id = '123-portal', structure = 'structure', tensioning = 'tensioning', ref = '22', feature = 'portal', transition = true, insulator = 'insulator', way = way },
   },
 })

--- a/import/test/test_import_landuse.lua
+++ b/import/test/test_import_landuse.lua
@@ -14,6 +14,8 @@ local way = {
 -- Landuse
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     landuse = 'railway',
   },
@@ -21,11 +23,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   landuse = {
-    { way = way },
+    { id = 'way-123', way = way },
   },
 })
 
 osm2pgsql.process_relation({
+  id = 123,
+  type = 'relation',
   tags = {
     landuse = 'railway',
   },
@@ -33,6 +37,6 @@ osm2pgsql.process_relation({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   landuse = {
-    { way = way },
+    { id = 'relation-123', way = way },
   },
 })

--- a/import/test/test_import_milestone.lua
+++ b/import/test/test_import_milestone.lua
@@ -10,6 +10,8 @@ local openrailwaymap = require('openrailwaymap')
 -- Milestones
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'milestone',
     ['railway:position'] = '1.2',
@@ -19,6 +21,6 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   railway_positions = {
-    { railway = 'milestone', position_text = '1.2', position_exact = '1.2345', zero = false, type = 'km', position_numeric = 1.2345 },
+    { id = '123-1', railway = 'milestone', position_text = '1.2', position_exact = '1.2345', zero = false, type = 'km', position_numeric = 1.2345 },
   },
 })

--- a/import/test/test_import_platform.lua
+++ b/import/test/test_import_platform.lua
@@ -14,6 +14,8 @@ local way = {
 -- Platforms
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'platform',
     ['name'] = 'name',
@@ -33,11 +35,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   platforms = {
-    { name = 'name', bench = true, shelter = true, elevator = true, departures_board = true, surface = 'concrete', height = '0.3', bin = true, ref = '{"1","2"}', tactile_paving = true, wheelchair = true, lit = true },
+    { id = 'node-123', name = 'name', bench = true, shelter = true, elevator = true, departures_board = true, surface = 'concrete', height = '0.3', bin = true, ref = '{"1","2"}', tactile_paving = true, wheelchair = true, lit = true },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['public_transport'] = 'platform',
     ['train'] = 'yes',
@@ -46,11 +50,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   platforms = {
-    {},
+    { id = 'node-123' },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['public_transport'] = 'platform',
     ['tram'] = 'yes',
@@ -59,11 +65,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   platforms = {
-    {},
+    { id = 'node-123' },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['public_transport'] = 'platform',
     ['subway'] = 'yes',
@@ -72,11 +80,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   platforms = {
-    {},
+    { id = 'node-123' },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['public_transport'] = 'platform',
     ['light_rail'] = 'yes',
@@ -85,11 +95,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   platforms = {
-    {},
+    { id = 'node-123' },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['public_transport'] = 'platform',
   },
@@ -97,11 +109,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   platforms = {
-    {},
+    { id = 'node-123' },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['public_transport'] = 'platform',
     ['bus'] = 'yes',
@@ -111,6 +125,8 @@ osm2pgsql.process_node({
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {})
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['public_transport'] = 'platform',
     ['trolleybus'] = 'yes',
@@ -120,6 +136,8 @@ osm2pgsql.process_node({
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {})
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['public_transport'] = 'platform',
     ['share_taxi'] = 'yes',
@@ -129,6 +147,8 @@ osm2pgsql.process_node({
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {})
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['public_transport'] = 'platform',
     ['ferry'] = 'yes',
@@ -138,6 +158,8 @@ osm2pgsql.process_node({
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {})
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['public_transport'] = 'platform',
   },
@@ -148,11 +170,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   platforms = {
-    { way = way },
+    { id = 'way-123', way = way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['public_transport'] = 'platform',
   },
@@ -163,11 +187,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   platforms = {
-    { way = way },
+    { id = 'way-123', way = way },
   },
 })
 
 osm2pgsql.process_relation({
+  id = 123,
+  type = 'relation',
   tags = {
     ['public_transport'] = 'platform',
   },
@@ -177,7 +203,7 @@ osm2pgsql.process_relation({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   platforms = {
-    { way = way },
+    { id = 'relation-123', way = way },
   },
 })
 

--- a/import/test/test_import_poi.lua
+++ b/import/test/test_import_poi.lua
@@ -26,6 +26,8 @@ end
 -- Places of interest
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'border',
   },
@@ -33,11 +35,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/border', rank = 1, layer = 'operator', minzoom = 10 },
+    { id = 'node-123', feature = 'general/border', rank = 1, layer = 'operator', minzoom = 10 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'owner_change',
   },
@@ -45,11 +49,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/owner-change', rank = 2, layer = 'operator', minzoom = 12 },
+    { id = 'node-123', feature = 'general/owner-change', rank = 2, layer = 'operator', minzoom = 12 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'radio',
     ['man_made'] = 'antenna',
@@ -58,11 +64,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/radio-antenna', rank = 3, layer = 'standard', minzoom = 12 },
+    { id = 'node-123', feature = 'general/radio-antenna', rank = 3, layer = 'standard', minzoom = 12 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'radio',
     ['man_made'] = 'mast',
@@ -71,11 +79,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/radio-mast', rank = 4, layer = 'standard', minzoom = 12 },
+    { id = 'node-123', feature = 'general/radio-mast', rank = 4, layer = 'standard', minzoom = 12 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'radio',
     ['man_made'] = 'tower',
@@ -84,11 +94,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/radio-mast', rank = 4, layer = 'standard', minzoom = 12 },
+    { id = 'node-123', feature = 'general/radio-mast', rank = 4, layer = 'standard', minzoom = 12 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'container_terminal',
   },
@@ -96,11 +108,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/container-terminal', rank = 5, layer = 'standard', minzoom = 12 },
+    { id = 'node-123', feature = 'general/container-terminal', rank = 5, layer = 'standard', minzoom = 12 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'ferry_terminal',
   },
@@ -108,11 +122,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/ferry-terminal', rank = 6, layer = 'standard', minzoom = 12 },
+    { id = 'node-123', feature = 'general/ferry-terminal', rank = 6, layer = 'standard', minzoom = 12 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'lubricator',
   },
@@ -120,11 +136,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/lubricator', rank = 7, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/lubricator', rank = 7, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'fuel',
   },
@@ -132,11 +150,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/fuel', rank = 8, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/fuel', rank = 8, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'sand_store',
   },
@@ -144,11 +164,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/sand_store', rank = 9, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/sand_store', rank = 9, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'defect_detector',
   },
@@ -156,11 +178,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/defect_detector', rank = 10, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/defect_detector', rank = 10, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'aei',
   },
@@ -168,11 +192,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/aei', rank = 11, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/aei', rank = 11, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'hump_yard',
   },
@@ -180,11 +206,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/hump_yard', rank = 12, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/hump_yard', rank = 12, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'loading_gauge',
   },
@@ -192,11 +220,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/loading_gauge', rank = 13, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/loading_gauge', rank = 13, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'preheating',
   },
@@ -204,11 +234,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/preheating', rank = 14, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/preheating', rank = 14, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'compressed_air_supply',
   },
@@ -216,11 +248,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/compressed_air_supply', rank = 15, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/compressed_air_supply', rank = 15, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'waste_disposal',
   },
@@ -228,11 +262,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/waste_disposal', rank = 16, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/waste_disposal', rank = 16, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'coaling_facility',
   },
@@ -240,11 +276,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/coaling_facility', rank = 17, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/coaling_facility', rank = 17, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'wash',
   },
@@ -252,11 +290,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/wash', rank = 18, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/wash', rank = 18, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'water_crane',
   },
@@ -264,11 +304,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/water_crane', rank = 19, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/water_crane', rank = 19, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'water_tower',
   },
@@ -276,11 +318,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/water_tower', rank = 20, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/water_tower', rank = 20, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'workshop',
   },
@@ -288,11 +332,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/workshop', rank = 21, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/workshop', rank = 21, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'engine_shed',
   },
@@ -300,11 +346,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/engine_shed', rank = 22, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/engine_shed', rank = 22, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['tourism'] = 'museum',
     ['museum'] = 'railway',
@@ -313,11 +361,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/museum-rail-transport', rank = 23, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/museum-rail-transport', rank = 23, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'museum',
   },
@@ -325,11 +375,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/museum', rank = 24, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/museum', rank = 24, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'power_supply',
   },
@@ -337,11 +389,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/power_supply', rank = 25, layer = 'electrification', minzoom = 13 },
+    { id = 'node-123', feature = 'general/power_supply', rank = 25, layer = 'electrification', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'rolling_highway',
   },
@@ -349,11 +403,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/rolling_highway', rank = 26, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/rolling_highway', rank = 26, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'pit',
   },
@@ -361,11 +417,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/pit', rank = 27, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/pit', rank = 27, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'loading_rack',
   },
@@ -373,11 +431,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/loading-rack', rank = 28, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/loading-rack', rank = 28, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'loading_ramp',
   },
@@ -385,11 +445,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/loading-ramp', rank = 29, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/loading-ramp', rank = 29, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'loading_tower',
   },
@@ -397,11 +459,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/loading-tower', rank = 30, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/loading-tower', rank = 30, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'unloading_hole',
   },
@@ -409,11 +473,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/unloading-hole', rank = 31, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/unloading-hole', rank = 31, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'track_scale',
   },
@@ -421,11 +487,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/track-scale', rank = 32, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/track-scale', rank = 32, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'carrier_truck_pit',
   },
@@ -433,11 +501,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/carrier-truck-pit', rank = 33, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/carrier-truck-pit', rank = 33, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'gauge_conversion',
   },
@@ -445,11 +515,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/gauge-conversion', rank = 34, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/gauge-conversion', rank = 34, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'car_shuttle',
   },
@@ -457,11 +529,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/car-shuttle', rank = 35, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/car-shuttle', rank = 35, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'car_dumper',
   },
@@ -469,11 +543,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/car-dumper', rank = 36, layer = 'standard', minzoom = 13 },
+    { id = 'node-123', feature = 'general/car-dumper', rank = 36, layer = 'standard', minzoom = 13 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'isolated_track_section',
   },
@@ -481,11 +557,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/isolated-track-section', rank = 37, layer = 'electrification', minzoom = 14 },
+    { id = 'node-123', feature = 'general/isolated-track-section', rank = 37, layer = 'electrification', minzoom = 14 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'level_crossing',
     ['emergency:phone'] = '041/785302',
@@ -494,11 +572,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/level-crossing', rank = 41, layer = 'standard', minzoom = 15, emergency_phone = '041/785302' },
+    { id = 'node-123', feature = 'general/level-crossing', rank = 41, layer = 'standard', minzoom = 15, emergency_phone = '041/785302' },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'level_crossing',
     ['crossing:light'] = 'yes',
@@ -507,11 +587,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/level-crossing-light', rank = 40, layer = 'standard', minzoom = 15 },
+    { id = 'node-123', feature = 'general/level-crossing-light', rank = 40, layer = 'standard', minzoom = 15 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'level_crossing',
     ['crossing:barrier'] = 'yes',
@@ -520,11 +602,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/level-crossing-barrier', rank = 39, layer = 'standard', minzoom = 15 },
+    { id = 'node-123', feature = 'general/level-crossing-barrier', rank = 39, layer = 'standard', minzoom = 15 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'level_crossing',
     ['crossing:light'] = 'yes',
@@ -534,11 +618,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/level-crossing-light-barrier', rank = 38, layer = 'standard', minzoom = 15 },
+    { id = 'node-123', feature = 'general/level-crossing-light-barrier', rank = 38, layer = 'standard', minzoom = 15 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'crossing',
   },
@@ -546,11 +632,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/crossing', rank = 42, layer = 'standard', minzoom = 15 },
+    { id = 'node-123', feature = 'general/crossing', rank = 42, layer = 'standard', minzoom = 15 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'hirail_access',
   },
@@ -558,11 +646,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/hirail_access', rank = 43, layer = 'standard', minzoom = 16 },
+    { id = 'node-123', feature = 'general/hirail_access', rank = 43, layer = 'standard', minzoom = 16 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'phone',
   },
@@ -570,11 +660,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/phone', rank = 44, layer = 'standard', minzoom = 16 },
+    { id = 'node-123', feature = 'general/phone', rank = 44, layer = 'standard', minzoom = 16 },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'buffer_stop',
   },
@@ -582,7 +674,7 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/buffer_stop', rank = 45, layer = 'standard', minzoom = 16 },
+    { id = 'node-123', feature = 'general/buffer_stop', rank = 45, layer = 'standard', minzoom = 16 },
   },
   signals = {
     {
@@ -592,6 +684,8 @@ assert.eq(osm2pgsql.get_and_clear_imported_data(), {
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'derail',
   },
@@ -599,7 +693,7 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/derail', rank = 46, layer = 'standard', minzoom = 16 },
+    { id = 'node-123', feature = 'general/derail', rank = 46, layer = 'standard', minzoom = 16 },
   },
   signals = {
     {
@@ -609,6 +703,8 @@ assert.eq(osm2pgsql.get_and_clear_imported_data(), {
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'rail_brake',
   },
@@ -616,7 +712,7 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/retarder', rank = 47, layer = 'standard', minzoom = 16 },
+    { id = 'node-123', feature = 'general/retarder', rank = 47, layer = 'standard', minzoom = 16 },
   },
 })
 
@@ -624,6 +720,8 @@ assert.eq(osm2pgsql.get_and_clear_imported_data(), {
 -- Places of interest
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'border',
   },
@@ -631,11 +729,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/border', rank = 1, layer = 'operator', minzoom = 10, way = polygon_way },
+    { id = 'way-123', feature = 'general/border', rank = 1, layer = 'operator', minzoom = 10, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'owner_change',
   },
@@ -643,11 +743,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/owner-change', rank = 2, layer = 'operator', minzoom = 12, way = polygon_way },
+    { id = 'way-123', feature = 'general/owner-change', rank = 2, layer = 'operator', minzoom = 12, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'radio',
     ['man_made'] = 'antenna',
@@ -657,11 +759,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/radio-antenna', rank = 3, layer = 'standard', minzoom = 12, way = polygon_way, radio = 'lte-r' },
+    { id = 'way-123', feature = 'general/radio-antenna', rank = 3, layer = 'standard', minzoom = 12, way = polygon_way, radio = 'lte-r' },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'radio',
     ['man_made'] = 'mast',
@@ -670,11 +774,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/radio-mast', rank = 4, layer = 'standard', minzoom = 12, way = polygon_way },
+    { id = 'way-123', feature = 'general/radio-mast', rank = 4, layer = 'standard', minzoom = 12, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'radio',
     ['man_made'] = 'tower',
@@ -683,11 +789,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/radio-mast', rank = 4, layer = 'standard', minzoom = 12, way = polygon_way },
+    { id = 'way-123', feature = 'general/radio-mast', rank = 4, layer = 'standard', minzoom = 12, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'container_terminal',
   },
@@ -695,11 +803,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/container-terminal', rank = 5, layer = 'standard', minzoom = 12, way = polygon_way },
+    { id = 'way-123', feature = 'general/container-terminal', rank = 5, layer = 'standard', minzoom = 12, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'ferry_terminal',
   },
@@ -707,11 +817,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/ferry-terminal', rank = 6, layer = 'standard', minzoom = 12, way = polygon_way },
+    { id = 'way-123', feature = 'general/ferry-terminal', rank = 6, layer = 'standard', minzoom = 12, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'lubricator',
   },
@@ -719,11 +831,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/lubricator', rank = 7, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/lubricator', rank = 7, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'fuel',
   },
@@ -731,11 +845,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/fuel', rank = 8, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/fuel', rank = 8, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'sand_store',
   },
@@ -743,11 +859,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/sand_store', rank = 9, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/sand_store', rank = 9, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'defect_detector',
   },
@@ -755,11 +873,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/defect_detector', rank = 10, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/defect_detector', rank = 10, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'aei',
   },
@@ -767,11 +887,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/aei', rank = 11, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/aei', rank = 11, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'hump_yard',
   },
@@ -779,11 +901,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/hump_yard', rank = 12, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/hump_yard', rank = 12, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'loading_gauge',
   },
@@ -791,11 +915,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/loading_gauge', rank = 13, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/loading_gauge', rank = 13, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'preheating',
   },
@@ -803,11 +929,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/preheating', rank = 14, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/preheating', rank = 14, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'compressed_air_supply',
   },
@@ -815,11 +943,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/compressed_air_supply', rank = 15, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/compressed_air_supply', rank = 15, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'waste_disposal',
   },
@@ -827,11 +957,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/waste_disposal', rank = 16, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/waste_disposal', rank = 16, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'coaling_facility',
   },
@@ -839,11 +971,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/coaling_facility', rank = 17, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/coaling_facility', rank = 17, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'wash',
   },
@@ -851,11 +985,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/wash', rank = 18, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/wash', rank = 18, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'water_crane',
   },
@@ -863,11 +999,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/water_crane', rank = 19, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/water_crane', rank = 19, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'water_tower',
   },
@@ -875,11 +1013,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/water_tower', rank = 20, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/water_tower', rank = 20, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'workshop',
   },
@@ -887,11 +1027,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/workshop', rank = 21, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/workshop', rank = 21, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'engine_shed',
   },
@@ -899,11 +1041,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/engine_shed', rank = 22, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/engine_shed', rank = 22, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['tourism'] = 'museum',
     ['museum'] = 'railway',
@@ -912,11 +1056,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/museum-rail-transport', rank = 23, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/museum-rail-transport', rank = 23, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'museum',
   },
@@ -924,11 +1070,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/museum', rank = 24, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/museum', rank = 24, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'power_supply',
   },
@@ -936,11 +1084,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/power_supply', rank = 25, layer = 'electrification', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/power_supply', rank = 25, layer = 'electrification', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'rolling_highway',
   },
@@ -948,11 +1098,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/rolling_highway', rank = 26, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/rolling_highway', rank = 26, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'pit',
   },
@@ -960,11 +1112,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/pit', rank = 27, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/pit', rank = 27, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'loading_rack',
   },
@@ -972,11 +1126,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/loading-rack', rank = 28, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/loading-rack', rank = 28, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'loading_ramp',
   },
@@ -984,11 +1140,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/loading-ramp', rank = 29, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/loading-ramp', rank = 29, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'loading_tower',
   },
@@ -996,11 +1154,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/loading-tower', rank = 30, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/loading-tower', rank = 30, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'unloading_hole',
   },
@@ -1008,11 +1168,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/unloading-hole', rank = 31, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/unloading-hole', rank = 31, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'track_scale',
   },
@@ -1020,11 +1182,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/track-scale', rank = 32, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/track-scale', rank = 32, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'carrier_truck_pit',
   },
@@ -1032,11 +1196,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/carrier-truck-pit', rank = 33, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/carrier-truck-pit', rank = 33, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'gauge_conversion',
   },
@@ -1044,11 +1210,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/gauge-conversion', rank = 34, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/gauge-conversion', rank = 34, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'car_shuttle',
   },
@@ -1056,11 +1224,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/car-shuttle', rank = 35, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/car-shuttle', rank = 35, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'car_dumper',
   },
@@ -1068,11 +1238,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/car-dumper', rank = 36, layer = 'standard', minzoom = 13, way = polygon_way },
+    { id = 'way-123', feature = 'general/car-dumper', rank = 36, layer = 'standard', minzoom = 13, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'isolated_track_section',
   },
@@ -1080,11 +1252,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/isolated-track-section', rank = 37, layer = 'electrification', minzoom = 14, way = polygon_way },
+    { id = 'way-123', feature = 'general/isolated-track-section', rank = 37, layer = 'electrification', minzoom = 14, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'level_crossing',
   },
@@ -1092,11 +1266,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/level-crossing', rank = 41, layer = 'standard', minzoom = 15, way = polygon_way },
+    { id = 'way-123', feature = 'general/level-crossing', rank = 41, layer = 'standard', minzoom = 15, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'level_crossing',
     ['crossing:light'] = 'yes',
@@ -1105,11 +1281,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/level-crossing-light', rank = 40, layer = 'standard', minzoom = 15, way = polygon_way },
+    { id = 'way-123', feature = 'general/level-crossing-light', rank = 40, layer = 'standard', minzoom = 15, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'level_crossing',
     ['crossing:barrier'] = 'yes',
@@ -1118,11 +1296,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/level-crossing-barrier', rank = 39, layer = 'standard', minzoom = 15, way = polygon_way },
+    { id = 'way-123', feature = 'general/level-crossing-barrier', rank = 39, layer = 'standard', minzoom = 15, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'level_crossing',
     ['crossing:light'] = 'yes',
@@ -1132,11 +1312,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/level-crossing-light-barrier', rank = 38, layer = 'standard', minzoom = 15, way = polygon_way },
+    { id = 'way-123', feature = 'general/level-crossing-light-barrier', rank = 38, layer = 'standard', minzoom = 15, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'crossing',
   },
@@ -1144,11 +1326,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/crossing', rank = 42, layer = 'standard', minzoom = 15, way = polygon_way },
+    { id = 'way-123', feature = 'general/crossing', rank = 42, layer = 'standard', minzoom = 15, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'hirail_access',
   },
@@ -1156,11 +1340,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/hirail_access', rank = 43, layer = 'standard', minzoom = 16, way = polygon_way },
+    { id = 'way-123', feature = 'general/hirail_access', rank = 43, layer = 'standard', minzoom = 16, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'phone',
   },
@@ -1168,11 +1354,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/phone', rank = 44, layer = 'standard', minzoom = 16, way = polygon_way },
+    { id = 'way-123', feature = 'general/phone', rank = 44, layer = 'standard', minzoom = 16, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'buffer_stop',
   },
@@ -1180,11 +1368,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/buffer_stop', rank = 45, layer = 'standard', minzoom = 16, way = polygon_way },
+    { id = 'way-123', feature = 'general/buffer_stop', rank = 45, layer = 'standard', minzoom = 16, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'derail',
   },
@@ -1192,11 +1382,13 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/derail', rank = 46, layer = 'standard', minzoom = 16, way = polygon_way },
+    { id = 'way-123', feature = 'general/derail', rank = 46, layer = 'standard', minzoom = 16, way = polygon_way },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'rail_brake',
   },
@@ -1204,6 +1396,6 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   pois = {
-    { feature = 'general/retarder', rank = 47, layer = 'standard', minzoom = 16, way = polygon_way },
+    { id = 'way-123', feature = 'general/retarder', rank = 47, layer = 'standard', minzoom = 16, way = polygon_way },
   },
 })

--- a/import/test/test_import_railway_line.lua
+++ b/import/test/test_import_railway_line.lua
@@ -37,6 +37,8 @@ end
 -- Railway lines
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'rail',
     ['railway:radio'] = 'lte-r',
@@ -45,6 +47,6 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   railway_line = {
-    { tunnel = false, bridge = false, highspeed = false, rank = 40, train_protection_rank = 0, way_length = 1, way = way, feature = 'rail', state = 'present', train_protection_construction_rank = 0, radio = 'lte-r' },
+    { id = '123-0', tunnel = false, bridge = false, highspeed = false, rank = 40, train_protection_rank = 0, way_length = 1, way = way, feature = 'rail', state = 'present', train_protection_construction_rank = 0, radio = 'lte-r' },
   },
 })

--- a/import/test/test_import_station.lua
+++ b/import/test/test_import_station.lua
@@ -14,6 +14,8 @@ local way = {
 -- Stations
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'station',
     name = 'name',
@@ -24,11 +26,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   stations = {
-    { feature = 'station', state = 'present', map_reference = 'ref', references = { ['railway-ref'] = 'ref' }, operator = '{"operator"}', station = 'train', name_tags = { name = 'name' }, name = 'name' },
+    { id = 'node-123-train', feature = 'station', state = 'present', map_reference = 'ref', references = { ['railway-ref'] = 'ref' }, operator = '{"operator"}', station = 'train', name_tags = { name = 'name' }, name = 'name' },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'halt',
   },
@@ -36,11 +40,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   stations = {
-    { feature = 'halt', state = 'present', station = 'train', name_tags = {}, references = {} },
+    { id = 'node-123-train', feature = 'halt', state = 'present', station = 'train', name_tags = {}, references = {} },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'tram_stop',
   },
@@ -48,11 +54,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   stations = {
-    { feature = 'tram_stop', state = 'present', station = 'tram', name_tags = {}, references = {} },
+    { id = 'node-123-tram', feature = 'tram_stop', state = 'present', station = 'tram', name_tags = {}, references = {} },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'service_station',
   },
@@ -60,11 +68,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   stations = {
-    { feature = 'service_station', state = 'present', station = 'train', name_tags = {}, references = {} },
+    { id = 'node-123-train', feature = 'service_station', state = 'present', station = 'train', name_tags = {}, references = {} },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['preserved:railway'] = 'yard',
   },
@@ -72,11 +82,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   stations = {
-    { feature = 'yard', state = 'preserved', station = 'train', name_tags = {}, references = {} },
+    { id = 'node-123-train', feature = 'yard', state = 'preserved', station = 'train', name_tags = {}, references = {} },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'yard',
     ['railway:yard:purpose'] = 'transloading;manifest',
@@ -86,11 +98,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   stations = {
-    { feature = 'yard', state = 'present', station = 'train', name_tags = {}, yard_hump = true, yard_purpose = '{"transloading","manifest"}', references = {} },
+    { id = 'node-123-train', feature = 'yard', state = 'present', station = 'train', name_tags = {}, yard_hump = true, yard_purpose = '{"transloading","manifest"}', references = {} },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['abandoned:railway'] = 'junction',
   },
@@ -98,11 +112,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   stations = {
-    { feature = 'junction', state = 'abandoned', station = 'train', name_tags = {}, references = {} },
+    { id = 'node-123-train', feature = 'junction', state = 'abandoned', station = 'train', name_tags = {}, references = {} },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['disused:railway'] = 'spur_junction',
   },
@@ -110,11 +126,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   stations = {
-    { feature = 'spur_junction', state = 'disused', station = 'train', name_tags = {}, references = {} },
+    { id = 'node-123-train', feature = 'spur_junction', state = 'disused', station = 'train', name_tags = {}, references = {} },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['proposed:railway'] = 'crossover',
     ['proposed:name'] = 'name',
@@ -123,11 +141,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   stations = {
-    { feature = 'crossover', state = 'proposed', station = 'train', name = 'name', name_tags = { ['proposed:name'] = 'name' }, references = {} },
+    { id = 'node-123-train', feature = 'crossover', state = 'proposed', station = 'train', name = 'name', name_tags = { ['proposed:name'] = 'name' }, references = {} },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['construction:railway'] = 'site',
     ['construction:name'] = 'name',
@@ -136,11 +156,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   stations = {
-    { feature = 'site', state = 'construction', station = 'train', name = 'name', name_tags = { ['construction:name'] = 'name' }, references = {} },
+    { id = 'node-123-train', feature = 'site', state = 'construction', station = 'train', name = 'name', name_tags = { ['construction:name'] = 'name' }, references = {} },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['razed:railway'] = 'station',
   },
@@ -148,11 +170,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   stations = {
-    { feature = 'station', state = 'razed', station = 'train', name_tags = {}, references = {} },
+    { id = 'node-123-train', feature = 'station', state = 'razed', station = 'train', name_tags = {}, references = {} },
   },
 })
 
 osm2pgsql.process_node({
+  id = 123,
+  type = 'node',
   tags = {
     ['railway'] = 'station',
     ['ref'] = 'ref',
@@ -169,11 +193,13 @@ osm2pgsql.process_node({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   stations = {
-    { feature = 'station', state = 'present', station = 'train', name_tags = {}, map_reference = 'railway_ref', references = {['ref'] = 'ref', ['railway-ref'] = 'railway_ref', ['uic'] = 'uic_ref', ['gb-crs'] = 'ref:crs', ['ibnr'] = 'ref:ibnr', ['iata'] = 'iata', ['ifopt'] = 'ref:IFOPT', ['eu-plc'] = 'ref:EU:PLC', ['fr-sncf-resarail'] = 'ref:FR:sncf:resarail' } },
+    { id = 'node-123-train', feature = 'station', state = 'present', station = 'train', name_tags = {}, map_reference = 'railway_ref', references = {['ref'] = 'ref', ['railway-ref'] = 'railway_ref', ['uic'] = 'uic_ref', ['gb-crs'] = 'ref:crs', ['ibnr'] = 'ref:ibnr', ['iata'] = 'iata', ['ifopt'] = 'ref:IFOPT', ['eu-plc'] = 'ref:EU:PLC', ['fr-sncf-resarail'] = 'ref:FR:sncf:resarail' } },
   },
 })
 
 osm2pgsql.process_way({
+  id = 123,
+  type = 'way',
   tags = {
     ['railway'] = 'station',
     name = 'name',
@@ -185,6 +211,6 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   stations = {
-    { feature = 'station', state = 'present', map_reference = 'ref', references = { ['railway-ref'] = 'ref' }, operator = '{"operator"}', station = 'train', name_tags = { name = 'name' }, name = 'name', way = way },
+    { id = 'way-123-train', feature = 'station', state = 'present', map_reference = 'ref', references = { ['railway-ref'] = 'ref' }, operator = '{"operator"}', station = 'train', name_tags = { name = 'name' }, name = 'name', way = way },
   },
 })

--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -528,38 +528,47 @@ const sources = {
   standard_railway_line_low: {
     type: 'vector',
     url: '/standard_railway_line_low',
+    promoteId: 'id',
   },
   speed_railway_line_low: {
     type: 'vector',
     url: '/speed_railway_line_low',
+    promoteId: 'id',
   },
   signals_railway_line_low: {
     type: 'vector',
     url: '/signals_railway_line_low',
+    promoteId: 'id',
   },
   electrification_railway_line_low: {
     type: 'vector',
     url: '/electrification_railway_line_low',
+    promoteId: 'id',
   },
   track_railway_line_low: {
     type: 'vector',
     url: '/track_railway_line_low',
+    promoteId: 'id',
   },
   operator_railway_line_low: {
     type: 'vector',
     url: '/operator_railway_line_low',
+    promoteId: 'id',
   },
   route_railway_line_low: {
     type: 'vector',
     url: '/route_railway_line_low',
+    promoteId: 'id',
   },
   openrailwaymap_low: {
     type: 'vector',
     url: '/railway_line_high',
+    promoteId: 'id',
   },
   standard_railway_text_stations_low: {
     type: 'vector',
     url: '/standard_railway_text_stations_low',
+    promoteId: 'id',
     metadata: {
       supports: ['language'],
     },
@@ -567,6 +576,7 @@ const sources = {
   standard_railway_text_stations_med: {
     type: 'vector',
     url: '/standard_railway_text_stations_med',
+    promoteId: 'id',
     metadata: {
       supports: ['language'],
     },
@@ -574,10 +584,12 @@ const sources = {
   high: {
     type: 'vector',
     url: '/railway_line_high,railway_text_km',
+    promoteId: 'id',
   },
   openrailwaymap_standard: {
     type: 'vector',
     url: '/standard_railway_turntables,standard_railway_text_stations,standard_railway_grouped_stations,standard_railway_grouped_station_areas,standard_railway_symbols,standard_railway_switch_ref,standard_station_entrances,standard_railway_platforms,standard_railway_platform_edges,standard_railway_stop_positions',
+    promoteId: 'id',
     metadata: {
       supports: ['language'],
     },
@@ -585,18 +597,22 @@ const sources = {
   openrailwaymap_speed: {
     type: 'vector',
     url: '/speed_railway_signals',
+    promoteId: 'id',
   },
   openrailwaymap_signals: {
     type: 'vector',
     url: '/signals_railway_signals,signals_signal_boxes',
+    promoteId: 'id',
   },
   openrailwaymap_electrification: {
     type: 'vector',
     url: '/electrification_signals,electrification_catenary,electrification_railway_symbols,electrification_substation',
+    promoteId: 'id',
   },
   openrailwaymap_operator: {
     type: 'vector',
     url: '/operator_railway_symbols',
+    promoteId: 'id',
   },
   openhistoricalmap: {
     type: 'vector',


### PR DESCRIPTION
For #796

Ensure every table has a primary key defined that is natural, based on OSM type, OSM ID and feature properties.

When this primary key will be used for lookup of features using the API, the same OSM feature will always keep the same primary key for lookup, allowing caching the API responses even when the database is re-imported.

Some tables import a single row per table per OSM object, and only of a single type. In those cases the OSM id is the primary key, and the OSM type is implicit.

Some tables import more than a single row per table per OSM object, or of multiple OSM types. In those cases the the OSM ID and type are imported in `osm_id` and `osm_type` columns, and the column `id` is the primary key.

See https://osm2pgsql.org/doc/manual.html#unique-ids

For example, a grouped set of stations will have a persistent ID of `node-29030440-light_rail-light_rail-halt`, which can then be used in the API to query the grouped station:
<img width="1329" height="246" alt="image" src="https://github.com/user-attachments/assets/5368caf2-9682-4a87-905e-d088b37ee911" />
