### PR TITLE
Fix OpenHistoricalMap features not showing popup

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -2403,13 +2403,13 @@ function popupContent(feature, abortController) {
   const colorProperty = featureCatalog.colorProperty || 'color';
 
   const propertiesFromView = featureCatalog.view;
-  if (!propertiesFromView) {
-    console.warn(`Feature catalog "${layerSource}" does not contain view information to fetch feature properties`, feature);
-    return;
-  }
+  const properties$ = propertiesFromView
+    ? fetchFeatureProperties(propertiesFromView)
+    : Promise.resolve(feature.properties);
+
   const popupContainer = createDomElement('div', 'loading');
 
-  fetchFeatureProperties(propertiesFromView)
+  properties$
     .then(properties => {
       const {catalogKey, keyVariable} = constructCatalogKey(properties[featureProperty]);
 


### PR DESCRIPTION
Related to #945

The OpenHistoricalMap features catalog do not have a view defined, but should still show the popup from the available properties data.

<img width="951" height="443" alt="image" src="https://github.com/user-attachments/assets/3d17cc7e-7853-42e7-900f-e1a74ffefab3" />
