### PR TITLE
Fix deactivated signals being visible in other layers

### DIFF
--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -4359,7 +4359,7 @@ const layers = [
       layout: {
         'visibility': ['case',
           ['==', ['global-state', 'style'], 'signals'], 'visible',
-          'visible',
+          'none',
         ],
         'symbol-z-order': 'source',
         'icon-overlap': 'always',
@@ -4481,7 +4481,7 @@ const layers = [
       layout: {
         'visibility': ['case',
           ['==', ['global-state', 'style'], 'signals'], 'visible',
-          'visible',
+          'none',
         ],
         'symbol-z-order': 'source',
         'icon-overlap': 'always',


### PR DESCRIPTION
The white cross indicating a deactivated signal, was visible in other layers than the train protection layer.

https://openrailwaymap.app/#view=18/50.944849/6.957327&style=electrification
<img width="1005" height="608" alt="image" src="https://github.com/user-attachments/assets/1e009efa-5a43-4960-91fd-93d43b859467" />
