### PR TITLE
Fix for substation import errors

### DIFF
--- a/api/features.mjs
+++ b/api/features.mjs
@@ -169,7 +169,7 @@ const railwayLineFeatures = {
     frequency: {
       name: 'Frequency',
       format: {
-        template: '%.2f Hz',
+        template: '%.2d Hz',
       },
     },
     voltage: {
@@ -187,7 +187,7 @@ const railwayLineFeatures = {
     future_frequency: {
       name: 'Future frequency',
       format: {
-        template: '%.2f Hz',
+        template: '%.2d Hz',
       },
     },
     future_voltage: {
@@ -661,7 +661,7 @@ const features = {
       height: {
         name: 'Height',
         format: {
-          template: '%.2f m',
+          template: '%.2d m',
         },
       },
       surface: {
@@ -718,13 +718,13 @@ const features = {
       height: {
         name: 'Height',
         format: {
-          template: '%.2f m',
+          template: '%.2d m',
         },
       },
       length: {
         name: 'Length',
         format: {
-          template: '%.0f m',
+          template: '%.0d m',
         },
       },
       tactile_paving: {

--- a/api/features.mjs
+++ b/api/features.mjs
@@ -169,7 +169,7 @@ const railwayLineFeatures = {
     frequency: {
       name: 'Frequency',
       format: {
-        template: '%.2d Hz',
+        template: '%.2f Hz',
       },
     },
     voltage: {
@@ -187,7 +187,7 @@ const railwayLineFeatures = {
     future_frequency: {
       name: 'Future frequency',
       format: {
-        template: '%.2d Hz',
+        template: '%.2f Hz',
       },
     },
     future_voltage: {
@@ -661,7 +661,7 @@ const features = {
       height: {
         name: 'Height',
         format: {
-          template: '%.2d m',
+          template: '%.2f m',
         },
       },
       surface: {
@@ -718,13 +718,13 @@ const features = {
       height: {
         name: 'Height',
         format: {
-          template: '%.2d m',
+          template: '%.2f m',
         },
       },
       length: {
         name: 'Length',
         format: {
-          template: '%.0d m',
+          template: '%.0f m',
         },
       },
       tactile_paving: {

--- a/api/test/api.hurl
+++ b/api/test/api.hurl
@@ -512,7 +512,7 @@ jsonpath "$.note" == null
 jsonpath "$.description" == null
 jsonpath "$.osm_id" == 320522867
 jsonpath "$.osm_type" == "W"
-jsonpath "$.conversion" == "30kV 50 Hz ⇒ 750V ="
+jsonpath "$.conversion" == "30.0 kV 50.00 Hz ⇒ 750 V ="
 
 # Railway crossing
 GET {{base_url}}/feature/openrailwaymap_standard/standard_railway_switch_ref/2101295628

--- a/api/test/api.hurl
+++ b/api/test/api.hurl
@@ -512,7 +512,7 @@ jsonpath "$.note" == null
 jsonpath "$.description" == null
 jsonpath "$.osm_id" == 320522867
 jsonpath "$.osm_type" == "W"
-jsonpath "$.conversion" == "30.0 kV 50.00 Hz ⇒ 750 V ="
+jsonpath "$.conversion" == "30 kV 50.00 Hz ⇒ 750 V ="
 
 # Railway crossing
 GET {{base_url}}/feature/openrailwaymap_standard/standard_railway_switch_ref/2101295628

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -1110,7 +1110,14 @@ function format_voltage_frequency(voltage, frequency)
 end
 
 function substation_voltage_frequency(voltage, frequency)
-  local voltages = map(split_semicolon(voltage), function(it) return tonumber(it) end)
+  local voltages = map(split_semicolon(voltage), function(it)
+    local parsed = tonumber(it)
+    if parsed then
+      return math.floor(parsed)
+    else
+      return nil
+    end
+  end)
   local frequencies = map(split_semicolon(frequency), function(it) return tonumber(it) end)
 
   if voltages and frequencies and #voltages == 2 and #frequencies == 2 then

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -1100,7 +1100,7 @@ function stop_position_type(tags)
 end
 
 function format_voltage_frequency(voltage, frequency)
-  local voltage_text = voltage < 1000.0 and string.format('%.0fV', voltage) or string.format('%.1fkV', voltage / 1000.0)
+  local voltage_text = voltage < 1000.0 and string.format('%.0f V', voltage) or string.format('%.1f kV', voltage / 1000.0)
 
   if frequency == 0 then
     return string.format("%s =", voltage_text)

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -1100,12 +1100,12 @@ function stop_position_type(tags)
 end
 
 function format_voltage_frequency(voltage, frequency)
-  local voltage_text = voltage < 1000.0 and string.format('%.0dV', voltage) or string.format('%.1dkV', voltage / 1000.0)
+  local voltage_text = voltage < 1000.0 and string.format('%.0fV', voltage) or string.format('%.1fkV', voltage / 1000.0)
 
   if frequency == 0 then
     return string.format("%s =", voltage_text)
   else
-    return string.format("%s %.2d Hz", voltage_text, frequency)
+    return string.format("%s %.2f Hz", voltage_text, frequency)
   end
 end
 

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -1100,7 +1100,7 @@ function stop_position_type(tags)
 end
 
 function format_voltage_frequency(voltage, frequency)
-  local voltage_text = voltage < 1000.0 and string.format('%.0d V', voltage) or string.format('%.1d kV', voltage / 1000.0)
+  local voltage_text = (voltage < 1000 and string.format('%d V', voltage)) or (voltage < 10000 and string.format('%.1f kV', voltage / 1000.0)) or string.format('%.0f kV', voltage / 1000.0)
 
   if frequency == 0 then
     return string.format("%s =", voltage_text)

--- a/import/openrailwaymap.lua
+++ b/import/openrailwaymap.lua
@@ -1100,7 +1100,7 @@ function stop_position_type(tags)
 end
 
 function format_voltage_frequency(voltage, frequency)
-  local voltage_text = voltage < 1000.0 and string.format('%.0f V', voltage) or string.format('%.1f kV', voltage / 1000.0)
+  local voltage_text = voltage < 1000.0 and string.format('%.0d V', voltage) or string.format('%.1d kV', voltage / 1000.0)
 
   if frequency == 0 then
     return string.format("%s =", voltage_text)

--- a/import/test/test_import_substation.lua
+++ b/import/test/test_import_substation.lua
@@ -60,3 +60,20 @@ assert.eq(osm2pgsql.get_and_clear_imported_data(), {
     { feature = 'traction', conversion = '110 kV 50.10 Hz ⇒ 15 kV 16.70 Hz', way = way },
   },
 })
+
+osm2pgsql.process_way({
+  tags = {
+    ['power'] = 'substation',
+    ['substation'] = 'traction',
+    ['voltage'] = '110000.1;1500',
+    ['frequency'] = '50.1;16.7',
+  },
+  as_polygon = function ()
+    return way
+  end,
+})
+assert.eq(osm2pgsql.get_and_clear_imported_data(), {
+  substation = {
+    { feature = 'traction', conversion = '110 kV 50.10 Hz ⇒ 1.5 kV 16.70 Hz', way = way },
+  },
+})

--- a/import/test/test_import_substation.lua
+++ b/import/test/test_import_substation.lua
@@ -57,6 +57,6 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   substation = {
-    { feature = 'traction', conversion = '400kV 50 Hz ⇒ 750V =', way = way },
+    { feature = 'traction', conversion = '400.0 kV 50.00 Hz ⇒ 750 V =', way = way },
   },
 })

--- a/import/test/test_import_substation.lua
+++ b/import/test/test_import_substation.lua
@@ -48,8 +48,8 @@ osm2pgsql.process_way({
   tags = {
     ['power'] = 'substation',
     ['substation'] = 'traction',
-    ['voltage'] = '400000;750',
-    ['frequency'] = '50;0',
+    ['voltage'] = '110000.1;15000',
+    ['frequency'] = '50.1;16.7',
   },
   as_polygon = function ()
     return way
@@ -57,6 +57,6 @@ osm2pgsql.process_way({
 })
 assert.eq(osm2pgsql.get_and_clear_imported_data(), {
   substation = {
-    { feature = 'traction', conversion = '400.0 kV 50.00 Hz ⇒ 750 V =', way = way },
+    { feature = 'traction', conversion = '110 kV 50.10 Hz ⇒ 15 kV 16.70 Hz', way = way },
   },
 })


### PR DESCRIPTION
This PR should fix the recent failures in nightly updates.

Recent update to what details are shown for traction substations improperly uses `%d` in `string.format`.\
`%d` accepts only integers, for real numbers `%f` should be used instead. That's fixed in this PR.

Do note, that this PR changes the intended behaviour see changes in tests.
