### PR TITLE
Martin 1.11

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -54,6 +54,7 @@ services:
         condition: service_completed_successfully
     environment:
       - DATABASE_URL=postgresql://postgres@db:5432/gis
+      - POSTGRES_RELOAD_INTERVAL=10s
     ulimits:
       nproc: 65535
       nofile:

--- a/martin.Dockerfile
+++ b/martin.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/maplibre/martin:1.8.2@sha256:7137cad2facf21ef4af6cbef051ce0553b717e8289fde57b50b50c5ac93275b7
+FROM ghcr.io/maplibre/martin:1.11.0@sha256:0650e9025f5fcffdc686358114679421b5e6b0ca37b374ad8a66f14709d59d2b
 
 COPY martin /config
 COPY symbols /symbols

--- a/martin/configuration.yml
+++ b/martin/configuration.yml
@@ -21,6 +21,8 @@ postgres:
   # # You may set this to `false` to disable.
   auto_publish: false
 
+  reload_interval: ${POSTGRES_RELOAD_INTERVAL:-0s}
+
   # No tables, see function sources below
   tables: {}
 


### PR DESCRIPTION
See https://github.com/maplibre/martin/releases/tag/martin-v1.11.0, https://github.com/maplibre/martin/releases/tag/martin-v1.10.0 and https://github.com/maplibre/martin/releases/tag/martin-v1.9.0.

Features of interest:
- MVT - MLT pre-encoding, for #919 / #996
- Live reloading of PostgreSQL sources (views / functions), useful for local development to avoid restarting Martin after re-importing data or changing database views