### PR TITLE
Fix missing preferred direction

### DIFF
--- a/proxy/js/styles.mjs
+++ b/proxy/js/styles.mjs
@@ -1729,7 +1729,7 @@ const preferredDirectionLayer = (id, filter, color, visibility) => ({
     'visibility': ['case',
       visibility ? ['==', visibility, false] : false, 'none',
       ['<', ['global-state', 'date'], defaultDate], 'none',
-      'none',
+      'visible',
     ],
     'symbol-placement': 'line',
     'symbol-spacing': 750,


### PR DESCRIPTION
Fixes #1065

The visibility was always set to `none`, for every layer.

http://localhost:8000/#view=16.67/51.189027/6.687403/0/3
<img width="864" height="651" alt="image" src="https://github.com/user-attachments/assets/bbb044f6-3f48-401f-82ae-83fd3f6c6c7d" />
