### PR TITLE
API startup deprecation messages, `HTTP_422_UNPROCESSABLE_ENTITY`

### DIFF
--- a/api/openrailwaymap_api/facility_api.py
+++ b/api/openrailwaymap_api/facility_api.py
@@ -1,5 +1,5 @@
 from fastapi import HTTPException
-from starlette.status import HTTP_400_BAD_REQUEST, HTTP_422_UNPROCESSABLE_ENTITY
+from starlette.status import HTTP_400_BAD_REQUEST, HTTP_422_UNPROCESSABLE_CONTENT
 
 QUERY_PARAMETERS = ['q', 'name', 'ref']
 
@@ -28,13 +28,13 @@ class FacilityAPI:
         if search_args_count > 1:
             args = ', '.join(QUERY_PARAMETERS)
             raise HTTPException(
-                HTTP_422_UNPROCESSABLE_ENTITY,
+                HTTP_422_UNPROCESSABLE_CONTENT,
                 {'type': 'multiple_query_args', 'error': 'More than one argument with a search term provided.', 'detail': f'Provide only one of the following query parameters: {args}'}
             )
         elif search_args_count == 0:
             args = ', '.join(QUERY_PARAMETERS)
             raise HTTPException(
-                HTTP_422_UNPROCESSABLE_ENTITY,
+                HTTP_422_UNPROCESSABLE_CONTENT,
                 {'type': 'no_query_arg', 'error': 'No argument with a search term provided.', 'detail': f'Provide one of the following query parameters: {args}'}
             )
 


### PR DESCRIPTION
Startup logged
```
api-1  |
api-1  |  ⚡ Starting FastAPI in production mode
api-1  | /app/api.py:12: StarletteDeprecationWarning: 'HTTP_422_UNPROCESSABLE_ENTITY' is deprecated. Use 'HTTP_422_UNPROCESSABLE_CONTENT' instead.
api-1  |   from openrailwaymap_api.facility_api import FacilityAPI
api-1  |
api-1  |  🐍 Using import string: api:app
api-1  |
api-1  |  🌐 Server started at http://0.0.0.0:5000
api-1  |     Documentation at http://0.0.0.0:5000/docs
```

See https://www.rfc-editor.org/info/rfc9110/#name-422-unprocessable-content
See https://fastapi.tiangolo.com/reference/status/#fastapi.status.HTTP_422_UNPROCESSABLE_CONTENT