### PR TITLE
Fix platform length not calculated correctly

### DIFF
--- a/api/test/api.hurl
+++ b/api/test/api.hurl
@@ -659,8 +659,8 @@ jsonpath "$.ref" == "2"
 jsonpath "$.feature" == "platform_edge"
 jsonpath "$.tactile_paving" == null
 jsonpath "$.height" == null
-jsonpath "$.length" > 251.2
-jsonpath "$.length" < 251.3
+jsonpath "$.length" > 152.7
+jsonpath "$.length" < 152.9
 jsonpath "$.osm_id" == 859918234
 jsonpath "$.osm_type" == "W"
 

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -343,7 +343,6 @@ local platform_edge = osm2pgsql.define_table({
     { column = 'way', type = 'linestring', not_null = true },
     { column = 'ref', sql_type = 'text' },
     { column = 'height', type = 'real' },
-    { column = 'length', type = 'real' },
     { column = 'tactile_paving', type = 'boolean' },
   },
 })
@@ -1542,12 +1541,10 @@ function osm2pgsql.process_way(object)
   end
 
   if tags.railway == 'platform_edge' then
-    local way = object:as_linestring():transform(3857)
     platform_edge:insert({
-      way = way,
+      way = object:as_linestring(),
       ref = tags.ref,
       height = tags.height,
-      length = way:length(),
       tactile_paving = tags.tactile_paving == 'yes' or nil,
     })
   end

--- a/import/sql/tile_views.sql
+++ b/import/sql/tile_views.sql
@@ -889,7 +889,7 @@ CREATE OR REPLACE VIEW standard_railway_platform_edges_view AS
     'platform_edge' as feature,
     ref,
     height,
-    length,
+    (st_length(st_transform(way, 3857)) * cos(radians(st_y(ST_Transform(ST_PointOnSurface(way), 4326)))))::real as length,
     tactile_paving
   FROM platform_edge;
 

--- a/import/sql/tile_views.sql
+++ b/import/sql/tile_views.sql
@@ -889,7 +889,7 @@ CREATE OR REPLACE VIEW standard_railway_platform_edges_view AS
     'platform_edge' as feature,
     ref,
     height,
-    (st_length(st_transform(way, 3857)) * cos(radians(st_y(ST_Transform(ST_PointOnSurface(way), 4326)))))::real as length,
+    st_length(st_transform(way, 4326), false) as length,
     tactile_paving
   FROM platform_edge;
 

--- a/import/test/test_import_platform.lua
+++ b/import/test/test_import_platform.lua
@@ -216,15 +216,13 @@ osm2pgsql.process_way({
     ['height'] = '0.4',
     ['tactile_paving'] = 'yes',
   },
-  as_linestring = function ()
-    return {
-      transform = function () return way end,
-    }
+  as_linestring = function()
+    return way
   end,
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   platform_edge = {
-    { ref = '4', height = '0.4', length = 1, tactile_paving = true, way = way },
+    { ref = '4', height = '0.4', tactile_paving = true, way = way },
   },
 })
 
@@ -233,15 +231,13 @@ osm2pgsql.process_way({
     ['railway'] = 'platform_edge',
     ['public_transport'] = 'platform',
   },
-  as_linestring = function ()
-    return {
-      transform = function () return way end,
-    }
+  as_linestring = function()
+    return way
   end,
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   platform_edge = {
-    { length = 1, way = way },
+    { way = way },
   },
   -- Not imported as platform
 })


### PR DESCRIPTION
The unit was correct, but the spherical projection was not taken into account.

Fixes #974

Followup on https://github.com/hiddewie/OpenRailwayMap-vector/pull/971 

On http://localhost:8000/#view=17.74/44.825825/-0.555384, Bordeaux-Saint-Jean.

Before:
<img width="1019" height="448" alt="image" src="https://github.com/user-attachments/assets/525c3ba2-df5d-402f-92b0-5392c60e85a8" />

After:
<img width="1019" height="448" alt="image" src="https://github.com/user-attachments/assets/6d34698a-bf1a-4ba9-a81f-bd4c2d18642d" />


