### PR TITLE
Fix typo in matching for Swiss signals 712/713

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -2964,7 +2964,7 @@ features:
     tags:
       - { tag: 'railway:signal:electricity', value: 'CH-FDV:712' }
       - { tag: 'railway:signal:electricity:form', value: 'sign' }
-      - { tag: 'railway:signal:electricity:type', value: 'power_off' }
+      - { tag: 'railway:signal:electricity:type', value: 'power_on' }
 
   - description: Einschaltsignal (light)
     country: CH
@@ -2972,7 +2972,7 @@ features:
     tags:
       - { tag: 'railway:signal:electricity', value: 'CH-FDV:713' }
       - { tag: 'railway:signal:electricity:form', value: 'light' }
-      - { tag: 'railway:signal:electricity:type', value: 'power_off' }
+      - { tag: 'railway:signal:electricity:type', value: 'power_on' }
 
   - description: Streckentrennung
     country: CH


### PR DESCRIPTION
Swiss signals 712/713 are "Einschaltsignale" so they should be classified as `power_on` instead of `power_off`. This is documented here: https://wiki.openstreetmap.org/wiki/DE:OpenRailwayMap/Tagging_in_Switzerland#712,_713_Einschaltsignal