### PR TITLE
Order of GB signals

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -6824,7 +6824,7 @@ features:
       - { tag: 'railway:signal:train_protection:form', value: 'sign' }
       - { tag: 'railway:signal:train_protection:type', value: 'block_marker' }
 
- - description: Shunting
+  - description: Shunting
     country: GB
     icon: [ default: 'gb/shunting' ]
     tags:
@@ -6838,7 +6838,7 @@ features:
       - { tag: 'railway:signal:shunting', value: 'GB-NR:limit' }
       - { tag: 'railway:signal:shunting:form', value: 'light' }
 
-    - description: Distant
+  - description: Distant
     country: GB
     icon: [ default: 'gb/distant-light' ]
     tags:

--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -6824,6 +6824,41 @@ features:
       - { tag: 'railway:signal:train_protection:form', value: 'sign' }
       - { tag: 'railway:signal:train_protection:type', value: 'block_marker' }
 
+ - description: Shunting
+    country: GB
+    icon: [ default: 'gb/shunting' ]
+    tags:
+      - { tag: 'railway:signal:shunting', value: 'GB-NR:shunting' }
+      - { tag: 'railway:signal:shunting:form', value: 'light' }
+
+  - description: Shunting limit
+    country: GB
+    icon: [ default: 'gb/limit-shunt' ]
+    tags:
+      - { tag: 'railway:signal:shunting', value: 'GB-NR:limit' }
+      - { tag: 'railway:signal:shunting:form', value: 'light' }
+
+    - description: Distant
+    country: GB
+    icon: [ default: 'gb/distant-light' ]
+    tags:
+      - { tag: 'railway:signal:distant', value: 'GB-NR:distant' }
+      - { tag: 'railway:signal:distant:form', value: 'light' }
+
+  - description: Distant (semaphore)
+    country: GB
+    icon: [ default: 'gb/distant-semaphore' ]
+    tags:
+      - { tag: 'railway:signal:distant', value: 'GB-NR:distant' }
+      - { tag: 'railway:signal:distant:form', value: 'semaphore' }
+
+  - description: Distant (board)
+    country: GB
+    icon: [ default: 'gb/distant-board' ]
+    tags:
+      - { tag: 'railway:signal:distant', value: 'GB-NR:distant' }
+      - { tag: 'railway:signal:distant:form', value: 'sign' }
+
   - description: Main (light)
     country: GB
     icon:
@@ -6849,27 +6884,6 @@ features:
       - { tag: 'railway:signal:main', value: 'GB-NR:SPAD' }
       - { tag: 'railway:signal:main:form', value: 'light' }
 
-  - description: Distant
-    country: GB
-    icon: [ default: 'gb/distant-light' ]
-    tags:
-      - { tag: 'railway:signal:distant', value: 'GB-NR:distant' }
-      - { tag: 'railway:signal:distant:form', value: 'light' }
-
-  - description: Distant (semaphore)
-    country: GB
-    icon: [ default: 'gb/distant-semaphore' ]
-    tags:
-      - { tag: 'railway:signal:distant', value: 'GB-NR:distant' }
-      - { tag: 'railway:signal:distant:form', value: 'semaphore' }
-
-  - description: Distant (board)
-    country: GB
-    icon: [ default: 'gb/distant-board' ]
-    tags:
-      - { tag: 'railway:signal:distant', value: 'GB-NR:distant' }
-      - { tag: 'railway:signal:distant:form', value: 'sign' }
-
   - description: Repeated (banner)
     country: GB
     icon: [ default: 'gb/repeated-banner' ]
@@ -6890,20 +6904,6 @@ features:
     tags:
       - { tag: 'railway:signal:route_distant', value: 'GB-NR:PRI' }
       - { tag: 'railway:signal:route_distant:form', value: 'light' }
-
-  - description: Shunting
-    country: GB
-    icon: [ default: 'gb/shunting' ]
-    tags:
-      - { tag: 'railway:signal:shunting', value: 'GB-NR:shunting' }
-      - { tag: 'railway:signal:shunting:form', value: 'light' }
-
-  - description: Shunting limit
-    country: GB
-    icon: [ default: 'gb/limit-shunt' ]
-    tags:
-      - { tag: 'railway:signal:shunting', value: 'GB-NR:limit' }
-      - { tag: 'railway:signal:shunting:form', value: 'light' }
 
   - description: Junction signals (feather & theatre)
     country: GB


### PR DESCRIPTION
In GB, shunt and distant signals are displayed below main signals.
(See:
[https://en.wikipedia.org/wiki/UK_railway_signalling#Position_light_signals](https://en.wikipedia.org/wiki/UK_railway_signalling#Position_light_signals) and 
[https://en.wikipedia.org/wiki/UK_railway_signalling#Semaphore_signals](https://en.wikipedia.org/wiki/UK_railway_signalling#Semaphore_signals)) 

I've moved the shunt and distant signals before main signals in signals_railway_signals.yaml so that they are displayed below the main signal.