### PR TITLE
Fix rendering of POIs in the electrification layer

### DIFF
--- a/import/sql/signal_features.sql.js
+++ b/import/sql/signal_features.sql.js
@@ -655,7 +655,7 @@ DO $do$ BEGIN
           "feature": "string",
           "deactivated": "boolean",
           "offset": "number",
-          "type": "stirng"
+          "type": "string"
         }
       }
     ]

--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -4889,7 +4889,7 @@ const layers = {
       layout: {
         'symbol-z-order': 'source',
         'icon-overlap': 'always',
-        'icon-image': ['concat', 'sdf:', ['get', 'feature0']],
+        'icon-image': ['concat', 'sdf:', ['get', 'feature']],
         'text-field': ['coalesce', ['get', 'ref'], ''],
         'text-font': font.regular,
         'text-size': 11,


### PR DESCRIPTION
Solves issue #956 
Fix for a bug in #939

Rendering of non-signal POIs (`power_supply` and `isolated_track_section`) in the electrification layer was broken in #939. This PR fixes that.

That PR was partially a preparation for #865 (Merging of signal layers). Rendering of POIs inside signal layers might need to be reworked again for #865.


https://localhost:8000/#view=19.19/50.0866823/19.9330909&style=electrification
| Before this fix | After this fix |
| --- | --- |
| <img width="840" height="697" alt="Image" src="https://github.com/user-attachments/assets/79c5968c-bf6a-4305-82f9-678213085ac7" /> | <img width="840" height="697" alt="Image" src="https://github.com/user-attachments/assets/27d75d03-36e0-4fc5-b4af-6669b137e724" /> |