### PR TITLE
Correct font name for railway positions

### DIFF
--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -1572,7 +1572,7 @@ const railwayKmText = {
       13,
       ['get', 'pos'],
     ],
-    'text-font': ['Fira Code Bold'],
+    'text-font': ['FiraCode-Bold'],
     'text-size': 11,
   },
 };


### PR DESCRIPTION
Followup from #920.

<img width="1329" height="246" alt="image" src="https://github.com/user-attachments/assets/19ca9702-90a5-4f22-87de-76453cf4c843" />
