### PR TITLE
Detect OpenHistoricalMap landuse as polygons

### DIFF
--- a/api/features.mjs
+++ b/api/features.mjs
@@ -559,6 +559,7 @@ const features = {
     features: {
       landuse: {
         name: 'Historical railway landuse',
+        type: 'polygon',
       },
     },
     properties: {


### PR DESCRIPTION
Fixes #978

http://localhost:8000/#view=17.28/49.005052/8.411097&date=1908
<img width="689" height="402" alt="image" src="https://github.com/user-attachments/assets/8d5224c5-93c5-4f95-b2c2-6167f3549e6c" />

Popup is now classifying the features as a way, not a node.

Link now points to https://www.openhistoricalmap.org/way/199474787#date=1908-01-01&layers=R which does work.
