### PR TITLE
Clean up unused search indices for reference searching

### DIFF
--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -282,8 +282,6 @@ local stations = osm2pgsql.define_table({
     { column = 'id', method = 'btree', unique = true },
     -- For building linking table between stations and stop areas
     { column = 'osm_type', method = 'btree' },
-    -- Search by reference
-    { expression = 'avals("references")', method = 'gin', where = '"references" IS NOT NULL' },
   },
 })
 
@@ -569,8 +567,6 @@ local stop_areas = osm2pgsql.define_table({
   indexes = {
     { column = 'osm_id', method = 'btree' },
     { column = 'platform_ref_ids', method = 'gin' },
-    -- Search by reference
-    { expression = 'avals("references")', method = 'gin', where = '"references" IS NOT NULL' },
   },
 })
 


### PR DESCRIPTION
Followup on #908.
Related to https://github.com/hiddewie/OpenRailwayMap-vector/issues/888.

The materialized view openrailwaymap_facilities_for_ref_search already contains the merged index for reference searching.
<img width="663" height="469" alt="image" src="https://github.com/user-attachments/assets/ab2d0721-037e-45d5-b547-ca35fc8bbad0" />
