### PR TITLE
Support values 1, 2 and 3 for `railway:octys` train protection tag

### DIFF
--- a/features/train_protection.yaml
+++ b/features/train_protection.yaml
@@ -263,7 +263,7 @@ features:
 
   - train_protection: octys
     tags:
-      - { tag: 'railway:octys', value: 'yes' }
+      - { tag: 'railway:octys', values: ['yes', '1', '2', '3'] }
 
   - train_protection: ouragan
     tags:


### PR DESCRIPTION
Fixes #1014

This will ensure the values 1, 2 and 3 are classified as having the Octys train protection system on the line, in use in France.

Tested on http://localhost:8000/#view=15/48.87427/2.34478&style=signals
<img width="966" height="699" alt="image" src="https://github.com/user-attachments/assets/ad16543c-f139-456a-a02b-73b6a49284ec" />
