### PR TITLE
CH: Add station distant board for signal system N

### DIFF
--- a/features/signals_railway_signals.yaml
+++ b/features/signals_railway_signals.yaml
@@ -2793,6 +2793,13 @@ features:
       - { tag: 'railway:signal:combined', value: 'CH-FDV:n' }
       - { tag: 'railway:signal:combined:form', value: 'light' }
 
+  - description: Merktafel für ein folgendes Einfahrsignal beim Signalsystem N
+    country: CH
+    icon: [ default: 'ch/fdv-568' ]
+    tags:
+      - { tag: 'railway:signal:station_distant', value: 'CH-FDV:568' }
+      - { tag: 'railway:signal:station_distant:form', value: 'sign' }
+
   - description: Fahrtstellungsmelder
     country: CH
     icon: [ default: 'ch/fdv-559' ]

--- a/symbols/ch/fdv-568.svg
+++ b/symbols/ch/fdv-568.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="14" height="14" viewBox="0 0 14 14">
+<rect x="0" y="0" width="14" height="14" fill="black" />
+<path fill-rule="nonzero" fill="white" d="M 7 0 L 14 7 L 7 14 L 0 7 Z M 7 0 "/>
+</svg>


### PR DESCRIPTION
This adds the diamond-shaped board placed at the last signal before station entry signals in system N.

I tried to add it the same way like the additional board for repeated distant signals (with two stars), but it seems that is not possible since I wanted to match for two tags (`railway:signal:station_distant=CH-FDV:568` and `railway:signal:station_distant:form=sign`). So I just added it as a separate signal, and placed it in the file so it always (correctly) appears above the distant/main signal.

I created the SVG myself from scratch.

http://localhost:8000/#view=18.66/47.4052253/8.5358631&style=signals (the additional unknown signal is an unrelated shunting signal)
<img width="457" height="477" alt="image" src="https://github.com/user-attachments/assets/65c3f71d-2181-4d69-ac2b-df171084f952" />
