### PR TITLE
Fix pitched style condition

### DIFF
--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -23,7 +23,7 @@ const pitchedVisibleAngle = 75;
 
 const filterPitchedFeatures = (azimuthProperty) =>
   ['any',
-    ['==', ['global-state', 'pitched'], true],
+    ['==', ['global-state', 'pitched'], false],
     ['all',
       ['!=', ['get', azimuthProperty], null],
       ['let', 'diff',
@@ -3633,7 +3633,7 @@ const layers = {
       },
       layout: {
         'visibility': ['case',
-          ['==', ['global-state', 'pitched'], true], 'none',
+          ['==', ['global-state', 'pitched'], false], 'none',
           'visible',
         ],
       },
@@ -3680,7 +3680,7 @@ const layers = {
       },
       layout: {
         'visibility': ['case',
-          ['==', ['global-state', 'pitched'], true], 'visible',
+          ['==', ['global-state', 'pitched'], false], 'visible',
           'none',
         ],
         'icon-overlap': 'always',
@@ -3742,7 +3742,7 @@ const layers = {
                   featureIndex === 0 ? 0 : ['get', `offset${featureIndex}`], // Offset from previous icons
                   2 * featureIndex, // Gap of 2 pixels for halo and spacing
                   ['case',
-                    ['==', ['global-state', 'pitched'], true], 0,
+                    ['==', ['global-state', 'pitched'], false], 0,
                     ['+',
                       ['get', 'offset0'], // Icon is shown above anchor in pitched view
                       4, // Signal anchor
@@ -3758,7 +3758,7 @@ const layers = {
                   featureIndex === 0 ? 0 : ['get', `offset${featureIndex}`], // Offset from previous icons
                   2 * featureIndex, // Gap of 2 pixels for halo and spacing
                   ['case',
-                    ['==', ['global-state', 'pitched'], true], 0,
+                    ['==', ['global-state', 'pitched'], false], 0,
                     ['+',
                       ['get', 'offset0'], // Icon is shown above anchor in pitched view
                       4, // Signal anchor
@@ -3794,7 +3794,7 @@ const layers = {
                 featureIndex === 0 ? 0 : ['get', `offset${featureIndex}`], // Offset from previous icons
                 2 * featureIndex, // Gap of 2 pixels for halo and spacing
                 ['case',
-                  ['==', ['global-state', 'pitched'], true], 0,
+                  ['==', ['global-state', 'pitched'], false], 0,
                   ['+',
                     ['get', 'offset0'], // Icon is shown above anchor in pitched view
                     4, // Signal anchor
@@ -3810,7 +3810,7 @@ const layers = {
                 featureIndex === 0 ? 0 : ['get', `offset${featureIndex}`], // Offset from previous icons
                 2 * featureIndex, // Gap of 2 pixels for halo and spacing
                 ['case',
-                  ['==', ['global-state', 'pitched'], true], 0,
+                  ['==', ['global-state', 'pitched'], false], 0,
                   ['+',
                     ['get', 'offset0'], // Icon is shown above anchor in pitched view
                     4, // Signal anchor
@@ -3857,12 +3857,12 @@ const layers = {
         'text-font': font.regular,
         'text-size': 9,
         'text-anchor': ['case',
-          ['==', ['global-state', 'pitched'], true], 'top',
+          ['==', ['global-state', 'pitched'], false], 'top',
           'bottom',
         ],
         'text-offset': ['interpolate', ['linear'],
           ['case',
-            ['==', ['global-state', 'pitched'], true], ['+', ['get', 'offset0'], 2], // 2 pixel spacing under icon
+            ['==', ['global-state', 'pitched'], false], ['+', ['get', 'offset0'], 2], // 2 pixel spacing under icon
             -1,
           ],
           -20 * 9, ['literal', [0, -20]],
@@ -4065,7 +4065,7 @@ const layers = {
       },
       layout: {
         'visibility': ['case',
-          ['==', ['global-state', 'pitched'], true], 'none',
+          ['==', ['global-state', 'pitched'], false], 'none',
           'visible',
         ],
       },
@@ -4103,7 +4103,7 @@ const layers = {
       },
       layout: {
         'visibility': ['case',
-          ['==', ['global-state', 'pitched'], true], 'visible',
+          ['==', ['global-state', 'pitched'], false], 'visible',
           'none',
         ],
         'icon-overlap': 'always',
@@ -4150,7 +4150,7 @@ const layers = {
                 featureIndex === 0 ? 0 : ['get', `offset${featureIndex}`], // Offset from previous icons
                 2 * featureIndex, // Gap of 2 pixels for halo and spacing
                 ['case',
-                  ['==', ['global-state', 'pitched'], true], 0,
+                  ['==', ['global-state', 'pitched'], false], 0,
                   ['+',
                     ['get', 'offset0'], // Icon is shown above anchor in pitched view
                     4, // Signal anchor
@@ -4183,7 +4183,7 @@ const layers = {
               featureIndex === 0 ? 0 : ['get', `offset${featureIndex}`], // Offset from previous icons
               2 * featureIndex, // Gap of 2 pixels for halo and spacing
               ['case',
-                ['==', ['global-state', 'pitched'], true], 0,
+                ['==', ['global-state', 'pitched'], false], 0,
                 ['+',
                   ['get', 'offset0'], // Icon is shown above anchor in pitched view
                   4, // Signal anchor
@@ -4246,7 +4246,7 @@ const layers = {
                 featureIndex === 0 ? 0 : ['get', `offset${featureIndex}`], // Offset from previous icons
                 2 * featureIndex, // Gap of 2 pixels for halo and spacing
                 ['case',
-                  ['==', ['global-state', 'pitched'], true],
+                  ['==', ['global-state', 'pitched'], false],
                   ['case', ['in', ['get', 'railway'], ['literal', ['derail', 'buffer_stop']]], 16, 0], // Derail and buffer stop icons
                   ['+',
                     ['get', 'offset0'], // Icon is shown above anchor in pitched view
@@ -4281,7 +4281,7 @@ const layers = {
               featureIndex === 0 ? 0 : ['get', `offset${featureIndex}`], // Offset from previous icons
               2 * featureIndex, // Gap of 2 pixels for halo and spacing
               ['case',
-                ['==', ['global-state', 'pitched'], true],
+                ['==', ['global-state', 'pitched'], false],
                 ['case', ['in', ['get', 'railway'], ['literal', ['derail', 'buffer_stop']]], 16, 0], // Derail and buffer stop icons
                 ['+',
                   ['get', 'offset0'], // Icon is shown above anchor in pitched view
@@ -4330,12 +4330,12 @@ const layers = {
         'text-font': font.regular,
         'text-size': 9,
         'text-anchor': ['case',
-          ['==', ['global-state', 'pitched'], true], 'top',
+          ['==', ['global-state', 'pitched'], false], 'top',
           'bottom',
         ],
         'text-offset': ['interpolate', ['linear'],
           ['case',
-            ['==', ['global-state', 'pitched'], true], ['+', ['get', 'offset0'], 2], // 2 pixel spacing under icon
+            ['==', ['global-state', 'pitched'], false], ['+', ['get', 'offset0'], 2], // 2 pixel spacing under icon
             -1,
           ],
           -20 * 9, ['literal', [0, -20]],
@@ -4660,7 +4660,7 @@ const layers = {
       },
       layout: {
         'visibility': ['case',
-          ['==', ['global-state', 'pitched'], true], 'none',
+          ['==', ['global-state', 'pitched'], false], 'none',
           'visible',
         ],
       },
@@ -4690,7 +4690,7 @@ const layers = {
       },
       layout: {
         'visibility': ['case',
-          ['==', ['global-state', 'pitched'], true], 'visible',
+          ['==', ['global-state', 'pitched'], false], 'visible',
           'none',
         ],
         'icon-overlap': 'always',
@@ -4738,7 +4738,7 @@ const layers = {
             ['interpolate', ['linear'],
               ['+',
                 ['case',
-                  ['==', ['global-state', 'pitched'], true], 0,
+                  ['==', ['global-state', 'pitched'], false], 0,
                   ['+',
                     ['get', 'offset0'], // Icon is shown above anchor in pitched view
                     4, // Signal anchor
@@ -4752,7 +4752,7 @@ const layers = {
             ['interpolate', ['linear'],
               ['+',
                 ['case',
-                  ['==', ['global-state', 'pitched'], true], 0,
+                  ['==', ['global-state', 'pitched'], false], 0,
                   ['+',
                     ['get', 'offset0'], // Icon is shown above anchor in pitched view
                     4, // Signal anchor
@@ -4786,7 +4786,7 @@ const layers = {
           ['interpolate', ['linear'],
             ['+',
               ['case',
-                ['==', ['global-state', 'pitched'], true], 0,
+                ['==', ['global-state', 'pitched'], false], 0,
                 ['+',
                   ['get', 'offset0'], // Icon is shown above anchor in pitched view
                   4, // Signal anchor
@@ -4800,7 +4800,7 @@ const layers = {
           ['interpolate', ['linear'],
             ['+',
               ['case',
-                ['==', ['global-state', 'pitched'], true], 0,
+                ['==', ['global-state', 'pitched'], false], 0,
                 ['+',
                   ['get', 'offset0'], // Icon is shown above anchor in pitched view
                   4, // Signal anchor
@@ -4846,12 +4846,12 @@ const layers = {
         'text-font': font.regular,
         'text-size': 9,
         'text-anchor': ['case',
-          ['==', ['global-state', 'pitched'], true], 'top',
+          ['==', ['global-state', 'pitched'], false], 'top',
           'bottom',
         ],
         'text-offset': ['interpolate', ['linear'],
           ['case',
-            ['==', ['global-state', 'pitched'], true], ['+', ['get', 'offset0'], 2], // 2 pixel spacing under icon
+            ['==', ['global-state', 'pitched'], false], ['+', ['get', 'offset0'], 2], // 2 pixel spacing under icon
             -1,
           ],
           -20 * 9, ['literal', [0, -20]],

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -115,7 +115,7 @@ function naturalSort(a, b) {
 const pitchRotationLimit = 30;
 
 const pitchedView = (pitch) =>
-  pitch ?? 0 > pitchRotationLimit;
+  (pitch ?? 0) > pitchRotationLimit;
 
 function facilitySearchUrl(type, term, language) {
   const url = new URL(`${location.origin}/api/facility`)
@@ -2306,7 +2306,7 @@ const onMapPitch = pitch => {
   const pitched = pitchedView(pitch)
   const pitchedState = (map.getGlobalState() ?? {}).pitched
   if (pitched !== pitchedState && map.isStyleLoaded()) {
-    map.setGlobalStateProperty('pitch', pitched);
+    map.setGlobalStateProperty('pitched', pitched);
   }
 }
 


### PR DESCRIPTION
This fixes a bug in https://github.com/hiddewie/OpenRailwayMap-vector/pull/946#issuecomment-4429490040

The pitched style was always rendered not checking if the pitch is actually > 30 degrees.



## Without pitch (`pitch <= 30`)
**This is fixed by this PR**

http://localhost:8000/#view=17.72/49.987131/14.365661/-137.6&style=signals
This PR | Previously
--- |---
<img width="338" height="855" alt="image" src="https://github.com/user-attachments/assets/ac623a1b-2340-4001-a71f-8fd836782e6f" /> | <img width="338" height="855" alt="image" src="https://github.com/user-attachments/assets/d9b49e3e-9120-49f5-a755-b8d99b9ce432" />

Similar changes are also in the other layers with pitching implemented, e.g. *Electricity* and *Speed*

### With pitch (`pitch > 30`)

**This is not changed by this PR**

http://localhost:8000/#view=17.72/49.987131/14.365661/-139.6/52&style=signals
This PR | Previously
--- |---
<img width="338" height="855" alt="image" src="https://github.com/user-attachments/assets/324468d4-e093-4904-a084-b4ae05a5c517" /> | <img width="338" height="855" alt="image" src="https://github.com/user-attachments/assets/2408fba8-3747-49a0-bb03-4c62a683c3e2" />
