### PR TITLE
Remove index on grouped station center

### DIFF
--- a/import/sql/stations_clustered.sql
+++ b/import/sql/stations_clustered.sql
@@ -145,10 +145,6 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS grouped_stations_with_importance AS
     ON ssa.stop_area_osm_id = sa.osm_id
   GROUP BY clustered.id;
 
-CREATE INDEX IF NOT EXISTS grouped_stations_with_importance_center_index
-  ON grouped_stations_with_importance
-    USING GIST(center);
-
 CREATE INDEX IF NOT EXISTS grouped_stations_with_importance_buffered_index
   ON grouped_stations_with_importance
     USING GIST(buffered);
@@ -162,7 +158,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS grouped_stations_with_importance_id
     USING BTREE(id);
 
 CLUSTER grouped_stations_with_importance
-  USING grouped_stations_with_importance_center_index;
+  USING grouped_stations_with_importance_buffered_index;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS stop_area_groups_buffered AS
   SELECT

--- a/import/sql/tile_views.sql
+++ b/import/sql/tile_views.sql
@@ -391,7 +391,7 @@ CREATE OR REPLACE VIEW railway_text_stations AS
     gs.id,
     osm_ids as osm_id,
     osm_types as osm_type,
-    center as way,
+    center,
     buffered,
     map_reference,
     "references",
@@ -465,7 +465,7 @@ RETURN (
     ST_AsMVT(tile, 'standard_railway_text_stations_low', 4096, 'way')
   FROM (
     SELECT
-      ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
+      ST_AsMVTGeom(center, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
       id,
       map_reference as label,
       name,
@@ -474,7 +474,7 @@ RETURN (
       operator_color,
       operator_bright
     FROM railway_text_stations
-    WHERE way && ST_TileEnvelope(z, x, y)
+    WHERE center && ST_TileEnvelope(z, x, y)
       AND feature = 'station'
       AND state = 'present'
       AND (station IS NULL OR station NOT IN ('light_rail', 'monorail', 'subway'))
@@ -518,7 +518,7 @@ RETURN (
     ST_AsMVT(tile, 'standard_railway_text_stations_med', 4096, 'way')
   FROM (
     SELECT
-      ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
+      ST_AsMVTGeom(center, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
       id,
       map_reference as label,
       name,
@@ -527,7 +527,7 @@ RETURN (
       operator_color,
       operator_bright
     FROM railway_text_stations
-    WHERE way && ST_TileEnvelope(z, x, y)
+    WHERE center && ST_TileEnvelope(z, x, y)
       AND feature = 'station'
       AND state = 'present'
       AND (station IS NULL OR station NOT IN ('light_rail', 'monorail', 'subway'))
@@ -684,7 +684,7 @@ RETURN (
     ST_AsMVT(tile, 'standard_railway_text_stations', 4096, 'way')
   FROM (
     SELECT
-      ST_AsMVTGeom(way, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
+      ST_AsMVTGeom(center, ST_TileEnvelope(z, x, y), extent => 4096, buffer => 64, clip_geom => true) AS way,
       id,
       state,
       feature,
@@ -697,7 +697,7 @@ RETURN (
       operator_color,
       operator_bright
     FROM railway_text_stations
-    WHERE way && ST_TileEnvelope(z, x, y)
+    WHERE center && ST_TileEnvelope(z, x, y)
       -- conditionally include features based on zoom level
       AND CASE
         -- Zooms < 8 are handled in the low and medium zoom tiles

--- a/import/sql/tile_views.sql
+++ b/import/sql/tile_views.sql
@@ -474,7 +474,7 @@ RETURN (
       operator_color,
       operator_bright
     FROM railway_text_stations
-    WHERE center && ST_TileEnvelope(z, x, y)
+    WHERE buffered && ST_TileEnvelope(z, x, y)
       AND feature = 'station'
       AND state = 'present'
       AND (station IS NULL OR station NOT IN ('light_rail', 'monorail', 'subway'))
@@ -527,7 +527,7 @@ RETURN (
       operator_color,
       operator_bright
     FROM railway_text_stations
-    WHERE center && ST_TileEnvelope(z, x, y)
+    WHERE buffered && ST_TileEnvelope(z, x, y)
       AND feature = 'station'
       AND state = 'present'
       AND (station IS NULL OR station NOT IN ('light_rail', 'monorail', 'subway'))
@@ -697,7 +697,7 @@ RETURN (
       operator_color,
       operator_bright
     FROM railway_text_stations
-    WHERE center && ST_TileEnvelope(z, x, y)
+    WHERE buffered && ST_TileEnvelope(z, x, y)
       -- conditionally include features based on zoom level
       AND CASE
         -- Zooms < 8 are handled in the low and medium zoom tiles


### PR DESCRIPTION
The grouped stations materialized view currently contains 4 indices, of which 2 are for querying by geometry (used for any map tile query). One for the center of the station (used for labels) and one for the buffered polygon (rendering the station outline).

However, both indices are not needed, the center index can be dropped if the buffered index is used for the station label queries. After all, the center geometry is guaranteed to be contained in the buffered geometry, and the buffered geometry is not so large that too many results would be returned for a tile.

A query plan with the station label query querying the center but using the buffered column for querying the data shows the correct index in use:
<img width="1221" height="486" alt="image" src="https://github.com/user-attachments/assets/8b08afb6-591a-478e-9489-b21dddbb4826" />
