### PR TITLE
Update operators.yaml with appropriate names

### DIFF
--- a/features/operators.yaml
+++ b/features/operators.yaml
@@ -174,7 +174,16 @@ operators:
 
   - country: BA
     names:
+      - 'Željeznice Republike Srpske'
+      - 'ŽRS'
+      - 'Желјезнице Републике Српске'
+      - 'ЖРС'
+    color: '#043bd7'
+
+  - country: BA
+    names:
       - 'Željeznice Federacije Bosne i Hercegovine'
+      - 'ŽFBH'
     color: 'rgb(247, 148, 30)'
 
   # --- BE --- #
@@ -2078,7 +2087,7 @@ operators:
 
   - country: RU
     names:
-      - 'Калининградский Железная Дорога'
+      - 'Калининградская Железная Дорога'
     color: '#ff3f72'
 
   - country: RU
@@ -2100,14 +2109,12 @@ operators:
 
   - country: RS
     names:
-      - 'Željeznice Republike Srpske'
-    color: '#043bd7'
-
-  - country: RS
-    names:
       - 'ЖС'
       - 'Железнице Србије'
-      - 'Zeleznice Srbije'
+      - 'Železnice Srbije' # These 3 above should be deprecated as ŽS has been split since 2015
+      - 'ИЖС'
+      - 'Инфраструктура железнице Србије'
+      - 'Infrastruktura železnice Srbije'
     color: '#ed1c24'
 
   - country: RS


### PR DESCRIPTION
Having edited a lot of railways in Serbia I realized that they mostly have `operator=Железнице Србије` that is wrong since 2015 when the company was split according to the EU Fourth Railway Package. The company managing the infrastructure is called [Инфраструктура Железнице Србије](https://en.wikipedia.org/wiki/Serbian_Railways_Infrastructure). I'm reluctant to batch rename until this is rendered properly here.

Apart from that Željeznice Republike Srpske operate in Republika Srpska that is a constituent entity of Bosnia and Herzegovina, not Serbia, so I moved the railway operator accordingly. Also fix a small mistake in some Russian operator name.