### PR TITLE
Request browser wake lock when location is being tracked

### DIFF
--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -2264,7 +2264,7 @@ class WakeLock {
           this.wakeLock = lock;
           console.info('Acquired wake lock')
         })
-        .catch(error => console.warn('Acquiring of wakelock failed', error));
+        .catch(error => console.warn('Acquiring of wake lock failed', error));
     }
   }
 

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -2248,12 +2248,37 @@ const geolocateControl = new maplibregl.GeolocateControl({
   showAccuracyCircle: false,
   showUserLocation: true,
 })
-geolocateControl.on('trackuserlocationstart', () => {
-  console.info('acquire wake lock')
-})
-geolocateControl.on('trackuserlocationend', () =>  {
-  console.info('release wake lock')
-})
+
+class WakeLock {
+  constructor() {
+    this.wakeLock = null;
+  }
+
+  acquire() {
+    if (navigator.wakeLock) {
+      navigator.wakeLock.request('screen')
+        .then(lock => {
+          if (this.wakeLock) {
+            this.wakeLock.release();
+          }
+          this.wakeLock = lock;
+          console.info('Acquired wake lock')
+        })
+        .catch(error => console.warn('Acquiring of wakelock failed', error));
+    }
+  }
+
+  release() {
+    if (this.wakeLock) {
+      this.wakeLock.release()
+      console.info('Released wake lock')
+    }
+  }
+}
+
+let wakeLock = new WakeLock()
+geolocateControl.on('trackuserlocationstart', () => wakeLock.acquire())
+geolocateControl.on('trackuserlocationend', () => wakeLock.release())
 map.addControl(dateControl);
 map.addControl(styleControl);
 map.addControl(navigationControl);

--- a/proxy/js/ui.js
+++ b/proxy/js/ui.js
@@ -2240,19 +2240,24 @@ const navigationControl = new maplibregl.NavigationControl({
   showCompass: true,
   visualizePitch: true,
 })
+const geolocateControl = new maplibregl.GeolocateControl({
+  positionOptions: {
+    enableHighAccuracy: true
+  },
+  trackUserLocation: true,
+  showAccuracyCircle: false,
+  showUserLocation: true,
+})
+geolocateControl.on('trackuserlocationstart', () => {
+  console.info('acquire wake lock')
+})
+geolocateControl.on('trackuserlocationend', () =>  {
+  console.info('release wake lock')
+})
 map.addControl(dateControl);
 map.addControl(styleControl);
 map.addControl(navigationControl);
-map.addControl(
-  new maplibregl.GeolocateControl({
-    positionOptions: {
-      enableHighAccuracy: true
-    },
-    trackUserLocation: true,
-    showAccuracyCircle: false,
-    showUserLocation: true,
-  })
-);
+map.addControl(geolocateControl);
 map.addControl(new EditControl());
 map.addControl(new ConfigurationControl());
 


### PR DESCRIPTION
Fixes #967 

If the user has enabled location tracking, the UI will request the browser to disable sleep.

See https://developer.chrome.com/docs/capabilities/web-apis/wake-lock
See https://stackoverflow.com/questions/6106747/can-i-prevent-phone-from-sleep-on-a-webpage
See https://w3c.github.io/screen-wake-lock/
See https://maplibre.org/maplibre-gl-js/docs/API/classes/GeolocateControl/


Semantics:
- By default does not do anything
- When the user requests location tracking, the browser wake lock is enabled
- When the user stops location tracking, the browser wake lock is disabled
- When the user is using location tracking, but moves the map, the wake lock is disabled until the user re-enables full location tracking