### PR TITLE
fix clashing colours for ATS/AWS/TMACS

### DIFF
--- a/features/train_protection.yaml
+++ b/features/train_protection.yaml
@@ -7,7 +7,7 @@ train_protections:
   - { train_protection: 'ctcs', legend: '列车运行监控记录 (LKJ)', color: 'hsl(10, 100%, 50%)' }
   - { train_protection: 'ctcs_2', legend: 'Chinese Train Control System (CTCS) level 2', color: 'hsl(190, 100%, 40%)' }
   - { train_protection: 'ctcs_3', legend: 'Chinese Train Control System (CTCS) level 3', color: 'hsl(190, 100%, 30%)' }
-  - { train_protection: 'ktcs', legend: '한국형 열차제어시스템 (KTCS)', color: '#c54800' }
+  - { train_protection: 'ktcs', legend: '한국형 열차제어시스템 (KTCS)', color: '#654321' }
   - { train_protection: 'ptc', legend: 'Positive train control (PTC)', color: '#cc0033' }
   - { train_protection: 'tvm', legend: 'Transmission Voie-Machine (TVM)', color: '#009966' }
   - { train_protection: 'kvb', legend: 'Contrôle de vitesse par balises (KVB)', color: '#66cc33' }
@@ -21,7 +21,7 @@ train_protections:
   - { train_protection: 'pzb', legend: 'Punktförmige Zugbeeinflussung (PZB)', color: '#ffb900' }
   - { train_protection: 'acses', legend: 'Advanced Civil Speed Enforcement System (ACSES)', color: '#0096d4' }
   - { train_protection: 'ases', legend: 'Advanced Speed Enforcement System (ASES)', color: '#0096d4' }
-  - { train_protection: 'atms', legend: 'Advanced Train Management System (ATMS)', color: '#0096d4' }
+  - { train_protection: 'atms', legend: 'Advanced Train Management System (ATMS)', color: '#4fb8af' }
   - { train_protection: 'als', legend: 'Автоматическая локомотивная сигнализация (ALS)', color: 'hsl(284, 100%, 40%)' }
   - { train_protection: 'atp', legend: 'Automatic Train Protection (ATP)', color: 'hsl(305, 100%, 40%)' }
   - { train_protection: 'aws', legend: 'Automatic Warning System (AWS)', color: 'hsl(50, 100%, 40%)' }
@@ -40,10 +40,10 @@ train_protections:
   - { train_protection: 'saet', legend: 'Système d''Automatisation de l''Exploitation des Trains (SAET)', color: 'hsl(305, 100%, 40%)' }
   - { train_protection: 'shp', legend: 'Samoczynne Hamowanie Pociągu (SHP)', color: 'hsl(35, 100%, 40%)' }
   - { train_protection: 'ssc', legend: 'Sistema di Supporto alla Condotta (SSC)', color: 'hsl(155, 100%, 40%)' }
-  - { train_protection: 'ats', legend: 'Automatic Train Stop (ATS)', color: '#b58a00' }
+  - { train_protection: 'ats', legend: 'Automatic Train Stop (ATS)', color: '#ff7033' }
   - { train_protection: 'atacs', legend: 'Advanced Train Administration and Communications System (ATACS)', color: '#008e2d' }
   - { train_protection: 'tbl', legend: 'Transmissie Baken-Lokomotief (TBL)', color: 'hsl(305, 100%, 40%)' }
-  - { train_protection: 'tmacs', legend: 'Train Management and Control System (TMACS)', color: '#ffcc00' }
+  - { train_protection: 'tmacs', legend: 'Train Management and Control System (TMACS)', color: '#66cc33' }
   - { train_protection: 'tpws', legend: 'Train Protection & Warning System (TPWS)', color: 'pink' }
   - { train_protection: 'zbs', legend: 'Zugbeeinflussung S-Bahn Berlin (ZBS)', color: 'hsl(155, 100%, 40%)' }
   - { train_protection: 'zsi127', legend: 'ZSI 127', color: '#884400' }


### PR DESCRIPTION
Currently, Australia has 3 different systems using yellow, which are hard to distinguish ($`{\color{#b58a00} \blacksquare\color{#ccaa00} \blacksquare\color{#ffcc00} \blacksquare}`$).

One of these systems is also used in the UK, and the other is also used in Korea. so we have to play a game a sudoku to keep the colours unique in all regions 😆

This PR proposes 4 changes:

1. 🇦🇺 TMACS $`{\color{#ffcc00} \blacksquare}`$ → $`{\color{#66cc33} \blacksquare}`$
2. 🇦🇺 ATMS $`{\color{#0096d4} \blacksquare}`$ → $`{\color{#4fb8af} \blacksquare}`$
3. 🇦🇺🇰🇷 ATS $`{\color{#b58a00} \blacksquare}`$ → $`{\color{#ff7033} \blacksquare}`$
4. 🇰🇷 KTCS $`{\color{#c54800} \blacksquare}`$ → $`{\color{#654321} \blacksquare}`$

---

Full list for each affected country:

AU:

- ATS $`{\color{#b58a00} \blacksquare}`$ → $`{\color{#ff7033} \blacksquare}`$
- AWS $`{\color{#ccaa00} \blacksquare}`$
- TMACS $`{\color{#ffcc00} \blacksquare}`$ → $`{\color{#66cc33} \blacksquare}`$
- TOW $`{\color{#884400} \blacksquare}`$
- TPWS $`{\color{#ffc0cb} \blacksquare}`$
- PTC $`{\color{#cc0033} \blacksquare}`$
- CBTC $`{\color{#cc0052} \blacksquare}`$
- ATP $`{\color{#cc00bb} \blacksquare}`$
- ATC $`{\color{#6600cc} \blacksquare}`$
- ETCS-2 $`{\color{#0058cc} \blacksquare}`$
- ETCS-1 $`{\color{#006eff} \blacksquare}`$
- ATMS $`{\color{#0096d4} \blacksquare}`$ → $`{\color{#4fb8af} \blacksquare}`$
- None $`{\color{#000000} \blacksquare}`$
- Unknown $`{\color{#999999} \blacksquare}`$

KR:

- ATS $`{\color{#b58a00} \blacksquare}`$ → $`{\color{#ff7033} \blacksquare}`$
- KTCS $`{\color{#c54800} \blacksquare}`$ → $`{\color{#654321} \blacksquare}`$
- CBTC $`{\color{#cc0052} \blacksquare}`$
- ATC $`{\color{#6600cc} \blacksquare}`$
- ETCS-1 $`{\color{#006eff} \blacksquare}`$
- TVM $`{\color{#66cc33} \blacksquare}`$
- Unknown $`{\color{#999999} \blacksquare}`$

GB (no change):

- AWS $`{\color{#ccaa00} \blacksquare}`$
- TPWS $`{\color{#ffc0cb} \blacksquare}`$
- CBTC $`{\color{#cc0052} \blacksquare}`$
- ATP $`{\color{#cc00bb} \blacksquare}`$
- ETCS-2 $`{\color{#0058cc} \blacksquare}`$
- ETCS-1 $`{\color{#006eff} \blacksquare}`$
- TVM $`{\color{#66cc33} \blacksquare}`$
- None $`{\color{#000000} \blacksquare}`$
- Unknown $`{\color{#999999} \blacksquare}`$

<table>
<tr>
<td></td>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>🇦🇺</td>
<td>
<img width="932" height="699" alt="image" src="https://github.com/user-attachments/assets/b303d91c-c14a-4df7-b2e6-1f6f49b256f4" />
<img width="334" height="240" alt="image" src="https://github.com/user-attachments/assets/0e6daedd-f9ed-40e5-adf1-478c9f6ba475" />
</td>
<td>
<img width="985" height="708" alt="image" src="https://github.com/user-attachments/assets/7f2406d2-0204-4a22-9aa1-63e6644dbd4d" />
<img width="393" height="262" alt="image" src="https://github.com/user-attachments/assets/6f9515d9-6bd9-48dc-8fed-7d5389d988ea" />
</td>
</tr>
<tr>
<td>🇰🇷</td>
<td>
<img width="582" height="669" alt="image" src="https://github.com/user-attachments/assets/a9519fa5-8e33-41e5-a869-b0355fe1fbef" />
</td>
<td>
<img width="561" height="713" alt="image" src="https://github.com/user-attachments/assets/71e923dc-6100-42f4-a266-6a7410fff689" /></td>
</tr>
<tr>
<td>🇬🇧</td>
<td colspan=2>no change</td>
</tr>
</table>

---
An alterantive idea is to change AWS $`{\color{#ccaa00} \blacksquare}`$ instead of ATS $`{\color{#b58a00} \blacksquare}`$. Then it would impact AU+GB intead of AU+KR.