### PR TITLE
Fix slow feature SQL queries for popup content

### DIFF
--- a/api/openrailwaymap_api/feature_api.py
+++ b/api/openrailwaymap_api/feature_api.py
@@ -58,13 +58,14 @@ class FeatureAPI:
         sql_query = f"""
             SELECT {', '.join(f'"{property}"' for property in properties if property)}
             FROM "{view_name}" 
-            WHERE id = $1::{view_id_type} 
+            WHERE id = $1 
         """
 
         async with self.database.acquire() as connection:
             statement = await connection.prepare(sql_query)
             async with connection.transaction():
-                async for record in statement.cursor(id):
+                cast_id = int(id) if view_id_type == 'numeric' else id
+                async for record in statement.cursor(cast_id):
                     return localize_fields(dict(record), localized_fields, lang)
                 else:
                     return None


### PR DESCRIPTION
This is mostly noticable when clicking on a signal, and waiting up to a few seconds to view the popup content.

The problem was the SQL query, filtering by the primary key. The indices were not the problem, but the casting of the primary key, confusing Postgres whether or not the index could be used.

Essentially a query with a perfect index lookup became a full table scan...

Comparison of the executed signals query below.

Before:
```sql
SELECT * from signals_railway_signals_view where id = '123'::numeric;
```
with plan
```
Gather  (cost=1001.27..13590.01 rows=1371 width=3811) (actual time=148.976..159.662 rows=0.00 loops=1)
  Workers Planned: 2
  Workers Launched: 2
  Buffers: shared hit=312358
  ->  Nested Loop  (cost=1.27..12452.91 rows=571 width=3811) (actual time=136.218..136.221 rows=0.00 loops=3)
        Join Filter: (s.osm_id = sd.signal_id)
        Buffers: shared hit=312358
        ->  Nested Loop  (cost=0.85..11998.10 rows=902 width=3623) (actual time=136.217..136.219 rows=0.00 loops=3)
              Buffers: shared hit=312358
              ->  Parallel Index Scan using signals_pkey on signals s  (cost=0.42..11030.48 rows=1685 width=3507) (actual time=136.216..136.216 rows=0.00 loops=3)
                    Filter: ((osm_id)::numeric = '123'::numeric)
                    Rows Removed by Filter: 269676
                    Index Searches: 1
                    Buffers: shared hit=312358
              ->  Index Scan using signal_features_signal_id_index on signal_features sf  (cost=0.42..0.56 rows=1 width=116) (never executed)
                    Index Cond: (signal_id = s.osm_id)
                    Filter: (layer = 'signals'::signal_layer)
                    Index Searches: 0
        ->  Index Scan using signal_direction_signal_id_index on signal_direction sd  (cost=0.42..0.44 rows=1 width=17) (never executed)
              Index Cond: (signal_id = sf.signal_id)
              Index Searches: 0
Planning:
  Buffers: shared hit=48
Planning Time: 1.692 ms
Execution Time: 160.141 ms
```

After:
```sql
SELECT * from signals_railway_signals_view where id = 123;
```
with plan
```
Nested Loop  (cost=1.27..2.03 rows=1 width=3811) (actual time=0.029..0.030 rows=0.00 loops=1)
  Buffers: shared hit=3
  ->  Nested Loop  (cost=0.85..1.30 rows=1 width=3615) (actual time=0.028..0.029 rows=0.00 loops=1)
        Buffers: shared hit=3
        ->  Index Scan using signals_pkey on signals s  (cost=0.42..0.64 rows=1 width=3507) (actual time=0.028..0.028 rows=0.00 loops=1)
              Index Cond: (osm_id = 123)
              Index Searches: 1
              Buffers: shared hit=3
        ->  Index Scan using signal_features_signal_id_index on signal_features sf  (cost=0.42..0.65 rows=1 width=116) (never executed)
              Index Cond: (signal_id = 123)
              Filter: (layer = 'signals'::signal_layer)
              Index Searches: 0
  ->  Index Scan using signal_direction_signal_id_index on signal_direction sd  (cost=0.42..0.64 rows=1 width=17) (never executed)
        Index Cond: (signal_id = 123)
        Index Searches: 0
Planning Time: 2.104 ms
Execution Time: 0.342 ms
```